### PR TITLE
Add bank account fields to billing info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Unreleased
+
+* - Added bank account attributes to `Recurly_BillingInfo`, these include:
+  + - `name_on_account`
+  + - `account_type` (`checking` or `savings`)
+  + - `last_four`
+  + - `routing_number`
+
 ## Version 2.4.2 (Apr 14th, 2015)
 
 * Fixes encoding of values with ampersands [#150](https://github.com/recurly/recurly-client-php/issues/150)

--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -9,6 +9,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
       array('GET', '/accounts/abcdef1234567890/billing_info', 'billing_info/show-200.xml'),
       array('GET', '/accounts/paypal1234567890/billing_info', 'billing_info/show-paypal-200.xml'),
       array('GET', '/accounts/amazon1234567890/billing_info', 'billing_info/show-amazon-200.xml'),
+      array('GET', '/accounts/bankaccount1234567890/billing_info', 'billing_info/show-bank-account-200.xml'),
       array('PUT', '/accounts/abcdef1234567890/billing_info', 'billing_info/show-200.xml'),
       array('DELETE', '/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
       array('DELETE', 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
@@ -50,6 +51,25 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertEquals($billing_info->paypal_billing_agreement_id, null);
     $this->assertEquals($billing_info->amazon_billing_agreement_id, 'C01-1234567-8901234');
     $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/amazon1234567890/billing_info');
+  }
+
+  public function testGetBankAccountBillingInfo() {
+    $billing_info = Recurly_BillingInfo::get('bankaccount1234567890', $this->client);
+
+    $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
+    $this->assertEquals($billing_info->name_on_account, 'John Doe');
+    $this->assertEquals($billing_info->first_name, null);
+    $this->assertEquals($billing_info->last_name, null);
+
+    $this->assertEquals($billing_info->address1, '123 Fake St');
+    $this->assertEquals($billing_info->country, 'US');
+
+    $this->assertEquals($billing_info->account_type, 'checking');
+    $this->assertEquals($billing_info->last_four, '6789');
+    $this->assertEquals($billing_info->routing_number, '125200057');
+
+    $this->assertEquals($billing_info->card_type, null);
+    $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/bankaccount1234567890/billing_info');
   }
 
   public function testDelete() {

--- a/Tests/fixtures/billing_info/show-bank-account-200.xml
+++ b/Tests/fixtures/billing_info/show-bank-account-200.xml
@@ -1,0 +1,24 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<billing_info href="https://api.recurly.com/v2/accounts/bankaccount1234567890/billing_info" type="bank_account">
+  <account href="https://api.recurly.com/v2/accounts/bankaccount1234567890"/>
+  <name_on_account>John Doe</name_on_account>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company nil="nil"></company>
+  <address1>123 Fake St</address1>
+  <address2 nil="nil"></address2>
+  <city>San Francisco</city>
+  <state>CA</state>
+  <zip>94107</zip>
+  <country>US</country>
+  <phone nil="nil"></phone>
+  <vat_number nil="nil"></vat_number>
+  <ip_address nil="nil"></ip_address>
+  <ip_address_country nil="nil"></ip_address_country>
+  <account_type>checking</account_type>
+  <last_four>6789</last_four>
+  <routing_number>125200057</routing_number>
+</billing_info>

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -8,9 +8,10 @@ class Recurly_BillingInfo extends Recurly_Resource
   public static function init()
   {
     Recurly_BillingInfo::$_writeableAttributes = array(
-      'first_name','last_name','ip_address',
+      'first_name','last_name','name_on_account','ip_address',
       'address1','address2','city','state','country','zip','phone','vat_number',
       'number','month','year','verification_value','start_year','start_month','issue_number',
+      'account_number','routing_number','account_type',
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id',
       'token_id'
     );


### PR DESCRIPTION
Adds ACH support for Billing Infos

cc/ @drewish  

tests:

```php
$billing_info = new Recurly_BillingInfo();
$billing_info->account_code = '<account-code>';
$billing_info->name_on_account = 'John Doe';
$billing_info->routing_number = '125200057';
$billing_info->account_number = '0123456789';
$billing_info->account_type = 'checking';
$billing_info->address1 = '123 Fake St';
$billing_info->city = 'San Francisco';
$billing_info->state ='CA';
$billing_info->country = 'US';
$billing_info->zip = '94107';
$billing_info->create();
```
  - check the billing info to see that it reflects that info
  