### PR TITLE
Remove old taxable attribute from the adjustment

### DIFF
--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -9,7 +9,7 @@ class Recurly_Adjustment extends Recurly_Resource
   {
     Recurly_Adjustment::$_writeableAttributes = array(
       'currency','unit_amount_in_cents','quantity','description',
-      'taxable','accounting_code'
+      'accounting_code'
     );
     Recurly_Adjustment::$_nestedAttributes = array(
       'invoice'

--- a/test/recurly/adjustment_test.php
+++ b/test/recurly/adjustment_test.php
@@ -11,4 +11,21 @@ class Recurly_AdjustmentTest extends UnitTestCase
     $this->assertIsA($adjustment, 'Recurly_Adjustment');
     $adjustment->delete();
   }
+
+  public function testXml() {
+    $charge = new Recurly_Adjustment();
+    $charge->account_code = '1';
+    $charge->description = 'Charge for extra bandwidth';
+    $charge->unit_amount_in_cents = 5000; // $50.00
+    $charge->currency = 'USD';
+    $charge->quantity = 1;
+    $charge->accounting_code = 'bandwidth';
+
+    // This deprecated parameter should be ignored:
+    $charge->taxable = 0;
+
+    $expected = '<?xml version="1.0"?>' + "\n";
+    $expected += '<adjustment><currency>USD</currency><unit_amount_in_cents>5000</unit_amount_in_cents><quantity>1</quantity><description>Charge for extra bandwidth</description><accounting_code>bandwidth</accounting_code></adjustment>';
+    $this->assertEqual($charge->xml(), $expected);
+  }
 }


### PR DESCRIPTION
It's no longer a writeable attribute. Add a test for the adjustment XML generation.
