### PR TITLE
Call Recurly_Resource's constructor

### DIFF
--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -7,6 +7,7 @@ class Recurly_Account extends Recurly_Resource
   protected static $_requiredAttributes;
 
   function __construct($accountCode = null) {
+    parent::__construct();
     if (!is_null($accountCode))
       $this->account_code = $accountCode;
     $this->address = new Recurly_Address();

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -6,6 +6,7 @@ class Recurly_Addon extends Recurly_Resource
   protected static $_nestedAttributes;
 
   function __construct() {
+    parent::__construct();
     $this->unit_amount_in_cents = new Recurly_CurrencyList('unit_amount_in_cents');
   }
 

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -7,6 +7,7 @@ class Recurly_Coupon extends Recurly_Resource
   protected $_redeemUrl;
 
   function __construct() {
+    parent::__construct();
     $this->discount_in_cents = new Recurly_CurrencyList('discount_in_cents');
   }
 

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -6,6 +6,7 @@ class Recurly_Plan extends Recurly_Resource
   protected static $_nestedAttributes;
 
   function __construct() {
+    parent::__construct();
     $this->setup_fee_in_cents = new Recurly_CurrencyList('setup_fee_in_cents');
     $this->unit_amount_in_cents = new Recurly_CurrencyList('unit_amount_in_cents');
   }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -15,9 +15,8 @@ class Recurly_Subscription extends Recurly_Resource
     Recurly_Subscription::$_nestedAttributes = array('account', 'subscription_add_ons');
   }
 
-  public function __construct($href = null, $client = null)
-  {
-    parent::__construct($href, $client);
+  public function __construct() {
+    parent::__construct();
     $this->subscription_add_ons = array();
   }
 


### PR DESCRIPTION
PHP doesn't call parent constructors automagically, so if you override it you need to call `parent::__construct()` yourself.

There's sort of a side question of should we maintain the same interface...  `Recurly_Subscription` was passing `$href` and `$client` up but none of the others were and `Recurly_Account` has a totally different thing where it'll accept `$accountCode`. So I think we could go either way but it'd be nice to pick one.
