### PR TITLE
Add tax_code to plan, add on and adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Reverted #64, removing `balance_in_cents_invoiced` and `balance_in_cents_uninvoiced` from `Recurly_Account`. They were never added to the API.
+* Added tax_code to plans, add-ons and adjustments [120](https://github.com/recurly/recurly-client-php/pull/120)
 
 ## Version 2.3.2 (Oct 21st, 2014)
 

--- a/Tests/Recurly/Adjustment_Test.php
+++ b/Tests/Recurly/Adjustment_Test.php
@@ -68,11 +68,13 @@ class Recurly_AdjustmentTest extends Recurly_TestCase
     $charge->currency = 'USD';
     $charge->quantity = 1;
     $charge->accounting_code = 'bandwidth';
+    $charge->tax_exempt = false;
+    $charge->tax_code = 'fake-tax-code';
 
     // This deprecated parameter should be ignored:
     $charge->taxable = 0;
 
-    $expected = "<?xml version=\"1.0\"?>\n<adjustment><currency>USD</currency><unit_amount_in_cents>5000</unit_amount_in_cents><quantity>1</quantity><description>Charge for extra bandwidth</description><accounting_code>bandwidth</accounting_code></adjustment>\n";
+    $expected = "<?xml version=\"1.0\"?>\n<adjustment><currency>USD</currency><unit_amount_in_cents>5000</unit_amount_in_cents><quantity>1</quantity><description>Charge for extra bandwidth</description><accounting_code>bandwidth</accounting_code><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code></adjustment>\n";
     $this->assertEquals($expected, $charge->xml());
   }
 }

--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -62,9 +62,11 @@ class Recurly_PlanTest extends Recurly_TestCase
     $plan->unit_amount_in_cents->addCurrency('EUR', 1200);
     $plan->setup_fee_in_cents->addCurrency('EUR', 500);
     $plan->total_billing_cycles = NULL;
+    $plan->tax_exempt = false;
+    $plan->tax_code = 'fake-tax-code';
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><USD>500</USD><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles nil=\"nil\"></total_billing_cycles></plan>\n",
+      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><USD>500</USD><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles nil=\"nil\"></total_billing_cycles><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code></plan>\n",
       $plan->xml()
     );
   }

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -14,7 +14,7 @@ class Recurly_Addon extends Recurly_Resource
   {
     Recurly_Addon::$_writeableAttributes = array(
       'add_on_code','name','display_quantity','default_quantity',
-      'unit_amount_in_cents','accounting_code'
+      'unit_amount_in_cents','accounting_code','tax_code'
     );
     Recurly_Addon::$_nestedAttributes = array();
   }

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -9,7 +9,7 @@ class Recurly_Adjustment extends Recurly_Resource
   {
     Recurly_Adjustment::$_writeableAttributes = array(
       'currency','unit_amount_in_cents','quantity','description',
-      'accounting_code','tax_exempt'
+      'accounting_code','tax_exempt','tax_code'
     );
     Recurly_Adjustment::$_nestedAttributes = array(
       'invoice'

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -19,7 +19,7 @@ class Recurly_Plan extends Recurly_Resource
       'bypass_hosted_confirmation','unit_name','payment_page_tos_link',
       'plan_interval_length','plan_interval_unit','trial_interval_length',
       'trial_interval_unit','unit_amount_in_cents','setup_fee_in_cents',
-      'total_billing_cycles','accounting_code','tax_exempt'
+      'total_billing_cycles','accounting_code','tax_exempt','tax_code'
     );
     Recurly_Plan::$_nestedAttributes = array(
       'add_ons'


### PR DESCRIPTION
Used in tax calculations for VAT 2015 and Avalara integration taxes only.

Valid tax_code values for VAT 2015 taxes are unknown, digital and physical. Valid tax_code values for Avalara integration taxes can be found in the Avalara documentation.

Approvers: @drewish 

Tests:
On a site with VAT 2015 and Avalara integration taxes enabled:
- Create/Update a plan, add_on and adjustment with a valid tax_code and verify there isn't an error
- Get the created/updated plan, add_on and adjustment and verify that the tax_code is returned in the results
- Attempt to create/update a plan, add_on and adjustment with an invalid tax_code and verify that an error is returned in the results
  On a site without VAT 2015 and Avalara integration taxes enabled:
- Get a plan, add_on and adjustment and verify that the tax_code is not returned in the results
- Attempt to create/update a plan, add_on and adjustment with a tax_code and verify that an error is returned in the results
