### PR TITLE
remove assumption of the result params via recurly.js

### DIFF
--- a/lib/recurly/recurly_js.php
+++ b/lib/recurly/recurly_js.php
@@ -27,12 +27,6 @@ class Recurly_js
     if (!isset($this->data['signature'], $this->data['account_code'], $this->data['plan_code'], $this->data['quantity']))
       throw new InvalidArgumentException("Signature, account_code, plan_code, and/or quantity not present.");
 
-    $verify_data = array(
-      'account_code' => $this->data['account_code'],
-      'plan_code' => $this->data['plan_code'],
-      'quantity' => $this->data['quantity']
-    );
-
     return $this->_verifyResults(self::SUBSCRIPTION_CREATED, $this->data);
   }
 


### PR DESCRIPTION
Isaac, can you please review these changes to the PHP client's recurly.js support, that remove the presumption it makes of the result params returned from the API?
