### PR TITLE
Adding missing fields to Invoice 

### DIFF
--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -7,7 +7,7 @@ class Recurly_Invoice extends Recurly_Resource
 
   public static function init()
   {
-    Recurly_Invoice::$_writeableAttributes = array('terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes');
+    Recurly_Invoice::$_writeableAttributes = array('terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes', 'collection_method', 'net_terms', 'po_number');
     Recurly_Invoice::$_nestedAttributes = array('account','line_items','transactions');
   }
 


### PR DESCRIPTION
added collection_method, net_terms, po_number

particularly adds support for creating invoices with manual
collection_method

resolves recurly/recurly-client-php#84