### PR TITLE
Fix Recurly_Invoice::get() documenting that it supports UUIDs.

### DIFF
--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -13,7 +13,7 @@ class Recurly_Invoice extends Recurly_Resource
 
   /**
    * Lookup an invoice by its ID
-   * @param string Invoice number or UUID
+   * @param string Invoice number
    * @return Recurly_Invoice invoice
    */
   public static function get($invoiceNumber, $client = null) {


### PR DESCRIPTION
The Recurly API doesn't support UUIDs for fetching invoices, so this just is a pure docs issue.
