### PR TITLE
Use invoice prefix when fetching PDF's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
+* Fixed bug where fetching an invoice PDF did not use the invoice number prefix [#155](https://github.com/recurly/recurly-client-php/pull/155)
 * - Added bank account attributes to `Recurly_BillingInfo`, these include:
   + - `name_on_account`
   + - `account_type` (`checking` or `savings`)
   + - `last_four`
   + - `routing_number`
+  * [#153](https://github.com/recurly/recurly-client-php/pull/153)
 
 ## Version 2.4.2 (Apr 14th, 2015)
 

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -24,7 +24,7 @@ class Recurly_Invoice extends Recurly_Resource
    * Retrieve the PDF version of this invoice
    */
   public function getPdf($locale = null) {
-    return Recurly_Invoice::getInvoicePdf($this->invoice_number, $locale, $this->_client);
+    return Recurly_Invoice::getInvoicePdf($this->invoiceNumberWithPrefix(), $locale, $this->_client);
   }
 
   /**


### PR DESCRIPTION
Missed a spot when adding the invoice number prefixes, we need to fetch the invoice PDF's using that prefix.

Fixes https://github.com/recurly/recurly-client-php/issues/143

cc/ @drewish 

tests:

  - Create an invoice that has a VAT EU prefix
```php
$i = Recurly_Invoice::get('<invoice_number_with_prefix>');
file_put_contents('invoice.pdf', $i->getPdf());
```
  - open up `invoice.pdf`, it should contain the invoice