### PR TITLE
Bump composer dev to 2.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3.x-dev"
+            "dev-master": "2.4.x-dev"
         }
     }
 }


### PR DESCRIPTION
Looking at https://packagist.org/packages/recurly/recurly-client I noticed it's still calling the dev branch 2.3.x-dev  so let's bump that too.