### PR TITLE
Include null attributes in XML

### DIFF
--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -60,9 +60,10 @@ class Recurly_PlanTest extends Recurly_TestCase
     $plan->unit_amount_in_cents->addCurrency('USD', 1500);
     $plan->unit_amount_in_cents->addCurrency('EUR', 1200);
     $plan->setup_fee_in_cents->addCurrency('EUR', 500);
+    $plan->total_billing_cycles = NULL;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><USD>500</USD><EUR>500</EUR></setup_fee_in_cents></plan>\n",
+      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><USD>500</USD><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles nil=\"nil\"></total_billing_cycles></plan>\n",
       $plan->xml()
     );
   }

--- a/Tests/Recurly/Resource_Test.php
+++ b/Tests/Recurly/Resource_Test.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once(__DIR__ . '/../test_helpers.php');
+
+class Recource_Mock_Resource extends Recurly_Resource {
+  protected function getNodeName() {
+    return 'mock';
+  }
+  protected function getWriteableAttributes() {
+    return array('date', 'bool', 'number', 'array', 'nil');
+  }
+  protected function getRequiredAttributes() {
+    return array('required');
+  }
+}
+
+class Recurly_ResourceTest extends Recurly_TestCase {
+
+  public function testXml() {
+    $resource = new Recource_Mock_Resource();
+    $resource->date = new DateTime("@1384202874");
+    $resource->bool = true;
+    $resource->number = 34;
+    $resource->array = array(
+      'int' => 1,
+      'string' => 'foo',
+    );
+    $resource->nil = null;
+    $this->assertEquals(
+      "<?xml version=\"1.0\"?>\n<mock><date>2013-11-11T20:47:54+00:00</date><bool>1</bool><number>34</number><array><int>1</int><string>foo</string></array><nil nil=\"nil\"></nil></mock>\n",
+      $resource->xml()
+    );
+  }
+}

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -41,7 +41,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->account = $account;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code><address/></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons/><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code><address></address></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons></subscription_add_ons><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method></subscription>\n",
       $subscription->xml()
   );
   }
@@ -73,7 +73,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $account->billing_info = $billing_info;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address/></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons/></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons></subscription>\n",
       $subscription->xml()
     );
   }
@@ -111,7 +111,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $account->billing_info = $billing_info;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address/></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons><subscription_add_on><add_on_code>more</add_on_code><quantity>1</quantity></subscription_add_on></subscription_add_ons></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons><subscription_add_on><add_on_code>more</add_on_code><quantity>1</quantity></subscription_add_on></subscription_add_ons></subscription>\n",
       $subscription->xml()
     );
   }


### PR DESCRIPTION
Note that this branch incorporates the changes in #66 which switched the tests over to PHPUnit. 

To change a plan's total_billing_cycles you'd need to set it to a null value:

> Number of billing cycles before the plan stops renewing, defaults to null for continuous auto renewal
> http://docs.recurly.com/api/plans

But we don't send values that were set to null so we'll need to make a couple of changes.
