### PR TITLE
Add a method to return an ID from an href.

### DIFF
--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -363,7 +363,31 @@ abstract class Recurly_Base
       return $new_obj;
     }
   }
+
+  /**
+   * Return the ID of a resource, using only the href property.
+   *
+   * This is most useful for stub objects that haven't been retrieved yet,
+   * where only the ID is needed instead of the full object.
+   *
+   * @throws Recurly_Href_Undefined_Exception
+   *   Thrown when an href was not set when constructing the object.
+   *
+   * @return string
+   *   The ID of the Recurly resource, such as a UUID or plan code.
+   */
+  public function idFromHref() {
+    if (!isset($this->_href)) {
+      throw new Recurly_Href_Undefined_Exception();
+    }
+
+    // This assumes that the end of _href is an ID.
+    $parts = parse_url($this->_href);
+    $path_parts = explode('/', $parts['path']);
+    return end($path_parts);
+  }
 }
 
 // In case node_class is not specified.
 class Recurly_Object {}
+class Recurly_Href_Undefined_Exception extends Exception {}


### PR DESCRIPTION
This PR adds a method to return an ID of an object without having to get() it from the Recurly API - particularly useful for stubs. For example, given an invoice UUID, to find the ID of an account you have to get() on the account stub, which can add quite a bit of lag to any requests. When all you want is the account code, it's a bit of overkill.

Now, this method works for me, but will certainly need some improvement. I went with the most non-invasive change, just to unblock my own work, but I have ideas for other, better approaches.
1. Push the method down to Recurly_Stub, since if you've loaded an object you can directly access the id and you shouldn't need this method.
2. Make the method abstract (since we don't have an interface) and require classes to implement it.
3. Change every Recurly object to store the unique ID as a property, and assign it when constructing or getting.
4. Decide that this isn't the library's problem at all, and make href the canonical identifier. However... I noticed that sometimes _href doesn't have my account's subdomain and is just api.recurly.com, so I don't know if this would cause problems.

Anyways, I figured I'd throw this out there before I did much more.
