### PR TITLE
Cleanup CHANGELOG for 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,34 @@
 # Recurly PHP Client Library CHANGELOG
 
-## Version 2.4.0 (Unreleased)
+## Version 2.4.0 (Feb 2nd, 2014)
 
-* Force cURL to validate SSL certificates: [122](https://github.com/recurly/recurly-client-php/pull/122)
+* Force cURL to validate SSL certificates [#122](https://github.com/recurly/recurly-client-php/pull/122)
 * Reverted #64, removing `balance_in_cents_invoiced` and `balance_in_cents_uninvoiced` from `Recurly_Account`. They were never added to the API.
-* Added tax_code to plans, add-ons and adjustments [120](https://github.com/recurly/recurly-client-php/pull/120)
-* Added invoice previews: `Recurly_Invoice::previewPendingCharges('<accountCode>');` [112](https://github.com/recurly/recurly-client-php/pull/112)
-* Added ability to read and write custom invoice notes [115](https://github.com/recurly/recurly-client-php/pull/115)
-* Added vat_location_valid field to Account [127](https://github.com/recurly/recurly-client-php/pull/127)
-* Added updateNotes() and vat_reverse_charge to Subscription. Added vat_reverse_charge_notes to Invoice. [128](https://github.com/recurly/recurly-client-php/pull/128)
-* Added `invoice_number_prefix` and `invoiceNumberWithPrefix()` to `Invoice`. This is to be used with the Country Invoice Sequencing feature. [130](https://github.com/recurly/recurly-client-php/pull/130)
+* Added `tax_code` to `Recurly_Plan`, `Recurly_Addon` and `Recurly_Adjustment` [#120](https://github.com/recurly/recurly-client-php/pull/120)
+* Added invoice previews: `Recurly_Invoice::previewPendingCharges($accountCode)` [#112](https://github.com/recurly/recurly-client-php/pull/112)
+* Added `terms_and_conditions` and `customer_notes` to `Recurly_Invoice` [#115](https://github.com/recurly/recurly-client-php/pull/115)
+* Added `vat_location_valid` field to `Recurly_Account` [#127](https://github.com/recurly/recurly-client-php/pull/127)
+* Added `updateNotes()` and `vat_reverse_charge` to `Recurly_Subscription`. [#128](https://github.com/recurly/recurly-client-php/pull/128)
+* Added `vat_reverse_charge_notes` to `Recurly_Invoice`. [#128](https://github.com/recurly/recurly-client-php/pull/128)
+* Added `invoice_number_prefix` and `invoiceNumberWithPrefix()` to `Recurly_Invoice`. This is to be used with the Country Invoice Sequencing feature. [#130](https://github.com/recurly/recurly-client-php/pull/130)
 
 ## Version 2.3.1 (Sept 26th, 2014)
 
-* Added remaining billing cycles to subscriptions: `subscription->remaining_billing_cycles` [91](https://github.com/recurly/recurly-client-php/pull/91)
-* Added subscription change preview for existing subscriptions: `subscription->preview()` [94](https://github.com/recurly/recurly-client-php/pull/94)
-* Remove readme reference to recurlyjs v2 private key [97](https://github.com/recurly/recurly-client-php/pull/97)
-* Addding bulk parameter to subscription creation [98](https://github.com/recurly/recurly-client-php/pull/98)
-* Added account entity use code: `account->entity_use_code` [100](https://github.com/recurly/recurly-client-php/pull/100)
-* Added PHP 5.6 and HHVM to travis.yml (thanks to [Nyholm](https://github.com/Nyholm)) [101](https://github.com/recurly/recurly-client-php/pull/101)
-* Update branch alias to 2.3.x-dev (thanks to [bangpound](https://github.com/bangpound)) [102](https://github.com/recurly/recurly-client-php/pull/102)
-* Bump phpunit to 4.2 [103](https://github.com/recurly/recurly-client-php/pull/103)
-* Adds PayPal and Amazon support to Recurly_BillingInfo [104](https://github.com/recurly/recurly-client-php/pull/104)
-* Adding bulk parameter to `$subscription->postpone()` [105](https://github.com/recurly/recurly-client-php/pull/105)
+* Added remaining billing cycles to subscriptions: `$subscription->remaining_billing_cycles` [#91](https://github.com/recurly/recurly-client-php/pull/91)
+* Added subscription change preview for existing subscriptions: `$subscription->preview()` [#94](https://github.com/recurly/recurly-client-php/pull/94)
+* Remove readme reference to RecurlyJS v2 private key [#97](https://github.com/recurly/recurly-client-php/pull/97)
+* Adding bulk parameter to subscription creation [#98](https://github.com/recurly/recurly-client-php/pull/98)
+* Added account entity use code: `$account->entity_use_code` [#100](https://github.com/recurly/recurly-client-php/pull/100)
+* Added PHP 5.6 and HHVM to `travis.yml` (thanks to [Nyholm](https://github.com/Nyholm)) [#101](https://github.com/recurly/recurly-client-php/pull/101)
+* Update branch alias to 2.3.x-dev (thanks to [bangpound](https://github.com/bangpound)) [#102](https://github.com/recurly/recurly-client-php/pull/102)
+* Bump phpunit to 4.2 [#103](https://github.com/recurly/recurly-client-php/pull/103)
+* Adds PayPal and Amazon support to `Recurly_BillingInfo` [#104](https://github.com/recurly/recurly-client-php/pull/104)
+* Adding bulk parameter to `$subscription->postpone()` [#105](https://github.com/recurly/recurly-client-php/pull/105)
 
 ## Version 2.3.0 (May 19th, 2014)
 
-* Added tax details to adjustments: `$adjustment->tax_details` [90](https://github.com/recurly/recurly-client-php/pull/90)
-* Added subscription previews: `$subscription->preview()` [90](https://github.com/recurly/recurly-client-php/pull/90)
+* Added tax details to adjustments: `$adjustment->tax_details` [#90](https://github.com/recurly/recurly-client-php/pull/90)
+* Added subscription previews: `$subscription->preview()` [#90](https://github.com/recurly/recurly-client-php/pull/90)
 
 ## Version 2.2.6 (May 9th, 2014)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@
 
 ## Version 2.1.4 (February 19, 2013)
 
-* Fixed fatal error in Recurly_Invoice::getInvoicePdf().
-* Fixed fatal error in Recurly_Account::close().
+* Fixed fatal error in `Recurly_Invoice::getInvoicePdf()`.
+* Fixed fatal error in `Recurly_Account::close()`.
 * Added `reopen()` and `reopenAccount` to `Recurly_Account`.
 
 ## Version 2.1.3 (February 8, 2013)
@@ -126,10 +126,10 @@ NOTE: Recurly.js signature and result retrieval is not backwards compatible with
 ## Version 2.0.5 (November 20, 2011)
 
 * Always send list of addons when performing a subscription update.
-* Fixed URL for Recurly_CouponRedemption::get().
-* Added Recurly_TransactionList::getForAccount().
-* Add coupon redemption via $coupon->redeemCoupon('account_code').
-* Properly encode plan_codes when limiting coupons to specific plans.
+* Fixed URL for `Recurly_CouponRedemption::get()`.
+* Added `Recurly_TransactionList::getForAccount()`.
+* Add coupon redemption via `$coupon->redeemCoupon('account_code')`.
+* Properly encode `plan_codes` when limiting coupons to specific plans.
 
 ## Version 2.0.4 (November 16, 2011)
 
@@ -138,12 +138,12 @@ NOTE: Recurly.js signature and result retrieval is not backwards compatible with
 
 ## Version 2.0.3 (November 9, 2011)
 
-* Use rawurlencode() instead of urlencode() to create resource URLs. Required for URLs that contain spaces
-* Raise Recurly_ValidationError for 422 instead of Recurly_RequestError. Bug introduced in earlier commit today
+* Use `rawurlencode()` instead of `urlencode()` to create resource URLs. Required for URLs that contain spaces
+* Raise `Recurly_ValidationError` for 422 instead of `Recurly_RequestError`. Bug introduced in earlier commit today
 
 ## Version 2.0.2 (November 9, 2011)
 
-* Fix Recurly_InvoiceList::getForAccount(), SubscriptionList::getForAccount()
+* Fix `Recurly_InvoiceList::getForAccount()`, `SubscriptionList::getForAccount()`
 * Interpret 4xx as request errors and 5xx as server errors for future error codes
 
 ## Version 2.0.1 (November 2, 2011)
@@ -153,7 +153,7 @@ NOTE: Recurly.js signature and result retrieval is not backwards compatible with
 Merged fixes from [beaudesigns](https://github.com/beaudesigns):
 
 * Replaced static class to DomDocument::loadXML()
-* "pending_subscription" now loads class Recurly_Subscription
+* "pending_subscription" now loads class `Recurly_Subscription`
 * Fixed references to $this that should have been local scopes
 
 ## Version 2.0.0 (October 18, 2011)

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -34,7 +34,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.3.2';
+  const API_CLIENT_VERSION = '2.4.0';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
- Use # for PR numbers
- Fix typos
- Consistent formatting

Also bumps the version number.