### PR TITLE
Properly encode entities when serializing XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.4.2 (Unreleased)
+
+* Fixes encoding of values with ampersands [#150](https://github.com/recurly/recurly-client-php/issues/150)
+
 ## Version 2.4.1 (Feb 6th, 2015)
 
 * Added adjustment refund support: `refund()` and `toRefundAttributes()` on `Recurly_Adjustment` [#133](https://github.com/recurly/recurly-client-php/pull/133)
-* Added invoice refund supprt: `refund()` and `refundAmount()` on `Recurly_Invoice` [#133](https://github.com/recurly/recurly-client-php/pull/133)
+* Added invoice refund support: `refund()` and `refundAmount()` on `Recurly_Invoice` [#133](https://github.com/recurly/recurly-client-php/pull/133)
 
 ## Version 2.4.0 (Feb 2nd, 2015)
 

--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -42,14 +42,14 @@ class Recurly_PlanTest extends Recurly_TestCase
   public function testCreateXml() {
     $plan = new Recurly_Plan();
     $plan->plan_code = 'platinum';
-    $plan->name = 'Platinum Plan';
+    $plan->name = 'Platinum & Gold Plan';
     $plan->unit_amount_in_cents->addCurrency('USD', 1500);
     $plan->unit_amount_in_cents->addCurrency('EUR', 1200);
     $plan->setup_fee_in_cents->addCurrency('EUR', 500);
     $plan->total_billing_cycles = 6;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles>6</total_billing_cycles></plan>\n",
+      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum &amp; Gold Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles>6</total_billing_cycles></plan>\n",
       $plan->xml()
     );
   }

--- a/Tests/Recurly/Resource_Test.php
+++ b/Tests/Recurly/Resource_Test.php
@@ -7,7 +7,7 @@ class Recource_Mock_Resource extends Recurly_Resource {
     return 'mock';
   }
   protected function getWriteableAttributes() {
-    return array('date', 'bool', 'number', 'array', 'nil');
+    return array('date', 'bool', 'number', 'array', 'nil', 'string');
   }
   protected function getRequiredAttributes() {
     return array('required');
@@ -26,8 +26,9 @@ class Recurly_ResourceTest extends Recurly_TestCase {
       'string' => 'foo',
     );
     $resource->nil = null;
+    $resource->string = "Foo & Bar";
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<mock><date>2013-11-11T20:47:54+00:00</date><bool>true</bool><number>34</number><array><int>1</int><string>foo</string></array><nil nil=\"nil\"></nil></mock>\n",
+      "<?xml version=\"1.0\"?>\n<mock><date>2013-11-11T20:47:54+00:00</date><bool>true</bool><number>34</number><array><int>1</int><string>foo</string></array><nil nil=\"nil\"></nil><string>Foo &amp; Bar</string></mock>\n",
       $resource->xml()
     );
   }

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -141,16 +141,16 @@ abstract class Recurly_Resource extends Recurly_Base
       } else if (is_null($val)) {
         $domAttribute = $doc->createAttribute('nil');
         $domAttribute->value = 'nil';
-        $attribute_node = $doc->createElement($key, null);
+        $attribute_node = $node->appendChild($doc->createElement($key));
         $attribute_node->appendChild($domAttribute);
-        $node->appendChild($attribute_node);
       } else {
         if ($val instanceof DateTime) {
           $val = $val->format('c');
         } else if (is_bool($val)) {
           $val = ($val ? 'true' : 'false');
         }
-        $node->appendChild($doc->createElement($key, $val));
+        $attribute_node = $node->appendChild($doc->createElement($key));
+        $attribute_node->appendChild($doc->createTextNode($val));
       }
     }
   }


### PR DESCRIPTION
Fixes #148. This also syncs up the style for creating the `$attribute_node` in the `null` case.