### PR TITLE
Create subscriptions/transactions with existing accounts

### DIFF
--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -4,6 +4,7 @@ class Recurly_Account extends Recurly_Resource
 {
   protected static $_writeableAttributes;
   protected static $_nestedAttributes;
+  protected static $_requiredAttributes;
 
   function __construct($accountCode = null) {
     if (!is_null($accountCode))
@@ -19,6 +20,9 @@ class Recurly_Account extends Recurly_Resource
     Recurly_Account::$_nestedAttributes = array(
       'adjustments','billing_info','invoices','subscriptions','transactions'
     );
+    Recurly_Account::$_requiredAttributes = array(
+      'account_code'
+    );
   }
 
   public static function get($accountCode, $client = null) {
@@ -27,7 +31,7 @@ class Recurly_Account extends Recurly_Resource
 
   public function create() {
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_ACCOUNTS);
-  }  
+  }
   public function update() {
     $this->_save(Recurly_Client::PUT, $this->uri());
   }
@@ -54,6 +58,9 @@ class Recurly_Account extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return Recurly_Account::$_writeableAttributes;
+  }
+  protected function getRequiredAttributes() {
+    return Recurly_Account::$_requiredAttributes;
   }
 }
 

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -36,7 +36,7 @@ class Recurly_Addon extends Recurly_Resource
       return Recurly_Addon::uriForAddOn($this->plan_code, $this->add_on_code);
   }
   protected static function uriForAddOn($planCode, $addonCode) {
-    return (Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) . 
+    return (Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) .
             Recurly_Client::PATH_ADDONS . '/' . rawurlencode($addonCode));
   }
 
@@ -45,6 +45,9 @@ class Recurly_Addon extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return Recurly_Addon::$_writeableAttributes;
+  }
+  protected function getRequiredAttributes() {
+    return array();
   }
 }
 

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -41,6 +41,9 @@ class Recurly_Adjustment extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Adjustment::$_writeableAttributes;
   }
+  protected function getRequiredAttributes() {
+    return array();
+  }
 }
 
 Recurly_Adjustment::init();

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -14,14 +14,14 @@ class Recurly_BillingInfo extends Recurly_Resource
     );
     Recurly_BillingInfo::$_nestedAttributes = array('account');
   }
-  
+
   public static function get($accountCode, $client = null) {
     return Recurly_Base::_get(Recurly_BillingInfo::uriForBillingInfo($accountCode), $client);
   }
 
   public function create() {
     $this->update();
-  }  
+  }
   public function update() {
     $this->_save(Recurly_Client::PUT, $this->uri());
   }
@@ -32,7 +32,7 @@ class Recurly_BillingInfo extends Recurly_Resource
   public static function deleteForAccount($accountCode) {
     return Recurly_Resource::_delete(Recurly_BillingInfo::uriForBillingInfo($accountCode));
   }
-  
+
   protected function uri() {
     if (!empty($this->_href))
       return $this->getHref();
@@ -50,6 +50,9 @@ class Recurly_BillingInfo extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return Recurly_BillingInfo::$_writeableAttributes;
+  }
+  protected function getRequiredAttributes() {
+    return array();
   }
 }
 

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -65,6 +65,9 @@ class Recurly_Coupon extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Coupon::$_writeableAttributes;
   }
+  protected function getRequiredAttributes() {
+    return array();
+  }
 }
 
 Recurly_Coupon::init();

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -10,7 +10,7 @@ class Recurly_Invoice extends Recurly_Resource
     Recurly_Invoice::$_writeableAttributes = array();
     Recurly_Invoice::$_nestedAttributes = array('account','line_items','transactions');
   }
