### PR TITLE
update branch alias to 2.3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2.x-dev"
+            "dev-master": "2.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
Since the latest version is 2.3.0, I presume that `master` should have its branch alias bumped accordingly.
