### PR TITLE
Spec for successfully submitted, declined transactions

### DIFF
--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -68,5 +68,10 @@ class Recurly_TransactionTest extends Recurly_TestCase
     $transaction = Recurly_Transaction::get('012345678901234567890123456789ab', $this->client);
     $this->assertInstanceOf('Recurly_Transaction', $transaction);
     $this->assertInstanceOf('Recurly_TransactionError', $transaction->transaction_error);
+    $this->assertEquals('invalid_card_number', $transaction->transaction_error->error_code);
+    $this->assertEquals('hard', $transaction->transaction_error->error_category);
+    $this->assertEquals('The credit card number is not valid. The customer needs to try a different number.', $transaction->transaction_error->merchant_message);
+    $this->assertEquals('Your card number is not valid. Please update your card number.', $transaction->transaction_error->customer_message);
+    $this->assertEquals('123', $transaction->transaction_error->gateway_error_code);
   }
 }


### PR DESCRIPTION
Adding specs that assert the transaction response messages and codes are accurate.

cc: @drewish 

To test out: `vendor/phpunit/phpunit/phpunit Tests/`