### PR TITLE
Support open amount and line item refunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Unreleased
+
+* Added adjustment refund support: `refund()` and `toRefundAttributes()` on `Recurly_Adjustment` [133](https://github.com/recurly/recurly-client-php/pull/133)
+* Added invoice refund supprt: `refund()` and `refundAmount()` on `Recurly_Invoice` [133](https://github.com/recurly/recurly-client-php/pull/133)
+
 ## Version 2.4.0 (Feb 2nd, 2014)
 
 * Force cURL to validate SSL certificates [#122](https://github.com/recurly/recurly-client-php/pull/122)

--- a/Tests/fixtures/invoices/refund-201.xml
+++ b/Tests/fixtures/invoices/refund-201.xml
@@ -1,0 +1,21 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/created-invoice
+
+<invoice href="https://api.recurly.com/v2/invoices/1001">
+  <account href="https://api.recurly.com/v2/accounts/1"/>
+  <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
+  <uuid>012345678901234567890123456789aa</uuid>
+  <state>collected</state>
+  <invoice_number type="integer">abcdef1234567890</invoice_number>
+  <po_number></po_number>
+  <vat_number></vat_number>
+  <subtotal_in_cents type="integer">-1000</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">2995</total_in_cents>
+  <currency>USD</currency>
+  <created_at type="datetime">2012-05-28T17:44:13Z</created_at>
+  <closed_at type="datetime">2012-05-28T17:44:13Z</closed_at>
+  <net_terms type="integer">0</net_terms>
+  <collection_method>automatic</collection_method>
+</invoice>

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -27,6 +27,37 @@ class Recurly_Adjustment extends Recurly_Resource
     return Recurly_Base::_delete($this->getHref(), $this->_client);
   }
 
+  /**
+   * Allows you to refund this particular item if it's a part of
+   * an invoice. It does this by calling the invoice's refund()
+   * Only 'invoiced' adjustments can be refunded.
+   *
+   * @param Integer the quantity you wish to refund, defaults to refunding the entire quantity
+   * @param Boolean indicates whether you want this adjustment refund prorated
+   * @return Recurly_Invoice the new refund invoice
+   * @throws Recurly_Error if the adjustment cannot be refunded.
+   */
+  public function refund($quantity = null, $prorate = false) {
+    if ($this->state == 'pending') {
+      throw new Recurly_Error("Only invoiced adjustments can be refunded");
+    }
+    $invoice = $this->invoice->get();
+    return $invoice->refund($this->toRefundAttributes($quantity, $prorate));
+  }
+
+  /**
+   * Converts this adjustment into the attributes needed for a refund.
+   *
+   * @param Integer the quantity you wish to refund, defaults to refunding the entire quantity
+   * @param Boolean indicates whether you want this adjustment refund prorated
+   * @return Array an array of refund attributes to be fed into invoice->refund()
+   */
+  public function toRefundAttributes($quantity = null, $prorate = false) {
+    if (is_null($quantity)) $quantity = $this->quantity;
+
+    return array('uuid' => $this->uuid, 'quantity' => $quantity, 'prorate' => $prorate);
+  }
+
   protected function createUriForAccount() {
     if (empty($this->account_code))
       throw new Recurly_Error("'account_code' is not specified");

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -91,11 +91,19 @@ abstract class Recurly_Resource extends Recurly_Base
 
   public function xml()
   {
-    $doc = new DOMDocument("1.0");
+    $doc = $this->createDocument();
     $root = $doc->appendChild($doc->createElement($this->getNodeName()));
     $this->populateXmlDoc($doc, $root, $this);
     // To be able to consistently run tests across different XML libraries,
     // favor `<foo></foo>` over `<foo/>`.
+    return $this->renderXML($doc);
+  }
+
+  public function createDocument() {
+    return new DOMDocument("1.0");
+  }
+
+  public function renderXML($doc) {
     return $doc->saveXML(null, LIBXML_NOEMPTYTAG);
   }
 


### PR DESCRIPTION
This pull request is to support both open amount and line item refunds on `Invoice`.

Approvers: @drewish 

### Testing

Open Amount:
```php
$invoice = Recurly_Invoice::get('1002');  // get some invoice
$ref = $invoice->refundAmount(100);      // refund some amount in cents
var_dump($ref); // verify the returned refund invoice is correct
```
Line Item [WIP]:
```php
// get some invoice, preferably with multiple line items
$invoice = Recurly_Invoice::get('1002');

// grab out which ever ones you want to refund
$line_items = $invoice->line_items;

// You probably want to build new adjustment objects
// rather than modifying your existing line items
// and passing those in
$adjustment_map = function($line_item) {
  return $line_item->toRefundAttributes();
};
$refunds = array_map($adjustment_map, $line_items);

$ref = $invoice->refund($refunds); // create a refund invoice from refund attributes
var_dump($ref);   // verify the returned refund invoice is correct
```