### PR TITLE
Add invoice previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Unreleased
+
+* Added invoice previews: `Recurly_Invoice::previewPendingCharges('<accountCode>');` [112](https://github.com/recurly/recurly-client-php/pull/112)
+
 ## Version 2.3.1 (Sept 26th, 2014)
 
 * Added remaining billing cycles to subscriptions: `subscription->remaining_billing_cycles` [91](https://github.com/recurly/recurly-client-php/pull/91)

--- a/Tests/fixtures/invoices/preview-200.xml
+++ b/Tests/fixtures/invoices/preview-200.xml
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="">
+  <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <uuid>012345678901234567890123456789ab</uuid>
+  <state>open</state>
+  <invoice_number type="integer">1000</invoice_number>
+  <currency>USD</currency>
+  <total_in_cents type="integer">300</total_in_cents>
+  <subtotal_in_cents type="integer">300</subtotal_in_cents>
+</invoice>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -49,6 +49,16 @@ class Recurly_Invoice extends Recurly_Resource
     return self::_post($uri, null, $client);
   }
 
+  /**
+   * Previews an invoice for an account using its pending charges
+   * @param string Unique account code
+   * @return Recurly_Invoice invoice on success
+   */
+  public static function previewPendingCharges($accountCode, $client = null) {
+    $uri = Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_INVOICES . '/preview';
+    return self::_post($uri, null, $client);
+  }
+
   public function markSuccessful() {
     $this->_save(Recurly_Client::PUT, $this->uri() . '/mark_successful');
   }


### PR DESCRIPTION
cc/ @drewish 

tests:
- create an uninvoiced charge on an account
- `$i = Recurly_Invoice::previewPendingCharges('<accountCode>');`
- verify `$i` has the correct invoice attributes and the charge is still uninvoiced