-  
+
   /**
    * Lookup an invoice by its ID
    * @param string Invoice number or UUID
@@ -55,6 +55,9 @@ class Recurly_Invoice extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return Recurly_Invoice::$_writeableAttributes;
+  }
+  protected function getRequiredAttributes() {
+    return array();
   }
 }
 

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -31,7 +31,7 @@ class Recurly_Plan extends Recurly_Resource
 
   public function create() {
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_PLANS);
-  }  
+  }
   public function update() {
     $this->_save(Recurly_Client::PUT, $this->uri());
   }
@@ -42,7 +42,7 @@ class Recurly_Plan extends Recurly_Resource
   public static function deletePlan($planCode) {
     return Recurly_Resource::_delete(Recurly_Plan::uriForPlan($planCode));
   }
-  
+
   protected function uri() {
     if (!empty($this->_href))
       return $this->getHref();
@@ -58,6 +58,9 @@ class Recurly_Plan extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return Recurly_Plan::$_writeableAttributes;
+  }
+  protected function getRequiredAttributes() {
+    return array();
   }
 }
 

--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -41,6 +41,9 @@ class Recurly_CouponRedemption extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_CouponRedemption::$_writeableAttributes;
   }
+  protected function getRequiredAttributes() {
+    return array();
+  }
 }
 
 Recurly_CouponRedemption::init();

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -100,6 +100,9 @@ class Recurly_Subscription extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Subscription::$_writeableAttributes;
   }
+  protected function getRequiredAttributes() {
+    return array();
+  }
 }
 
 Recurly_Subscription::init();

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -1,9 +1,9 @@
 <?php
 
 class Recurly_SubscriptionAddOn extends Recurly_Resource {
-	
+
 	protected static $_writeableAttributes;
-	
+
 	public static function init() {
 		Recurly_SubscriptionAddOn::$_writeableAttributes = array(
 			'add_on_code',
@@ -11,21 +11,23 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
 			'unit_amount_in_cents'
 		);
 	}
-	
+
 	protected function getNodeName() {
 		return 'subscription_add_on';
 	}
-	
+
 	protected function getWriteableAttributes() {
 		return Recurly_SubscriptionAddOn::$_writeableAttributes;
 	}
-	
-	
+  protected function getRequiredAttributes() {
+    return array();
+  }
+
 	protected function populateXmlDoc(&$doc, &$node, &$obj) {
 		$addonNode = $node->appendChild($doc->createElement($this->getNodeName()));
 		parent::populateXmlDoc($doc, $addonNode, $obj);
 	}
-	
+
   protected function getChangedAttributes()
   {
     // Return all attributes

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -56,6 +56,9 @@ class Recurly_Transaction extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Transaction::$_writeableAttributes;
   }
+  protected function getRequiredAttributes() {
+    return array();
+  }
 }
 
 Recurly_Transaction::init();

--- a/test/fixtures/transactions/show-200-error.xml
+++ b/test/fixtures/transactions/show-200-error.xml
@@ -1,0 +1,54 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890">
+  <account href="https://api.recurly.com/v2/accounts/verena"/>
+  <uuid>abcdef1234567890</uuid>
+  <action>purchase</action>
+  <amount_in_cents type="integer">30000</amount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <currency>USD</currency>
+  <status>declined</status>
+  <reference nil="nil"></reference>
+  <test type="boolean">true</test>
+  <voidable type="boolean">true</voidable>
+  <refundable type="boolean">true</refundable>
+  <transaction_error>
+    <error_code>invalid_card_number</error_code>
+    <error_category>hard</error_category>
+    <merchant_message>The credit card number is not valid. The customer needs to try a different number.</merchant_message>
+    <customer_message>Your card number is not valid. Please update your card number.</customer_message>
+  </transaction_error>
+  <cvv_result code=""></cvv_result>
+  <avs_result code=""></avs_result>
+  <avs_result_street nil="nil"></avs_result_street>
+  <avs_result_postal nil="nil"></avs_result_postal>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <details>
+    <account>
+      <account_code>gob</account_code>
+      <first_name>George Oscar</first_name>
+      <last_name>Bluth</last_name>
+      <company nil="nil"></company>
+      <email>gobias@bluth-company.com</email>
+      <billing_info type="credit_card">
+        <first_name nil="nil"></first_name>
+        <last_name nil="nil"></last_name>
+        <address1 nil="nil"></address1>
+        <address2 nil="nil"></address2>
+        <city nil="nil"></city>
+        <state nil="nil"></state>
+        <zip nil="nil"></zip>
+        <country nil="nil"></country>
+        <phone nil="nil"></phone>
+        <vat_number nil="nil"></vat_number>
+        <cc_type>visa</cc_type>
+        <year type="integer">2011</year>
+        <month type="integer">12</month>
+        <first_six>411111</first_six>
+        <last_four>1111</last_four>
+      </billing_info>
+    </account>
+  </details>
+</transaction>

--- a/test/recurly/account_test.php
+++ b/test/recurly/account_test.php
@@ -3,7 +3,7 @@
 class Recurly_AccountTest extends UnitTestCase
 {
   public function testGetAccount()
-  {  
+  {
     $responseFixture = loadFixture('./fixtures/accounts/show-200.xml');
 
     $client = new MockRecurly_Client();
@@ -18,7 +18,7 @@ class Recurly_AccountTest extends UnitTestCase
     $this->assertEqual($account->created_at->getTimestamp(), 1304164800);
     $this->assertEqual($account->getHref(),'https://api.recurly.com/v2/accounts/abcdef1234567890');
   }
-  
+
   public function testUpdateError()
   {
     $responseFixture = loadFixture('./fixtures/accounts/show-200.xml');
@@ -30,7 +30,7 @@ class Recurly_AccountTest extends UnitTestCase
 
     $account = Recurly_Account::get('abcdef1234567890', $client);
     $account->email = 'invalidemail.com';
-    
+
     try {
       $account->update();
       $this->fail("Expected Recurly_ValidationError");
@@ -45,7 +45,7 @@ class Recurly_AccountTest extends UnitTestCase
     $this->assertEqual($account->errors[0]->symbol, 'invalid_email');
     $this->assertEqual($account->errors[0]->description, 'is not a valid email address');
   }
-  
+
   public function testXml()
   {
     $account = new Recurly_Account();


### PR DESCRIPTION
Currently, because of the way the XML is generated, one can't pass an existing account to a new subscription/transaction—it results in an empty <account/> node.

This should be fixed. An account that is fetched through the API should be able to be passed directly to a new Subscription or Transaction object and properly generate the XML for the request.
