### PR TITLE
bulk param

### DIFF
--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -86,9 +86,10 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->account_code = 'act123';
     $account->first_name = 'Verena';
     $account->address->address1 = "123 Main St.";
+    $account->tax_exempt = false;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address></account>\n",
+      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt></account>\n",
       $account->xml()
     );
   }

--- a/Tests/Recurly/Resource_Test.php
+++ b/Tests/Recurly/Resource_Test.php
@@ -27,7 +27,7 @@ class Recurly_ResourceTest extends Recurly_TestCase {
     );
     $resource->nil = null;
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<mock><date>2013-11-11T20:47:54+00:00</date><bool>1</bool><number>34</number><array><int>1</int><string>foo</string></array><nil nil=\"nil\"></nil></mock>\n",
+      "<?xml version=\"1.0\"?>\n<mock><date>2013-11-11T20:47:54+00:00</date><bool>true</bool><number>34</number><array><int>1</int><string>foo</string></array><nil nil=\"nil\"></nil></mock>\n",
       $resource->xml()
     );
   }

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -53,6 +53,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->plan_code = 'gold';
     $subscription->quantity = 1;
     $subscription->currency = 'USD';
+    $subscription->bulk = true;
 
     $account = new Recurly_Account();
     $account->account_code = 'account_code';
@@ -75,7 +76,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $account->billing_info = $billing_info;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons><bulk>true</bulk></subscription>\n",
       $subscription->xml()
     );
   }

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -129,7 +129,7 @@ abstract class Recurly_Resource extends Recurly_Base
         if ($val instanceof DateTime) {
           $val = $val->format('c');
         } else if (is_bool($val)) {
-          $val = ($val ? 1 : 0);
+          $val = ($val ? 'true' : 'false');
         }
         $node->appendChild($doc->createElement($key, $val));
       }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -11,7 +11,7 @@ class Recurly_Subscription extends Recurly_Resource
       'account','plan_code','coupon_code','unit_amount_in_cents','quantity',
       'currency','starts_at','trial_ends_at','total_billing_cycles', 'first_renewal_date',
       'timeframe', 'subscription_add_ons', 'net_terms', 'po_number', 'collection_method',
-      'cost_in_cents', 'remaining_billing_cycles'
+      'cost_in_cents', 'remaining_billing_cycles', 'bulk'
     );
     Recurly_Subscription::$_nestedAttributes = array('account', 'subscription_add_ons');
   }


### PR DESCRIPTION
This new parameter allows you to bypass the 60 second limit on adding multiple subscriptions for the same plan to one account.

The boolean serialization to {0,1} was changed to {true,false} to match the api. It was not being used by any of the other serializers so should be backwards compatible.

Also adding a test for `$account->tax_exempt` to make sure false is working correctly.
