### PR TITLE
Fix updating currency lists on loaded resources, such as plans

### DIFF
--- a/lib/recurly/currency_list.php
+++ b/lib/recurly/currency_list.php
@@ -4,43 +4,51 @@ class Recurly_CurrencyList implements ArrayAccess, Countable, IteratorAggregate
 {
   private $currencies;
   private $nodeName;
-  
+
   function __construct($nodeName) {
     $this->nodeName = $nodeName;
     $this->currencies = array();
   }
 
   public function addCurrency($currencyCode, $amountInCents) {
-    $this->currencies[$currencyCode] = new Recurly_Currency($currencyCode, $amountInCents);
-  }
-  public function __set($k, $v) {
-    if (is_string($k) && strlen($k) == 3) {
-      $this->addCurrency($k, $v);
+    if (is_string($currencyCode) && strlen($currencyCode) == 3) {
+      $this->currencies[$currencyCode] = new Recurly_Currency($currencyCode, $amountInCents);
     }
   }
 
-  public function offsetSet($offset, $value) {
-    if (is_null($offset)) {
-      $this->currencies[] = $value;
-    } else {
-      $this->currencies[$offset] = $value;
-    }
+  public function getCurrency($currencyCode) {
+    return isset($this->currencies[$currencyCode]) ? $this->currencies[$currencyCode] : null;
   }
+
+  public function offsetSet($offset, $value) {
+    return $this->addCurrency($offset, $value);
+  }
+
   public function offsetExists($offset) {
     return isset($this->currencies[$offset]);
   }
+
   public function offsetUnset($offset) {
     unset($this->currencies[$offset]);
   }
+
   public function offsetGet($offset) {
-    return isset($this->currencies[$offset]) ? $this->currencies[$offset] : null;
+    return $this->getCurrency($offset);
   }
-  
+
+  public function __set($k, $v) {
+    return $this->offsetSet($k, $v);
+  }
+
+  public function __get($k) {
+    return $this->offsetGet($k);
+  }
+
   public function count()
   {
     return count($this->currencies);
   }
-  
+
   public function getIterator() {
     return new ArrayIterator($this->currencies);
   }

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -138,15 +138,20 @@ abstract class Recurly_Resource extends Recurly_Base
   protected function getChangedAttributes($nested = false)
   {
     $attributes = array();
+    $writableAttributes = $this->getWriteableAttributes();
     $requiredAttributes = $this->getRequiredAttributes();
-    foreach($this->getWriteableAttributes() as $attr) {
+
+    foreach($writableAttributes as $attr) {
+      if(!isset($this->_values[$attr])) { continue; }
+
       if(isset($this->_unsavedKeys[$attr]) ||
-         ($nested && in_array($attr, $requiredAttributes)) ||
-         (isset($this->_values[$attr]) && is_array($this->_values[$attr])))
+         $nested && in_array($attr, $requiredAttributes) ||
+         (is_array($this->_values[$attr]) || $this->_values[$attr] instanceof ArrayAccess))
       {
         $attributes[$attr] = $this->$attr;
       }
     }
+
     return $attributes;
   }
 

--- a/test/recurly/plan_test.php
+++ b/test/recurly/plan_test.php
@@ -25,7 +25,7 @@ class Recurly_PlanTest extends UnitTestCase
     $this->assertEqual($plan->setup_fee_in_cents['EUR']->amount_in_cents, 400);
   }
 
-  public function testXml()
+  public function testCreateXml()
   {
     $plan = new Recurly_Plan();
     $plan->plan_code = 'platinum';
@@ -37,5 +37,24 @@ class Recurly_PlanTest extends UnitTestCase
     $xml = $plan->xml();
     $this->assertEqual($xml,
       "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><EUR>500</EUR></setup_fee_in_cents></plan>\n");
+  }
+
+  public function testUpdateXml()
+  {
+    $responseFixture = loadFixture('./fixtures/plans/show-200.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $responseFixture, array('GET', '/plans/silver'));
+
+    $plan = Recurly_Plan::get('silver', $client);
+    $plan->plan_code = 'platinum';
+    $plan->name = 'Platinum Plan';
+    $plan->unit_amount_in_cents->addCurrency('USD', 1500);
+    $plan->unit_amount_in_cents->addCurrency('EUR', 1200);
+    $plan->setup_fee_in_cents->addCurrency('EUR', 500);
+
+    $xml = $plan->xml();
+    $this->assertEqual($xml,
+      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><USD>500</USD><EUR>500</EUR></setup_fee_in_cents></plan>\n");
   }
 }


### PR DESCRIPTION
Fixes an issue where updating a specific currency on a previously loaded resource wouldn't take affect. Because the currency list is neither an array nor updates the unsavedAttrs array on the parent, it wasn't being persisted. This checks if the attr in question is either an array or implements ArrayAccess, in which case it's persisted automatically.

Also, setter access of currencies is now supported:

``` php
<?
$plan = Recurly_Plan::get('small');
$plan->unit_amount_in_cents->USD = 1000; // USD 10.00 monthly fee
$plan->setup_fee_in_cents->USD = 5000; // USD 50.00 setup fee
$plan->update();
```
