### PR TITLE
Adding `gateway_error_code` to `Transaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Unreleased
+
+* Added `gateway_error_code` to `Transaction`
+
 ## Version 2.4.3 (June 4th, 2015)
 
 * Fixed bug where fetching an invoice PDF did not use the invoice number prefix [#155](https://github.com/recurly/recurly-client-php/pull/155)

--- a/Tests/fixtures/transactions/create-422.xml
+++ b/Tests/fixtures/transactions/create-422.xml
@@ -8,6 +8,7 @@ Content-Type: application/xml; charset=utf-8
     <error_category>declined</error_category>
     <customer_message lang="en-US">Your card number is not valid. Please update your card number.</customer_message>
     <merchant_message lang="en-US">The credit card number is not valid. The customer needs to try a different number.</merchant_message>
+    <gateway_error_code>123</gateway_error_code>
   </transaction_error>
   <error field="transaction.account.billing_info.credit_card_number" symbol="invalid" lang="en-US">is not valid</error>
   <transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890">
@@ -26,6 +27,7 @@ Content-Type: application/xml; charset=utf-8
       <error_category>hard</error_category>
       <merchant_message>The credit card number is not valid. The customer needs to try a different number.</merchant_message>
       <customer_message>Your card number is not valid. Please update your card number.</customer_message>
+      <gateway_error_code>123</gateway_error_code>
     </transaction_error>
     <cvv_result code=""></cvv_result>
     <avs_result code=""></avs_result>

--- a/Tests/fixtures/transactions/show-200-error.xml
+++ b/Tests/fixtures/transactions/show-200-error.xml
@@ -19,6 +19,7 @@ Content-Type: application/xml; charset=utf-8
     <error_category>hard</error_category>
     <merchant_message>The credit card number is not valid. The customer needs to try a different number.</merchant_message>
     <customer_message>Your card number is not valid. Please update your card number.</customer_message>
+    <gateway_error_code>123</gateway_error_code>
   </transaction_error>
   <cvv_result code=""></cvv_result>
   <avs_result code=""></avs_result>

--- a/lib/recurly/transaction_error.php
+++ b/lib/recurly/transaction_error.php
@@ -6,24 +6,28 @@ class Recurly_TransactionError
    * Error code
    */
   var $error_code;
-  
+
   /**
    * Error category
    */
   var $error_category;
-  
+
   /**
    * Message to display to the customer
    */
   var $customer_message;
-  
+
   /**
    * Advice to the merchant on why the transaction failed
    */
   var $merchant_message;
-  
-  
+
+  /**
+   * The error code returned by the gateway
+   */
+  var $gateway_error_code;
+
   public function __toString() {
-    return "<Recurly_TransactionError error_code=\"{$this->error_code}\" error_category=\"{$this->error_category}\" customer_message=\"{$this->customer_message}\" transaction_error=\"{$this->merchant_message}\">";
+    return "<Recurly_TransactionError error_code=\"{$this->error_code}\" error_category=\"{$this->error_category}\" customer_message=\"{$this->customer_message}\" transaction_error=\"{$this->merchant_message}\" gateway_error_code=\"{$this->gateway_error_code}\">";
   }
 }


### PR DESCRIPTION
Added `gateway_error_code` to `Transaction` now that it’s exposed https://docs.recurly.com/api/transactions/error-codes

cc: @whiteotter 