### PR TITLE
Fixed a "Strict Standards" coding error in Recurly_SubscriptionAddOn

### DIFF
--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -23,12 +23,12 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
     return array();
   }
 
-	protected function populateXmlDoc(&$doc, &$node, &$obj) {
+	protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {
 		$addonNode = $node->appendChild($doc->createElement($this->getNodeName()));
 		parent::populateXmlDoc($doc, $addonNode, $obj);
 	}
 
-  protected function getChangedAttributes()
+  protected function getChangedAttributes($nested = false)
   {
     // Return all attributes
     return $this->_values;
@@ -46,4 +46,3 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
 }
 
 Recurly_SubscriptionAddOn::init();
-


### PR DESCRIPTION
The override declarations in the Recurly_SubscriptionAddOn class didn't
match the declarations in the Recurly_Resource class. Solved by adding
the missing optional parameters.
