### PR TITLE
Provided access to invoice id on manual subscription

### DIFF
--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -75,6 +75,7 @@ abstract class Recurly_Resource extends Recurly_Base
       Recurly_Resource::__parseXmlToUpdateObject($response->body);
     }
     $response->assertSuccessResponse($this);
+    return $this;
   }
 
 

--- a/lib/recurly/stub.php
+++ b/lib/recurly/stub.php
@@ -23,6 +23,10 @@ class Recurly_Stub extends Recurly_Base
     return self::_get($this->_href, $this->_client);
   }
   
+  function getHref() {
+    return $this->_href;
+  }
+
   public function __toString()
   {
     return "<Recurly_Stub[{$this->objectType}] href={$this->_href}>";

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -26,7 +26,7 @@ class Recurly_Subscription extends Recurly_Resource
   }
 
   public function create() {
-    $this->_save(Recurly_Client::POST, Recurly_Client::PATH_SUBSCRIPTIONS);
+    return $this->_save(Recurly_Client::POST, Recurly_Client::PATH_SUBSCRIPTIONS);
   }
 
   public function preview() {


### PR DESCRIPTION
Here is how i'm using it

```
$subscription = new Recurly_Subscription();
...
$subscription_response = $subscription->create();
$href = explode('/', $subscription_response->__get('invoice')->getHref());
$invoice_number= array_pop( $href );
```
