### PR TITLE
Add ip_address to Transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   + - `last_four`
   + - `routing_number`
   * [#153](https://github.com/recurly/recurly-client-php/pull/153)
+* Added `ip_address` attribute to `Recurly_Transaction`[#157](https://github.com/recurly/recurly-client-php/pull/157)
 
 ## Version 2.4.2 (Apr 14th, 2015)
 

--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -19,6 +19,7 @@ class Recurly_TransactionTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Stub', $transaction->subscription);
 
     $this->assertEquals($transaction->account->getHref(), 'https://api.recurly.com/v2/accounts/verena');
+    $this->assertEquals($transaction->ip_address, '127.0.0.1');
   }
 
   public function testCreateTransactionFailed() {

--- a/Tests/fixtures/transactions/create-422.xml
+++ b/Tests/fixtures/transactions/create-422.xml
@@ -32,6 +32,7 @@ Content-Type: application/xml; charset=utf-8
     <avs_result_street nil="nil"></avs_result_street>
     <avs_result_postal nil="nil"></avs_result_postal>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <ip_address>127.0.0.1</ip_address>
     <details>
       <account>
         <account_code>verena</account_code>

--- a/Tests/fixtures/transactions/refund-202.xml
+++ b/Tests/fixtures/transactions/refund-202.xml
@@ -19,6 +19,7 @@ Content-Type: application/xml; charset=utf-8
   <avs_result_street nil="nil"></avs_result_street>
   <avs_result_postal nil="nil"></avs_result_postal>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <ip_address>127.0.0.1</ip_address>
   <details>
     <account>
       <account_code>gob</account_code>

--- a/Tests/fixtures/transactions/show-200-error.xml
+++ b/Tests/fixtures/transactions/show-200-error.xml
@@ -25,6 +25,7 @@ Content-Type: application/xml; charset=utf-8
   <avs_result_street nil="nil"></avs_result_street>
   <avs_result_postal nil="nil"></avs_result_postal>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <ip_address>127.0.0.1</ip_address>
   <details>
     <account>
       <account_code>gob</account_code>

--- a/Tests/fixtures/transactions/show-200.xml
+++ b/Tests/fixtures/transactions/show-200.xml
@@ -24,6 +24,7 @@ Content-Type: application/xml; charset=utf-8
   <avs_result_street>Y</avs_result_street>
   <avs_result_postal>Y</avs_result_postal>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <ip_address>127.0.0.1</ip_address>
   <details>
     <account>
       <account_code>gob</account_code>


### PR DESCRIPTION
Adding `ip_address` to transactions now that it's exposed
https://docs.recurly.com/api/transactions#create-transaction

cc: @drewish 

Test:
`$transaction = Recurly_Transaction::get(‘<uuid>’);`
`print htmlspecialchars($transaction);`
