### PR TITLE
Add bank_account_authorized_at to subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 ## Unreleased
 
 * Fixed bug where fetching an invoice PDF did not use the invoice number prefix [#155](https://github.com/recurly/recurly-client-php/pull/155)
-* - Added bank account attributes to `Recurly_BillingInfo`, these include:
-  + - `name_on_account`
-  + - `account_type` (`checking` or `savings`)
-  + - `last_four`
-  + - `routing_number`
+* Added bank account attributes to `Recurly_BillingInfo`, these include:
+  + `name_on_account`
+  + `account_type` (`checking` or `savings`)
+  + `last_four`
+  + `routing_number`
   * [#153](https://github.com/recurly/recurly-client-php/pull/153)
 * Added `ip_address` attribute to `Recurly_Transaction`[#157](https://github.com/recurly/recurly-client-php/pull/157)
+* Added `bank_account_authorized_at` to `Recurly_Subscription` [#156](https://github.com/recurly/recurly-client-php/pull/156)
 
 ## Version 2.4.2 (Apr 14th, 2015)
 

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -12,7 +12,7 @@ class Recurly_Subscription extends Recurly_Resource
       'currency','starts_at','trial_ends_at','total_billing_cycles', 'first_renewal_date',
       'timeframe', 'subscription_add_ons', 'net_terms', 'po_number', 'collection_method',
       'cost_in_cents', 'remaining_billing_cycles', 'bulk', 'terms_and_conditions', 'customer_notes',
-      'vat_reverse_charge_notes'
+      'vat_reverse_charge_notes', 'bank_account_authorized_at'
     );
     Recurly_Subscription::$_nestedAttributes = array('account', 'subscription_add_ons');
   }


### PR DESCRIPTION
For back dating bank account authorization when importing subscriptions, the API user can specify a `bank_account_authorized_at` timestamp of when that authorization occurred.

cc/ @drewish  

tests:

```php
$account = Recurly_Account::get('<account_code>');
$sub = new Recurly_Subscription();
$sub->plan_code = '<plan_code>';
$sub->currency = 'USD';
$sub->account = $account;
$sub->bank_account_authorized_at = '2015-02-15T08:00:00+00:00';
$sub->create();

$sub = Recurly_Subscription::get($sub->uuid);
var_dump($sub->bank_account_authorized_at); //> 2015-02-15 08:00:00.000000"
```