### PR TITLE
Ensure client is passed to stubs

### DIFF
--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -4,10 +4,24 @@ require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_BaseTest extends Recurly_TestCase {
 
-  public function testParsingXMLToNewObject() {
-    $this->client->addResponse('GET', '/accounts/abcdef1234567890', 'accounts/empty.xml');
+  public function testParsingEmptyXML() {
+    $this->client->addResponse('GET', 'abcdef1234567890', 'accounts/empty.xml');
 
-    $account = Recurly_Account::get('abcdef1234567890', $this->client);
+    $account = Recurly_Base::_get('abcdef1234567890', $this->client);
     $this->assertNull($account);
+  }
+
+  public function testPassingClientToStub() {
+    $this->client->addResponse('GET', 'abcdef1234567890', 'adjustments/show-200.xml');
+
+    $adjustment = Recurly_Base::_get('abcdef1234567890', $this->client);
+    $this->assertInstanceOf('Recurly_Adjustment', $adjustment);
+    $this->assertInstanceOf('Recurly_Stub', $adjustment->invoice);
+
+    // The client is protected so we do a little song and dance to access it:
+    $reflection = new \ReflectionClass($adjustment->invoice);
+    $property = $reflection->getProperty('_client');
+    $property->setAccessible(true);
+    $this->assertEquals($property->getValue($adjustment->invoice), $this->client);
   }
 }

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -189,8 +189,8 @@ abstract class Recurly_Base
     $rootNode = $dom->documentElement;
 
     $obj = Recurly_Resource::__createNodeObject($rootNode);
-    Recurly_Resource::__parseXmlToObject($rootNode->firstChild, $obj);
     $obj->_client = $client;
+    Recurly_Resource::__parseXmlToObject($rootNode->firstChild, $obj);
     return $obj;
   }
 


### PR DESCRIPTION
@bhelx noticed that we when you tried `$this->invoice->get()` in a `Recurly_Adjustment` the client wasn't passed through the `Recurly_Stub` to the `Recurly_Invoice` making it impossible to test the code. 

I wrote up a test to confirm that was the problem then located the issue. We were assigning the client to the object after its stubs had been created.