### PR TITLE
Add a method to return all values from a resource.

### DIFF
--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -52,7 +52,7 @@ abstract class Recurly_Resource extends Recurly_Base
    * @return array
    *   The array of values stored with this resource.
    */
-  public function values() {
+  public function getValues() {
     return $this->_values;
   }
 


### PR DESCRIPTION
Over at the <a href="https://drupal.org/project/recurly_entity">Recurly Entity</a> module for Drupal, we need to construct an array with all data properties of a resource if we want to store it in the local database. We'd been manually copying in attributes from writeableAttributes and the like, but that's fragile and not good for future updates.

Since we return raw values anyways (by reference even), I didn't see any reason to not allow fetching _values all at once.
