### PR TITLE
Allow updating a subscription's addons

### DIFF
--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -29,6 +29,7 @@ require_once(dirname(__FILE__) . '/recurly/plan_list.php');
 require_once(dirname(__FILE__) . '/recurly/redemption.php');
 require_once(dirname(__FILE__) . '/recurly/subscription.php');
 require_once(dirname(__FILE__) . '/recurly/subscription_list.php');
+require_once(dirname(__FILE__) . '/recurly/subscription_addon.php');
 require_once(dirname(__FILE__) . '/recurly/transaction.php');
 require_once(dirname(__FILE__) . '/recurly/transaction_error.php');
 require_once(dirname(__FILE__) . '/recurly/transaction_list.php');

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -131,6 +131,8 @@ abstract class Recurly_Base
     'setup_fee_in_cents' => 'Recurly_CurrencyList',
     'subscription' => 'Recurly_Subscription',
     'subscriptions' => 'Recurly_SubscriptionList',
+    'subscription_add_ons' => 'array',
+    'subscription_add_on' => 'Recurly_SubscriptionAddOn',
     'transaction' => 'Recurly_Transaction',
     'transactions' => 'Recurly_TransactionList',
     'transaction_error' => 'Recurly_TransactionError',

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -96,6 +96,11 @@ abstract class Recurly_Resource extends Recurly_Base
       } else if ($val instanceof Recurly_Resource) {
         $attribute_node = $node->appendChild($doc->createElement($key));
         $this->populateXmlDoc($doc, $attribute_node, $val);
+      } else if (is_array($val)) {
+      	$attribute_node = $node->appendChild($doc->createElement($key));
+      	foreach ($val as $child) {
+      		$child->populateXmlDoc($doc, $attribute_node, $child);
+      	}
       } else {
         $node->appendChild($doc->createElement($key, $val));
       }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -10,9 +10,9 @@ class Recurly_Subscription extends Recurly_Resource
     Recurly_Subscription::$_writeableAttributes = array(
       'account','plan_code','coupon_code','unit_amount_in_cents','quantity',
       'currency','starts_at','trial_ends_at','total_billing_cycles',
-      'timeframe'
+      'timeframe', 'subscription_add_ons'
     );
-    Recurly_Subscription::$_nestedAttributes = array('account');
+    Recurly_Subscription::$_nestedAttributes = array('account', 'subscription_add_ons');
   }
 
   public static function get($uuid, $client = null) {

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -1,0 +1,33 @@
+<?php
+
+class Recurly_SubscriptionAddOn extends Recurly_Resource {
+	
+	protected static $_writeableAttributes;
+	
+	public static function init() {
+		Recurly_SubscriptionAddOn::$_writeableAttributes = array(
+			'add_on_code',
+			'quantity',
+			'unit_amount_in_cents'
+		);
+	}
+	
+	protected function getNodeName() {
+		return 'subscription_add_on';
+	}
+	
+	protected function getWriteableAttributes() {
+		return Recurly_SubscriptionAddOn::$_writeableAttributes;
+	}
+	
+	
+	protected function populateXmlDoc(&$doc, &$node, &$obj) {
+		$addonNode = $node->appendChild($doc->createElement($this->getNodeName()));
+		parent::populateXmlDoc($doc, $addonNode, $obj);
+	}
+	
+
+}
+
+Recurly_SubscriptionAddOn::init();
+


### PR DESCRIPTION
The helper class to create subscription add-ons was missing. 

This patch enables creating/updating subscription with add-ons:

``` php
$recSub = new Recurly_Subscription();
$recSub->account_code = '123';
$recSub->plan_code = 'myplan';
$recSub->currency = 'USD';
$addon = new Recurly_SubscriptionAddOn();
$addon->add_on_code = 'MY_ADDON';
$addon->quantity = 3;
$recSub->subscription_add_ons = array($addon);
$recSub->create();
```

See support req #5699.
