### PR TITLE
Fix static deletion methods and add tests

### DIFF
--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -39,8 +39,8 @@ class Recurly_Account extends Recurly_Resource
   public function close() {
     return Recurly_Resource::_delete($this->uri());
   }
-  public static function closeAccount($accountCode) {
-    return Recurly_Resource::_delete(Recurly_Account::uriForAccount($accountCode));
+  public static function closeAccount($accountCode, $client = null) {
+    return Recurly_Base::_delete(Recurly_Account::uriForAccount($accountCode), $client);
   }
 
   protected function uri() {

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -18,8 +18,8 @@ class Recurly_Addon extends Recurly_Resource
     Recurly_Addon::$_nestedAttributes = array();
   }
 
-  public static function get($planCode, $addonCode) {
-    return Recurly_Base::_get(Recurly_Addon::uriForAddOn($planCode, $addonCode));
+  public static function get($planCode, $addonCode, $client = null) {
+    return Recurly_Base::_get(Recurly_Addon::uriForAddOn($planCode, $addonCode), $client);
   }
 
   public function create() {
@@ -31,7 +31,7 @@ class Recurly_Addon extends Recurly_Resource
   }
 
   public function delete() {
-    return Recurly_Resource::_delete($this->uri());
+    return Recurly_Base::_delete($this->uri(), $this->_client);
   }
 
   protected function uri() {

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -16,15 +16,15 @@ class Recurly_Adjustment extends Recurly_Resource
     );
   }
 
-  public static function get($adjustment_uuid) {
-    return Recurly_Base::_get(Recurly_Client::PATH_ADJUSTMENTS . '/' . rawurlencode($adjustment_uuid));
+  public static function get($adjustment_uuid, $client = null) {
+    return Recurly_Base::_get(Recurly_Client::PATH_ADJUSTMENTS . '/' . rawurlencode($adjustment_uuid), $client);
   }
 
   public function create() {
     $this->_save(Recurly_Client::POST, $this->createUriForAccount());
   }
   public function delete() {
-    return Recurly_Resource::_delete($this->getHref());
+    return Recurly_Base::_delete($this->getHref(), $this->_client);
   }
 
   protected function createUriForAccount() {

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -21,7 +21,6 @@ abstract class Recurly_Base
   }
 
 
-
   /**
    * Request the URI, validate the response and return the object.
    * @param string Resource URI, if not fully qualified, the base URL will be appended
@@ -51,6 +50,24 @@ abstract class Recurly_Base
     $object = Recurly_Base::__parseXmlToNewObject($response->body, $client);
     $response->assertSuccessResponse($object);
     return $object;
+  }
+
+  /**
+   * Delete the URI, validate the response and return the object.
+   * @param string Resource URI, if not fully qualified, the base URL will be appended
+   * @param string Data to post to the URI
+   * @param string Optional client for the request, useful for mocking the client
+   */
+  protected static function _delete($uri, $client = null)
+  {
+    if (is_null($client))
+      $client = new Recurly_Client();
+    $response = $client->request(Recurly_Client::DELETE, $uri);
+    $response->assertValidResponse();
+    if ($response->body) {
+      return Recurly_Base::__parseXmlToNewObject($response->body, $client);
+    }
+    return null;
   }
 
   /**

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -27,10 +27,10 @@ class Recurly_BillingInfo extends Recurly_Resource
   }
 
   public function delete() {
-    return Recurly_Resource::_delete($this->uri());
+    return Recurly_Base::_delete($this->uri(), $this->_client);
   }
-  public static function deleteForAccount($accountCode) {
-    return Recurly_Resource::_delete(Recurly_BillingInfo::uriForBillingInfo($accountCode));
+  public static function deleteForAccount($accountCode, $client = null) {
+    return Recurly_Base::_delete(Recurly_BillingInfo::uriForBillingInfo($accountCode), $client);
   }
 
   protected function uri() {

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -70,9 +70,7 @@ class Recurly_Client
 
   public function request($method, $uri, $data = null)
   {
-    $response = $this->_sendRequest($method, $uri, $data);
-    $response->assertValidResponse();
-    return $response;
+    return $this->_sendRequest($method, $uri, $data);
   }
 
   /**

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -43,10 +43,10 @@ class Recurly_Coupon extends Recurly_Resource
 
 
   public function delete() {
-    return Recurly_Resource::_delete($this->uri());
+    return Recurly_Base::_delete($this->uri(), $this->_client);
   }
-  public static function deleteCoupon($couponCode) {
-    return Recurly_Resource::_delete(Recurly_Coupon::uriForCoupon($couponCode));
+  public static function deleteCoupon($couponCode, $client = null) {
+    return Recurly_Base::_delete(Recurly_Coupon::uriForCoupon($couponCode), $client);
   }
 
   protected function uri() {

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -37,10 +37,10 @@ class Recurly_Plan extends Recurly_Resource
   }
 
   public function delete() {
-    return Recurly_Resource::_delete($this->uri());
+    return Recurly_Base::_delete($this->uri(), $this->_client);
   }
-  public static function deletePlan($planCode) {
-    return Recurly_Resource::_delete(Recurly_Plan::uriForPlan($planCode));
+  public static function deletePlan($planCode, $client = null) {
+    return Recurly_Base::_delete(Recurly_Plan::uriForPlan($planCode), $client);
   }
 
   protected function uri() {

--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -17,7 +17,7 @@ class Recurly_CouponRedemption extends Recurly_Resource
   }
 
   public function delete($accountCode = null) {
-    return Recurly_Resource::_delete($this->uri($accountCode));
+    return Recurly_Base::_delete($this->uri($accountCode), $this->_client);
   }
   public static function deleteCouponRedemption($accountCode) {
     return Recurly_CouponRedemption::uriForAccount($accountCode);

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -60,26 +60,11 @@ abstract class Recurly_Resource extends Recurly_Base
       $this->_client = new Recurly_Client();
 
     $response = $this->_client->request($method, $uri, $this->xml());
-    Recurly_Resource::__parseXmlToUpdateObject($response->body);
-    $response->assertSuccessResponse($this);
-  }
-
-  /**
-   * Delete the object at the given URI.
-   * @param string URI of the object to delete
-   * @param array Additional parameters for the delete
-   */
-  protected function _delete($uri)
-  {
-    if (is_null($this->_client))
-      $this->_client = new Recurly_Client();
-
-    $response = $this->_client->request(Recurly_Client::DELETE, $uri);
-    if($response->body) {
+    $response->assertValidResponse();
+    if (isset($response->body)) {
       Recurly_Resource::__parseXmlToUpdateObject($response->body);
     }
     $response->assertSuccessResponse($this);
-    return true;
   }
 
 

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -25,10 +25,11 @@ class Recurly_Transaction extends Recurly_Resource
    * Refund a previous, successful transaction
    */
   public function refund($amountInCents = null) {
-    if (is_null($amountInCents))
-      $this->_delete($this->uri());
-    else
-      $this->_delete($this->uri() . '?amount_in_cents=' . strval(intval($amountInCents)));
+    $uri = $this->uri();
+    if (!is_null($amountInCents)) {
+      $uri .= '?amount_in_cents=' . strval(intval($amountInCents));
+    }
+    $this->_save(Recurly_Client::DELETE, $uri);
   }
 
   /**

--- a/test/all_tests.php
+++ b/test/all_tests.php
@@ -23,8 +23,10 @@ class AllTests extends TestSuite {
     $this->addFile(__DIR__ . '/recurly/client_test.php');
     $this->addFile(__DIR__ . '/recurly/recurlyjs_test.php');
 
+    $this->addFile(__DIR__ . '/recurly/adjustment_test.php');
     $this->addFile(__DIR__ . '/recurly/account_test.php');
     $this->addFile(__DIR__ . '/recurly/account_list_test.php');
+    $this->addFile(__DIR__ . '/recurly/billing_info_test.php');
     $this->addFile(__DIR__ . '/recurly/coupon_test.php');
     $this->addFile(__DIR__ . '/recurly/currency_list_test.php');
     $this->addFile(__DIR__ . '/recurly/invoice_test.php');

--- a/test/fixtures/accounts/destroy-204.xml
+++ b/test/fixtures/accounts/destroy-204.xml
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/test/fixtures/addons/destroy-204.xml
+++ b/test/fixtures/addons/destroy-204.xml
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/test/fixtures/addons/show-200.xml
+++ b/test/fixtures/addons/show-200.xml
@@ -1,0 +1,16 @@
+Status: 200 OK
+Content-Type: application/xml; charset=utf-8
+ETag: "a81253e90a4f16089b951028675c58d2"
+
+<?xml version="1.0" encoding="UTF-8"?>
+<add_on href="https://api.recurly.com/v2/plans/gold/add_ons/ipaddresses">
+  <plan href="https://api.recurly.com/v2/plans/gold"/>
+  <add_on_code>ipaddresses</add_on_code>
+  <name>IP Addresses</name>
+  <display_quantity_on_hosted_page type="boolean">false</display_quantity_on_hosted_page>
+  <default_quantity type="integer">1</default_quantity>
+  <unit_amount_in_cents>
+    <USD type="integer">200</USD>
+  </unit_amount_in_cents>
+  <created_at type="datetime">2011-06-28T12:34:56Z</created_at>
+</add_on>

--- a/test/fixtures/adjustments/destroy-204.xml
+++ b/test/fixtures/adjustments/destroy-204.xml
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/test/fixtures/billing_info/destroy-204.xml
+++ b/test/fixtures/billing_info/destroy-204.xml
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/test/fixtures/billing_info/show-200.xml
+++ b/test/fixtures/billing_info/show-200.xml
@@ -14,15 +14,12 @@ Content-Type: application/xml; charset=utf-8
   <zip>90210</zip>
   <country>US</country>
   <phone nil="nil"></phone>
+  <vat_number>2000</vat_number>
   <ip_address>127.0.0.1</ip_address>
   <ip_address_country nil="nil"></ip_address_country>
-  <cc_type>visa</cc_type>
+  <card_type>Visa</card_type>
   <year type="integer">2015</year>
   <month type="integer">1</month>
-  <start_year type="integer">2010</start_year>
-  <start_month type="integer">12</start_month>
-  <issue_number type="integer">20</issue_number>
-  <vat_number>2000</vat_number>
-  <last_four>1111</last_four>
   <first_six>411111</first_six>
+  <last_four>1111</last_four>
 </billing_info>

--- a/test/fixtures/coupons/destroy-204.xml
+++ b/test/fixtures/coupons/destroy-204.xml
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/test/fixtures/plans/destroy-204.xml
+++ b/test/fixtures/plans/destroy-204.xml
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/test/recurly/account_test.php
+++ b/test/recurly/account_test.php
@@ -19,6 +19,16 @@ class Recurly_AccountTest extends UnitTestCase
     $this->assertEqual($account->getHref(),'https://api.recurly.com/v2/accounts/abcdef1234567890');
   }
 
+  public function testCloseAccount()
+  {
+    $responseFixture = loadFixture(__DIR__ . '/../fixtures/accounts/destroy-204.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $responseFixture, array('DELETE', '/accounts/abcdef1234567890'));
+
+    Recurly_Account::closeAccount('abcdef1234567890', $client);
+  }
+
   public function testUpdateError()
   {
     $responseFixture = loadFixture(__DIR__ . '/../fixtures/accounts/show-200.xml');

--- a/test/recurly/addon_test.php
+++ b/test/recurly/addon_test.php
@@ -1,0 +1,17 @@
+<?php
+
+class Recurly_AddonTest extends UnitTestCase
+{
+  public function testDelete() {
+    $getFixture = loadFixture(__DIR__ . '/../fixtures/addons/show-200.xml');
+    $deleteFixture = loadFixture(__DIR__ . '/../fixtures/addons/destroy-204.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $getFixture, array('GET', '/plans/gold/add_ons/ipaddresses'));
+    $client->returns('request', $deleteFixture, array('DELETE', '/plans/gold/add_ons/ipaddresses'));
+
+    $addon = Recurly_Addon::get('gold', 'ipaddresses', $client);
+    $this->assertIsA($addon, 'Recurly_Addon');
+    $addon->delete();
+  }
+}

--- a/test/recurly/adjustment_test.php
+++ b/test/recurly/adjustment_test.php
@@ -1,0 +1,17 @@
+<?php
+
+class Recurly_AdjustmentTest extends UnitTestCase
+{
+  public function testDelete() {
+    $getFixture = loadFixture(__DIR__ . '/../fixtures/adjustments/show-200.xml');
+    $deleteFixture = loadFixture(__DIR__ . '/../fixtures/adjustments/destroy-204.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $getFixture, array('GET', '/adjustments/abcdef1234567890'));
+    $client->returns('request', $deleteFixture, array('DELETE', 'https://api.recurly.com/v2/adjustments/abcdef1234567890'));
+
+    $adjustment = Recurly_Adjustment::get('abcdef1234567890', $client);
+    $this->assertIsA($adjustment, 'Recurly_Adjustment');
+    $adjustment->delete();
+  }
+}

--- a/test/recurly/billing_info_test.php
+++ b/test/recurly/billing_info_test.php
@@ -1,0 +1,46 @@
+<?php
+
+class Recurly_BillingInfoTest extends UnitTestCase
+{
+  public function testGetAccount()
+  {
+    $responseFixture = loadFixture(__DIR__ . '/../fixtures/billing_info/show-200.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $responseFixture, array('GET', '/accounts/abcdef1234567890/billing_info'));
+
+    $billing_info = Recurly_BillingInfo::get('abcdef1234567890', $client);
+
+    $this->assertIsA($billing_info, 'Recurly_BillingInfo');
+    $this->assertEqual($billing_info->first_name, 'Larry');
+    $this->assertEqual($billing_info->address1, '123 Pretty Pretty Good St.');
+    $this->assertEqual($billing_info->country, 'US');
+    $this->assertEqual($billing_info->card_type, 'Visa');
+    $this->assertEqual($billing_info->year, 2015);
+    $this->assertEqual($billing_info->month, 1);
+    $this->assertEqual($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info');
+  }
+
+  public function testDelete() {
+    $getFixture = loadFixture(__DIR__ . '/../fixtures/billing_info/show-200.xml');
+    $deleteFixture = loadFixture(__DIR__ . '/../fixtures/billing_info/destroy-204.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $getFixture, array('GET', '/accounts/abcdef1234567890/billing_info'));
+    $client->returns('request', $deleteFixture, array('DELETE', 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info'));
+
+    $billing_info = Recurly_BillingInfo::get('abcdef1234567890', $client);
+    $this->assertIsA($billing_info, 'Recurly_BillingInfo');
+    $billing_info->delete();
+  }
+
+  public function testDeleteForAccount() {
+    $responseFixture = loadFixture(__DIR__ . '/../fixtures/billing_info/destroy-204.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $responseFixture, array('DELETE', '/accounts/abcdef1234567890/billing_info'));
+
+    Recurly_BillingInfo::deleteForAccount('abcdef1234567890', $client);
+  }
+
+}

--- a/test/recurly/coupon_test.php
+++ b/test/recurly/coupon_test.php
@@ -19,6 +19,16 @@ class Recurly_CouponTest extends UnitTestCase
     $this->assertEqual($coupon->discount_in_cents['USD']->amount_in_cents, 1000);
   }
 
+  public function testDeleteCoupon()
+  {
+    $responseFixture = loadFixture(__DIR__ . '/../fixtures/coupons/destroy-204.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $responseFixture, array('DELETE', '/coupons/special'));
+
+    Recurly_Coupon::deleteCoupon('special', $client);
+  }
+
   // Parse plan_codes array in response
   public function testPlanCodesXml()
   {

--- a/test/recurly/invoice_test.php
+++ b/test/recurly/invoice_test.php
@@ -60,8 +60,8 @@ class Recurly_InvoiceTest extends UnitTestCase
 
   public function testMarkSuccessful()
   {
-    $loadFixture = loadFixture('./fixtures/invoices/show-200.xml');
-    $responseFixture = loadFixture('./fixtures/invoices/mark_successful-200.xml');
+    $loadFixture = loadFixture(__DIR__ . '/../fixtures/invoices/show-200.xml');
+    $responseFixture = loadFixture(__DIR__ . '/../fixtures/invoices/mark_successful-200.xml');
 
     $client = new MockRecurly_Client();
     $client->returns('request', $loadFixture, array('GET', '/invoices/abcdef1234567890'));
@@ -79,8 +79,8 @@ class Recurly_InvoiceTest extends UnitTestCase
 
   public function testMarkFailed()
   {
-    $loadFixture = loadFixture('./fixtures/invoices/show-200.xml');
-    $responseFixture = loadFixture('./fixtures/invoices/mark_failed-200.xml');
+    $loadFixture = loadFixture(__DIR__ . '/../fixtures/invoices/show-200.xml');
+    $responseFixture = loadFixture(__DIR__ . '/../fixtures/invoices/mark_failed-200.xml');
 
     $client = new MockRecurly_Client();
     $client->returns('request', $loadFixture, array('GET', '/invoices/abcdef1234567890'));

--- a/test/recurly/plan_test.php
+++ b/test/recurly/plan_test.php
@@ -25,6 +25,16 @@ class Recurly_PlanTest extends UnitTestCase
     $this->assertEqual($plan->setup_fee_in_cents['EUR']->amount_in_cents, 400);
   }
 
+  public function testDeletePlan()
+  {
+    $responseFixture = loadFixture(__DIR__ . '/../fixtures/plans/destroy-204.xml');
+
+    $client = new MockRecurly_Client();
+    $client->returns('request', $responseFixture, array('DELETE', '/plans/platinum'));
+
+    Recurly_Plan::deletePlan('platinum', $client);
+  }
+
   public function testCreateXml()
   {
     $plan = new Recurly_Plan();


### PR DESCRIPTION
On https://github.com/recurly/recurly-client-php/issues/46 iclo pointed we have static delete methods calling into the non-static Recurly_Resource::_delete() causing a fatal error.

I moved the _delete() method up to Recurly_Base and made it static,
and adjusted all the deletion calls accordly. Transaction refunds are
a special case since they're the only place we do a DELETE that
returns a body. Since we had no tests, I spent a bit of time adding
those, which required some changes to pass the mock client through.
