### PR TITLE
Bump phpunit to 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "4.2.*"
     },
     "autoload": {
         "classmap": ["lib"]


### PR DESCRIPTION
Maybe Travis will be happier. It seems like when they upgrade PHPUnit it breaks. I suspect that we end up using the new runner (4.2) script with the old libraries we've installed (4.1).

Let's just bump it for now but next time around we'll try to figure out a more sustainable fix.

Approver: @whiteotter 
Testing:
- Follow the instructions in `CONTRIBUTING.md`
