### PR TITLE
Add Invoice#invoice_number_prefix and Invoice#invoiceNumberWithPrefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added ability to read and write custom invoice notes [115](https://github.com/recurly/recurly-client-php/pull/115)
 * Added vat_location_valid field to Account [127](https://github.com/recurly/recurly-client-php/pull/127)
 * Added updateNotes() and vat_reverse_charge to Subscription. Added vat_reverse_charge_notes to Invoice. [128](https://github.com/recurly/recurly-client-php/pull/128)
+* Added `invoice_number_prefix` and `invoiceNumberWithPrefix()` to `Invoice`. This is to be used with the Country Invoice Sequencing feature. [130](https://github.com/recurly/recurly-client-php/pull/130)
 
 ## Version 2.3.1 (Sept 26th, 2014)
 

--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -7,19 +7,20 @@ class Recurly_InvoiceTest extends Recurly_TestCase
 
   function defaultResponses() {
     return array(
-      array('GET', '/invoices/abcdef1234567890', 'invoices/show-200.xml'),
+      array('GET', '/invoices/1001', 'invoices/show-200.xml'),
+      array('GET', '/invoices/1002', 'invoices/show-with-prefix-200.xml'),
     );
   }
 
   public function testGetInvoice() {
-    $invoice = Recurly_Invoice::get('abcdef1234567890', $this->client);
+    $invoice = Recurly_Invoice::get('1001', $this->client);
 
     $this->assertInstanceOf('Recurly_Invoice', $invoice);
     $this->assertInstanceOf('Recurly_Stub', $invoice->account);
     $this->assertInstanceOf('Recurly_Stub', $invoice->subscription);
     $this->assertEquals($invoice->state, 'collected');
     $this->assertEquals($invoice->total_in_cents, 2995);
-    $this->assertEquals($invoice->getHref(),'https://api.recurly.com/v2/invoices/abcdef1234567890');
+    $this->assertEquals($invoice->getHref(),'https://api.recurly.com/v2/invoices/1001');
     $this->assertInstanceOf('Recurly_TransactionList', $invoice->transactions);
     $this->assertEquals($invoice->transactions->current()->uuid, '012345678901234567890123456789ab');
     $this->assertEquals($invoice->transactions->count(), 1);
@@ -27,6 +28,15 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $this->assertEquals($invoice->terms_and_conditions, 'Some Terms and Conditions');
     $this->assertEquals($invoice->customer_notes, 'Some Customer Notes');
     $this->assertEquals($invoice->vat_reverse_charge_notes, 'Some VAT Notes');
+    $this->assertEquals($invoice->invoice_number_prefix, '');
+    $this->assertEquals($invoice->invoiceNumberWithPrefix(), '1001');
+  }
+
+  public function testGetInvoiceWithPrefix() {
+    $invoice = Recurly_Invoice::get('1002', $this->client);
+    $this->assertEquals($invoice->invoice_number, '1002');
+    $this->assertEquals($invoice->invoice_number_prefix, 'GB');
+    $this->assertEquals($invoice->invoiceNumberWithPrefix(), 'GB1002');
   }
 
   public function testInvoicePendingCharges() {
@@ -91,24 +101,24 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     // - Recurly_Resource::_save() passes the current XML into the PUT which
     //   doesn't seem quite right but I don't want to change it without
     //   understanding what side effects it would have.
-    $this->client->addResponse('PUT', 'https://api.recurly.com/v2/invoices/abcdef1234567890/mark_successful', 'invoices/mark_successful-200.xml');
+    $this->client->addResponse('PUT', 'https://api.recurly.com/v2/invoices/1001/mark_successful', 'invoices/mark_successful-200.xml');
 
-    $invoice = Recurly_Invoice::get('abcdef1234567890', $this->client);
+    $invoice = Recurly_Invoice::get('1001', $this->client);
     $invoice->markSuccessful();
     $this->assertEquals($invoice->state, 'collected');
   }
 
   public function testMarkFailed() {
     // See the notes in testMarkSuccessful().
-    $this->client->addResponse('PUT', 'https://api.recurly.com/v2/invoices/abcdef1234567890/mark_failed', 'invoices/mark_failed-200.xml');
+    $this->client->addResponse('PUT', 'https://api.recurly.com/v2/invoices/1001/mark_failed', 'invoices/mark_failed-200.xml');
 
-    $invoice = Recurly_Invoice::get('abcdef1234567890', $this->client);
+    $invoice = Recurly_Invoice::get('1001', $this->client);
     $invoice->markFailed();
     $this->assertEquals($invoice->state, 'failed');
   }
 
   public function testGetInvoicePdf() {
-    $result = Recurly_Invoice::getInvoicePdf('abcdef1234567890', 'en-GB', $this->client);
-    $this->assertEquals(array('/invoices/abcdef1234567890', 'en-GB'), $result);
+    $result = Recurly_Invoice::getInvoicePdf('1001', 'en-GB', $this->client);
+    $this->assertEquals(array('/invoices/1001', 'en-GB'), $result);
   }
 }

--- a/Tests/fixtures/invoices/create-201.xml
+++ b/Tests/fixtures/invoices/create-201.xml
@@ -8,6 +8,7 @@ Location: https://api.recurly.com/v2/invoices/created-invoice
   <uuid>012345678901234567890123456789ab</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <currency>USD</currency>
   <total_in_cents type="integer">300</total_in_cents>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/Tests/fixtures/invoices/mark_failed-200.xml
+++ b/Tests/fixtures/invoices/mark_failed-200.xml
@@ -2,11 +2,12 @@ HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<invoice href="https://api.recurly.com/v2/invoices/abcdef1234567890">
+<invoice href="https://api.recurly.com/v2/invoices/1001">
   <account href="https://api.recurly.com/v2/accounts/1"/>
   <uuid>012345678901234567890123456789aa</uuid>
   <state>failed</state>
-  <invoice_number type="integer">abcdef1234567890</invoice_number>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">2995</subtotal_in_cents>
@@ -17,7 +18,7 @@ Content-Type: application/xml; charset=utf-8
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/190357944dad4d461272774dd184a17e" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>
-      <invoice href="https://api.recurly.com/v2/invoices/abcdef1234567890"/>
+      <invoice href="https://api.recurly.com/v2/invoices/1001"/>
       <uuid>012345678901234567890123456789ab</uuid>
       <state>invoiced</state>
       <description>Silver Plan</description>

--- a/Tests/fixtures/invoices/mark_successful-200.xml
+++ b/Tests/fixtures/invoices/mark_successful-200.xml
@@ -2,11 +2,12 @@ HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<invoice href="https://api.recurly.com/v2/invoices/abcdef1234567890">
+<invoice href="https://api.recurly.com/v2/invoices/1001">
   <account href="https://api.recurly.com/v2/accounts/1"/>
   <uuid>012345678901234567890123456789aa</uuid>
   <state>collected</state>
-  <invoice_number type="integer">abcdef1234567890</invoice_number>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>
   <subtotal_in_cents type="integer">2995</subtotal_in_cents>
@@ -17,7 +18,7 @@ Content-Type: application/xml; charset=utf-8
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/190357944dad4d461272774dd184a17e" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>
-      <invoice href="https://api.recurly.com/v2/invoices/abcdef1234567890"/>
+      <invoice href="https://api.recurly.com/v2/invoices/1001"/>
       <uuid>012345678901234567890123456789ab</uuid>
       <state>invoiced</state>
       <description>Silver Plan</description>

--- a/Tests/fixtures/invoices/preview-200.xml
+++ b/Tests/fixtures/invoices/preview-200.xml
@@ -7,6 +7,7 @@ Content-Type: application/xml; charset=utf-8
   <uuid>012345678901234567890123456789ab</uuid>
   <state>open</state>
   <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <currency>USD</currency>
   <total_in_cents type="integer">300</total_in_cents>
   <subtotal_in_cents type="integer">300</subtotal_in_cents>

--- a/Tests/fixtures/invoices/show-with-prefix-200.xml
+++ b/Tests/fixtures/invoices/show-with-prefix-200.xml
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<invoice href="https://api.recurly.com/v2/invoices/1001">
+<invoice href="https://api.recurly.com/v2/invoices/1002">
   <account href="https://api.recurly.com/v2/accounts/1"/>
   <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
   <uuid>012345678901234567890123456789aa</uuid>
   <state>collected</state>
-  <invoice_number type="integer">1001</invoice_number>
-  <invoice_number_prefix></invoice_number_prefix>
+  <invoice_number type="integer">1002</invoice_number>
+  <invoice_number_prefix>GB</invoice_number_prefix>
   <po_number></po_number>
   <vat_number></vat_number>
   <subtotal_in_cents type="integer">2995</subtotal_in_cents>
@@ -26,7 +26,7 @@ Content-Type: application/xml; charset=utf-8
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/012345678901234567890123456789ab" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>
-      <invoice href="https://api.recurly.com/v2/invoices/1001"/>
+      <invoice href="https://api.recurly.com/v2/invoices/1002"/>
       <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
       <uuid>012345678901234567890123456789ab</uuid>
       <state>invoiced</state>
@@ -49,7 +49,7 @@ Content-Type: application/xml; charset=utf-8
   <transactions type="array">
     <transaction href="https://api.recurly.com/v2/transactions/012345678901234567890123456789ab" type="credit_card">
       <account href="https://api.recurly.com/v2/accounts/1"/>
-      <invoice href="https://api.recurly.com/v2/invoices/1001"/>
+      <invoice href="https://api.recurly.com/v2/invoices/1002"/>
       <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
       <uuid>012345678901234567890123456789ab</uuid>
       <action>purchase</action>

--- a/Tests/fixtures/subscriptions/preview-200-change.xml
+++ b/Tests/fixtures/subscriptions/preview-200-change.xml
@@ -31,6 +31,7 @@ Content-Type: application/xml; charset=utf-8
     <uuid>abcdefg123</uuid>
     <state>open</state>
     <invoice_number nil="nil"></invoice_number>
+    <invoice_number_prefix></invoice_number_prefix>
     <po_number nil="nil"></po_number>
     <vat_number></vat_number>
     <subtotal_in_cents type="integer">5000</subtotal_in_cents>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -70,6 +70,10 @@ class Recurly_Invoice extends Recurly_Resource
     $this->_save(Recurly_Client::PUT, $this->uri() . '/mark_failed');
   }
 
+  public function invoiceNumberWithPrefix() {
+    return $this->invoice_number_prefix . $this->invoice_number;
+  }
+
   protected function getNodeName() {
     return 'invoice';
   }
@@ -80,10 +84,11 @@ class Recurly_Invoice extends Recurly_Resource
     return array();
   }
   protected function uri() {
+    $invoiceNumberWithPrefix = $this->invoiceNumberWithPrefix();
     if (!empty($this->_href))
       return $this->getHref();
-    else if (!empty($this->invoice_number))
-      return Recurly_Invoice::uriForInvoice($this->invoice_number);
+    else if (!empty($invoiceNumberWithPrefix))
+      return Recurly_Invoice::uriForInvoice($invoiceNumberWithPrefix);
     else
       throw new Recurly_Error("Invoice number not specified");
   }


### PR DESCRIPTION
cc/ @drewish   

tests:

  - Turn on the Country Invoice Sequencing feature with VAT taxes
  - Create a VAT taxed invoice 
  - `Recurly_Invoice::get('GB1000')->invoiceNumberWithPrefix()` should find the correct invoice and return its full invoice number.