### PR TITLE
126 psr3 logger for v2.41

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "authors": [],
     "require": {
         "php": ">= 5.3.0",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -149,10 +149,10 @@ class Recurly_Client
       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
     }
 
-    if(Recurly_Client::$logger){
+    if (Recurly_Client::$logger) {
       Recurly_Client::$logger->info('Send request to Recurly', array('method' => $method, 'uri' => $uri));
       Recurly_Client::$logger->debug('Send request with headers', array('headers' => $headers));
-      if(!empty($data)){
+      if ($data) {
         Recurly_Client::$logger->debug('Recurly request body', array('body' => $data));
       }
     }
@@ -178,9 +178,9 @@ class Recurly_Client
     }
     $headers = $this->_getHeaders($header);
 
-    if(Recurly_Client::$logger){
+    if (Recurly_Client::$logger) {
       Recurly_Client::$logger->debug('Response from Recurly', array('headers' => $headers));
-      if(!empty($body)){
+      if ($body) {
         Recurly_Client::$logger->debug('Recurly response body', array('body' => $body));
       }
     }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -1,5 +1,7 @@
 <?php
 
+use Psr\Log\LoggerInterface;
+
 /**
  * Recurly_Client provides methods for interacting with the {@link http://docs.recurly.com/api Recurly} API.
  *
@@ -23,6 +25,11 @@ class Recurly_Client
    * Base API URL
    */
   public static $apiUrl = 'https://%s.recurly.com/v2';
+
+  /**
+   * PSR-3 logger for logging client requests
+   */
+  public static $logger = null;
 
   /**
    * API Key instance, may differ from the static key
@@ -118,12 +125,13 @@ class Recurly_Client
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
     curl_setopt($ch, CURLOPT_TIMEOUT, 45);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+    $headers = array(
       'Content-Type: application/xml; charset=utf-8',
       'Accept: application/xml',
       Recurly_Client::__userAgent(),
       'Accept-Language: ' . $this->_acceptLanguage
-    ));
+    );
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     curl_setopt($ch, CURLOPT_USERPWD, $this->apiKey());
 
     if ('POST' == $method)
@@ -139,6 +147,14 @@ class Recurly_Client
     else if('GET' != $method)
     {
       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    }
+
+    if(Recurly_Client::$logger){
+      Recurly_Client::$logger->info('Send request to Recurly', array('method' => $method, 'uri' => $uri));
+      Recurly_Client::$logger->debug('Send request with headers', array('headers' => $headers));
+      if(!empty($data)){
+        Recurly_Client::$logger->debug('Recurly request body', array('body' => $data));
+      }
     }
 
     $response = curl_exec($ch);
@@ -161,6 +177,13 @@ class Recurly_Client
       list($header, $body) = explode("\r\n\r\n", $body, 2);
     }
     $headers = $this->_getHeaders($header);
+
+    if(Recurly_Client::$logger){
+      Recurly_Client::$logger->debug('Response from Recurly', array('headers' => $headers));
+      if(!empty($body)){
+        Recurly_Client::$logger->debug('Recurly response body', array('body' => $body));
+      }
+    }
 
     return new Recurly_ClientResponse($statusCode, $headers, $body);
   }


### PR DESCRIPTION
This PR addresses #126, providing a similar logging facility as the ruby client.

As discussed in #126, the php-fig PSR-3 logging interface has been incorporated into the Recurly_Client class.  I chose to adopt the existing paradigm for setting up the Recurly client with static variables to setup the logger.  Using the logger is optional.

Here's an example for how to use logging with the PSR-3 compliant [monolog](https://github.com/Seldaek/monolog) library

``` php
<?php

use Monolog\Logger;
use Monolog\Handler\StreamHandler;

require_once('lib/recurly.php');

// Required for the API
Recurly_Client::$subdomain = 'your-subdomain';
Recurly_Client::$apiKey = 'abcdef01234567890abcdef01234567890';

// create a log channel, add a log handler, and record all DEBUG level and higher
$logger = new Logger('recurly');
$logger->pushHandler(new StreamHandler('path/to/recurly.log', Logger::DEBUG));

// tell Recurly_Client to use the logger
Recurly_Client::$logger = $logger;
```

I wasn't sure what to have the actual messages say in the request and response section. Feel fee to modify.
