### PR TITLE
Add option to specify the refund_apply_order for invoice refunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Added `gateway_error_code` to `Transaction`
+* Added `gateway_error_code` to `Transaction` [#163](https://github.com/recurly/recurly-client-php/pull/163)
+* Add support for `refund_apply_order` when performing an open amount or line item refund [#161](https://github.com/recurly/recurly-client-php/pull/161)]
 
 ## Version 2.4.3 (June 4th, 2015)
 

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -34,15 +34,16 @@ class Recurly_Adjustment extends Recurly_Resource
    *
    * @param Integer the quantity you wish to refund, defaults to refunding the entire quantity
    * @param Boolean indicates whether you want this adjustment refund prorated
+   * @param String indicates the refund order to apply, valid options: {'credit','transaction'}, defaults to 'credit'
    * @return Recurly_Invoice the new refund invoice
    * @throws Recurly_Error if the adjustment cannot be refunded.
    */
-  public function refund($quantity = null, $prorate = false) {
+  public function refund($quantity = null, $prorate = false, $refund_apply_order = 'credit') {
     if ($this->state == 'pending') {
       throw new Recurly_Error("Only invoiced adjustments can be refunded");
     }
     $invoice = $this->invoice->get();
-    return $invoice->refund($this->toRefundAttributes($quantity, $prorate));
+    return $invoice->refund($this->toRefundAttributes($quantity, $prorate), $refund_apply_order);
   }
 
   /**

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -77,12 +77,14 @@ class Recurly_Invoice extends Recurly_Resource
   /**
    * Refunds an open amount from the invoice and returns a new refund invoice
    * @param Integer amount in cents to refund from this invoice
+   * @param String indicates the refund order to apply, valid options: {'credit','transaction'}, defaults to 'credit'
    * @return Recurly_Invoice a new refund invoice
    */
-  public function refundAmount($amount_in_cents) {
+  public function refundAmount($amount_in_cents, $refund_apply_order = 'credit') {
     $doc = $this->createDocument();
 
     $root = $doc->appendChild($doc->createElement($this->getNodeName()));
+    $root->appendChild($doc->createElement('refund_apply_order', $refund_apply_order));
     $root->appendChild($doc->createElement('amount_in_cents', $amount_in_cents));
 
     return $this->createRefundInvoice($this->renderXML($doc));
@@ -91,14 +93,16 @@ class Recurly_Invoice extends Recurly_Resource
   /**
    * Refunds given line items from an invoice and returns new refund invoice
    * @param Array refund attributes or Array of refund attributes to refund (see 'REFUND ATTRIBUTES' in docs or Recurly_Adjustment#toRefundAttributes)
+   * @param String indicates the refund order to apply, valid options: {'credit','transaction'}, defaults to 'credit'
    * @return Recurly_Invoice a new refund invoice
    */
-  public function refund($line_items) {
+  public function refund($line_items, $refund_apply_order = 'credit') {
     if (isset($line_items['uuid'])) { $line_items = array($line_items); }
 
     $doc = $this->createDocument();
 
     $root = $doc->appendChild($doc->createElement($this->getNodeName()));
+    $root->appendChild($doc->createElement('refund_apply_order', $refund_apply_order));
     $line_items_node = $root->appendChild($doc->createElement('line_items'));
 
     foreach ($line_items as $line_item) {


### PR DESCRIPTION
cc/ @drewish 

tests:

- Create a new invoice with 2 line items and make sure it is paid
- Attempt a transaction first line item refund:

```php
$inv = Recurly_Invoice::get('<invoice_number>');
$refInv = $inv->refund([$inv->line_items[0]->toRefundAttributes()], 'transaction');
print($refInv->invoice_number); // should contain the refund of the first line item

$refInv = $inv->line_items[1]->refund(null, false, 'transaction');
print($refInv->invoice_number); // should contain the refund of the last line item
```

- Create another invoice and make sure it is paid
- Attempt a transaction first open amount refund:

```php
$inv = Recurly_Invoice::get('<invoice_number>');
$refInv = $inv->refundAmount(1000, 'transaction');
print($refInv->invoice_number);
```