### PR TITLE
Added create and update functionality for plans

### DIFF
--- a/library/recurlyplan.php
+++ b/library/recurlyplan.php
@@ -45,4 +45,55 @@ class RecurlyPlan
 			throw new RecurlyException("Could not get subscription plan {$planCode}: {$result->response} -- ({$result->code})");
 		}
 	}
+	
+	public function create()
+	{
+		$uri = RecurlyClient::PATH_PLANS;
+		$data = $this->getXml();
+		$result = RecurlyClient::__sendRequest($uri, 'POST', $data);
+		if (preg_match("/^2..$/", $result->code)) {
+			return RecurlyClient::__parse_xml($result->response, 'plan');
+		} else if (strpos($result->response, '<errors>') > 0 && $result->code == 422) {
+			throw new RecurlyValidationException($result->code, $result->response);
+		} else {
+			throw new RecurlyException("Could not create an account for {$this->plan_code}: {$result->response} -- ({$result->code}) ");
+		}
+	}
+	
+	public function update()
+	{
+		$uri = RecurlyClient::PATH_PLANS . urlencode($this->plan_code);
+		$data = $this->getXml();
+		$result = RecurlyClient::__sendRequest($uri, 'PUT', $data);
+		if (preg_match("/^2..$/", $result->code)) {
+			return RecurlyClient::__parse_xml($result->response, 'plan');
+		} else if (strpos($result->response, '<errors>') > 0 && $result->code == 422) {
+			throw new RecurlyValidationException($result->code, $result->response);
+		} else {
+			throw new RecurlyException("Could not update the plan for {$this->plan_code}: {$result->response} ({$result->code})");
+		}
+	
+	}
+	
+	public function getXml()
+	{
+		$doc = new DOMDocument("1.0");
+		$this->populateXmlDoc($doc, $doc);
+		return $doc->saveXML();
+	}
+	
+	public function populateXmlDoc(&$doc, &$root)
+	{
+		$plan = $root->appendChild($doc->createElement("plan"));
+		$plan->appendChild($doc->createElement("plan_code", $this->plan_code));
+		$plan->appendChild($doc->createElement("name", $this->name));
+		$plan->appendChild($doc->createElement("description", $this->description));
+		$plan->appendChild($doc->createElement("unit_amount_in_cents", $this->unit_amount_in_cents));
+		$plan->appendChild($doc->createElement("plan_interval_length", $this->plan_interval_length));
+		$plan->appendChild($doc->createElement("plan_interval_unit", $this->plan_interval_unit));
+		$plan->appendChild($doc->createElement("trial_interval_length", $this->trial_interval_length));
+		$plan->appendChild($doc->createElement("trial_interval_unit", $this->trial_interval_unit));
+		$plan->appendChild($doc->createElement("setup_fee_in_cents", $this->setup_fee_in_cents));
+		return $plan;
+	}	
 }


### PR DESCRIPTION
As I was required to keep up to date information between our internal plan data and Recurly's one, I added create (POST) and update (PUT) functionality through the API. Tested against the current version of Recurly, it just works seamlessly. I was able to both create plans, and update existing old ones.
