### PR TITLE
Add entity_use_code to account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Added remaining billing cycles to subscriptions: `subscription->remaining_billing_cycles` [91](https://github.com/recurly/recurly-client-php/pull/91)
-* Add subscription change preview for existing subscriptions: `subscription->preview()` [94](https://github.com/recurly/recurly-client-php/pull/94)
+* Added subscription change preview for existing subscriptions: `subscription->preview()` [94](https://github.com/recurly/recurly-client-php/pull/94)
+* Added account entity use code: `account->entity_use_code` [100](https://github.com/recurly/recurly-client-php/pull/100)
 
 ## Version 2.3.0 (May 19th, 2014)
 

--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -28,6 +28,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $this->assertEquals($account->created_at->getTimestamp(), 1304164800);
     $this->assertEquals($account->getHref(),'https://api.recurly.com/v2/accounts/abcdef1234567890');
     $this->assertTrue($account->tax_exempt);
+    $this->assertEquals($account->entity_use_code, 'I');
   }
 
   public function testCloseAccount() {
@@ -87,9 +88,10 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->first_name = 'Verena';
     $account->address->address1 = "123 Main St.";
     $account->tax_exempt = false;
+    $account->entity_use_code = 'I';
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt></account>\n",
+      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt><entity_use_code>I</entity_use_code></account>\n",
       $account->xml()
     );
   }

--- a/Tests/fixtures/accounts/show-200.xml
+++ b/Tests/fixtures/accounts/show-200.xml
@@ -15,6 +15,7 @@ Content-Type: application/xml; charset=utf-8
   <last_name>David</last_name>
   <company_name>Home Box Office</company_name>
   <vat_number>ST-1937</vat_number>
+  <entity_use_code>I</entity_use_code>
   <balance_in_cents_invoiced>
     <USD type="integer">1000</USD>
     <EUR type="integer">800</EUR>

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -19,7 +19,7 @@ class Recurly_Account extends Recurly_Resource
   {
     Recurly_Account::$_writeableAttributes = array(
       'account_code','username','first_name','last_name','vat_number',
-      'email','company_name','accept_language','billing_info','address','tax_exempt'
+      'email','company_name','accept_language','billing_info','address','tax_exempt', 'entity_use_code'
     );
     Recurly_Account::$_nestedAttributes = array(
       'adjustments','billing_info','invoices','subscriptions','transactions'


### PR DESCRIPTION
From our recent integration with Avalara, we now give merchants the ability to set their account tax use code.

cc/ @drewish 
