### PR TITLE
Update notes path and vat_reverse_charge_notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added invoice previews: `Recurly_Invoice::previewPendingCharges('<accountCode>');` [112](https://github.com/recurly/recurly-client-php/pull/112)
 * Added ability to read and write custom invoice notes [115](https://github.com/recurly/recurly-client-php/pull/115)
 * Added vat_location_valid field to Account [127](https://github.com/recurly/recurly-client-php/pull/127)
+* Added updateNotes() and vat_reverse_charge to Subscription. Added vat_reverse_charge_notes to Invoice. [128](https://github.com/recurly/recurly-client-php/pull/128)
 
 ## Version 2.3.1 (Sept 26th, 2014)
 

--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -26,6 +26,7 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $this->assertEquals($invoice->tax_type, 'usst');
     $this->assertEquals($invoice->terms_and_conditions, 'Some Terms and Conditions');
     $this->assertEquals($invoice->customer_notes, 'Some Customer Notes');
+    $this->assertEquals($invoice->vat_reverse_charge_notes, 'Some VAT Notes');
   }
 
   public function testInvoicePendingCharges() {
@@ -41,6 +42,7 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $this->assertEquals($invoice->getHref(),'https://api.recurly.com/v2/invoices/012345678901234567890123456789ab');
     $this->assertEquals($invoice->terms_and_conditions, 'Some Terms and Conditions');
     $this->assertEquals($invoice->customer_notes, 'Some Customer Notes');
+    $this->assertEquals($invoice->vat_reverse_charge_notes, 'Some VAT Notes');
   }
 
   public function testFailedInvoicePendingCharges() {
@@ -66,8 +68,9 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $this->assertEquals($invoice->currency, 'USD');
     $this->assertEquals($invoice->total_in_cents, 300);
     $this->assertEquals($invoice->getHref(), Null);
-    $this->assertEquals($invoice->terms_and_conditions, "New Terms");
-    $this->assertEquals($invoice->customer_notes, "New Notes");
+    $this->assertEquals($invoice->terms_and_conditions, 'New Terms');
+    $this->assertEquals($invoice->customer_notes, 'New Notes');
+    $this->assertEquals($invoice->vat_reverse_charge_notes, 'New VAT Notes');
   }
 
   public function testFailedPreviewPendingCharges() {

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -27,6 +27,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $this->assertEquals('usst', $subscription->tax_type);
     $this->assertEquals('Some Terms and Conditions', $subscription->terms_and_conditions);
     $this->assertEquals('Some Customer Notes', $subscription->customer_notes);
+    $this->assertEquals('Some VAT Notes', $subscription->vat_reverse_charge_notes);
 
     # TODO: Should test the rest of the parsing.
   }
@@ -174,5 +175,20 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
 
     $this->assertEquals('5000', $subscription->cost_in_cents);
     $this->assertEquals('gold', $subscription->plan_code);
+  }
+
+  public function testUpdateNotes() {
+    $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200.xml');
+    $this->client->addResponse('PUT', 'https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/notes', 'subscriptions/show-200-changed-notes.xml');
+
+    $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
+
+    $notes = array("customer_notes" => "New Customer Notes", "terms_and_condititions" => "New Terms", "vat_reverse_charge_notes" => "New VAT Notes");
+
+    $subscription->updateNotes($notes);
+
+    foreach($notes as $key => $value) {
+      $this->assertEquals($subscription->$key, $value);
+    }
   }
 }

--- a/Tests/fixtures/invoices/create-201.xml
+++ b/Tests/fixtures/invoices/create-201.xml
@@ -13,4 +13,5 @@ Location: https://api.recurly.com/v2/invoices/created-invoice
   <subtotal_in_cents type="integer">300</subtotal_in_cents>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
+  <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
 </invoice>

--- a/Tests/fixtures/invoices/preview-200.xml
+++ b/Tests/fixtures/invoices/preview-200.xml
@@ -12,4 +12,5 @@ Content-Type: application/xml; charset=utf-8
   <subtotal_in_cents type="integer">300</subtotal_in_cents>
   <terms_and_conditions>New Terms</terms_and_conditions>
   <customer_notes>New Notes</customer_notes>
+  <vat_reverse_charge_notes>New VAT Notes</vat_reverse_charge_notes>
 </invoice>

--- a/Tests/fixtures/invoices/show-200.xml
+++ b/Tests/fixtures/invoices/show-200.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <tax_type>usst</tax_type>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
+  <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/012345678901234567890123456789ab" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>

--- a/Tests/fixtures/subscriptions/show-200-changed-notes.xml
+++ b/Tests/fixtures/subscriptions/show-200-changed-notes.xml
@@ -24,9 +24,9 @@ Content-Type: application/xml; charset=utf-8
   <trial_ends_at nil="nil"></trial_ends_at>
   <tax_in_cents type="integer">0</tax_in_cents>
   <tax_type>usst</tax_type>
-  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
-  <customer_notes>Some Customer Notes</customer_notes>
-  <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
+  <terms_and_conditions>New Terms</terms_and_conditions>
+  <customer_notes>New Customer Notes</customer_notes>
+  <vat_reverse_charge_notes>New VAT Notes</vat_reverse_charge_notes>
   <subscription_add_ons type="array">
     <subscription_add_on>
       <name>IP Addresses</name>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -7,7 +7,7 @@ class Recurly_Invoice extends Recurly_Resource
 
   public static function init()
   {
-    Recurly_Invoice::$_writeableAttributes = array('terms_and_conditions', 'customer_notes');
+    Recurly_Invoice::$_writeableAttributes = array('terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes');
     Recurly_Invoice::$_nestedAttributes = array('account','line_items','transactions');
   }
 
@@ -48,10 +48,7 @@ class Recurly_Invoice extends Recurly_Resource
   public static function invoicePendingCharges($accountCode, $attributes = array(), $client = null) {
     $uri = Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_INVOICES;
     $invoice = new self();
-    foreach($attributes as $key => $value) {
-      $invoice->$key = $value;
-    }
-    return self::_post($uri, $invoice->xml(), $client);
+    return self::_post($uri, $invoice->setValues($attributes)->xml(), $client);
   }
 
   /**
@@ -63,10 +60,7 @@ class Recurly_Invoice extends Recurly_Resource
   public static function previewPendingCharges($accountCode, $attributes = array(), $client = null) {
     $uri = Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_INVOICES . '/preview';
     $invoice = new self();
-    foreach($attributes as $key => $value) {
-      $invoice->$key = $value;
-    }
-    return self::_post($uri, $invoice->xml(), $client);
+    return self::_post($uri, $invoice->setValues($attributes)->xml(), $client);
   }
 
   public function markSuccessful() {

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -60,7 +60,18 @@ abstract class Recurly_Resource extends Recurly_Base
     return $this->_errors;
   }
 
-
+  /**
+   * Does a mass assignment on this resource's values
+   *
+   * @parameter array
+   *   The array of values to set on the resource.
+   */
+  public function setValues($values) {
+    foreach($values as $key => $value) {
+      $this->$key = $value;
+    }
+    return $this;
+  }
 
   protected function _save($method, $uri)
   {

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -11,7 +11,8 @@ class Recurly_Subscription extends Recurly_Resource
       'account','plan_code','coupon_code','unit_amount_in_cents','quantity',
       'currency','starts_at','trial_ends_at','total_billing_cycles', 'first_renewal_date',
       'timeframe', 'subscription_add_ons', 'net_terms', 'po_number', 'collection_method',
-      'cost_in_cents', 'remaining_billing_cycles', 'bulk', 'terms_and_conditions', 'customer_notes'
+      'cost_in_cents', 'remaining_billing_cycles', 'bulk', 'terms_and_conditions', 'customer_notes',
+      'vat_reverse_charge_notes'
     );
     Recurly_Subscription::$_nestedAttributes = array('account', 'subscription_add_ons');
   }
@@ -98,6 +99,15 @@ class Recurly_Subscription extends Recurly_Resource
    **/
   public function postpone($nextRenewalDate, $bulk = false) {
     $this->_save(Recurly_Client::PUT, $this->uri() . '/postpone?next_renewal_date=' . $nextRenewalDate . '&bulk=' . ((bool) $bulk));
+  }
+
+  /**
+   * Updates the notes fields of the subscription without generating a SubscriptionChange.
+   *
+   * @parameter array of notes, allowed keys: (customer_notes, terms_and_conditions, vat_reverse_charge_notes)
+   **/
+  public function updateNotes($notes) {
+    $this->setValues($notes)->_save(Recurly_Client::PUT, $this->uri() . '/notes');
   }
 
   protected function uri() {


### PR DESCRIPTION
This adds the new `update_notes` path for `Subscription` and adds `vat_reverse_charge_notes` to `Invoice`. 

Relies on https://github.com/recurly/recurly-client-php/pull/115

Approvers: @drewish 