### PR TITLE
Adding vat_location_valid field to Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added tax_code to plans, add-ons and adjustments [120](https://github.com/recurly/recurly-client-php/pull/120)
 * Added invoice previews: `Recurly_Invoice::previewPendingCharges('<accountCode>');` [112](https://github.com/recurly/recurly-client-php/pull/112)
 * Added ability to read and write custom invoice notes [115](https://github.com/recurly/recurly-client-php/pull/115)
+* Added vat_location_valid field to Account [127](https://github.com/recurly/recurly-client-php/pull/127)
 
 ## Version 2.3.1 (Sept 26th, 2014)
 

--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -29,6 +29,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $this->assertEquals($account->getHref(),'https://api.recurly.com/v2/accounts/abcdef1234567890');
     $this->assertTrue($account->tax_exempt);
     $this->assertEquals($account->entity_use_code, 'I');
+    $this->assertEquals($account->vat_location_valid, true);
   }
 
   public function testCloseAccount() {

--- a/Tests/fixtures/accounts/show-200.xml
+++ b/Tests/fixtures/accounts/show-200.xml
@@ -28,4 +28,5 @@ Content-Type: application/xml; charset=utf-8
   </address>
   <accept_language>en-US</accept_language>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_location_valid type="boolean">true</vat_location_valid>
 </account>


### PR DESCRIPTION
This field will show up when the account is elligible and has been
location verified according to the VAT rules. It will be true when
passed and false when failed.

There weren't any needed changes for the library code here as it's a
read-only attribute. I just wanted to update the fixture and the test.