### PR TITLE
Add missing class to get the redemptions of a coupon

### DIFF
--- a/Tests/Recurly/Coupon_Test.php
+++ b/Tests/Recurly/Coupon_Test.php
@@ -34,6 +34,16 @@ class Recurly_CouponTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_CouponRedemption', $redemption);
   }
 
+  public function testGetCouponRedemptions() {
+    $this->client->addResponse('GET', 'https://api.recurly.com/v2/coupons/special/redemptions', 'coupons/show-redemptions-200.xml');
+
+    $coupon = Recurly_Coupon::get('special', $this->client);
+    $redemptions = $coupon->redemptions->get();
+
+    $this->assertInstanceOf('Recurly_CouponRedemptionList', $redemptions);
+    $this->assertEquals(2, $redemptions->count());
+  }
+
   public function testRedeemCouponExpired() {
     $this->client->addResponse('GET', '/coupons/expired', 'coupons/show-200-expired.xml');
 

--- a/Tests/fixtures/coupons/show-redemptions-200.xml
+++ b/Tests/fixtures/coupons/show-redemptions-200.xml
@@ -13,13 +13,13 @@ Location: https://api.recurly.com/v2/coupons/special/redemptions
     <state>active</state>
     <created_at type="datetime">2014-01-06T19:06:35Z</created_at>
   </redemption>
-    <redemption href="https://api.recurly.com/v2/accounts/with_address/redemption">
-      <coupon href="https://api.recurly.com/v2/coupons/special"/>
-      <account href="https://api.recurly.com/v2/accounts/1234567890abcdef"/>
-      <single_use type="boolean">false</single_use>
-      <total_discounted_in_cents type="integer">1238</total_discounted_in_cents>
-      <currency>USD</currency>
-      <state>active</state>
-      <created_at type="datetime">2014-01-14T13:27:53Z</created_at>
-    </redemption>
+  <redemption href="https://api.recurly.com/v2/accounts/with_address/redemption">
+    <coupon href="https://api.recurly.com/v2/coupons/special"/>
+    <account href="https://api.recurly.com/v2/accounts/1234567890abcdef"/>
+    <single_use type="boolean">false</single_use>
+    <total_discounted_in_cents type="integer">1238</total_discounted_in_cents>
+    <currency>USD</currency>
+    <state>active</state>
+    <created_at type="datetime">2014-01-14T13:27:53Z</created_at>
+  </redemption>
 </redemptions>

--- a/Tests/fixtures/coupons/show-redemptions-200.xml
+++ b/Tests/fixtures/coupons/show-redemptions-200.xml
@@ -1,0 +1,25 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/coupons/special/redemptions
+
+<?xml version="1.0" encoding="UTF-8"?>
+<redemptions type="array">
+  <redemption href="https://api.recurly.com/v2/accounts/with_address/redemption">
+    <coupon href="https://api.recurly.com/v2/coupons/special"/>
+    <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+    <single_use type="boolean">false</single_use>
+    <total_discounted_in_cents type="integer">0</total_discounted_in_cents>
+    <currency>USD</currency>
+    <state>active</state>
+    <created_at type="datetime">2014-01-06T19:06:35Z</created_at>
+  </redemption>
+    <redemption href="https://api.recurly.com/v2/accounts/with_address/redemption">
+      <coupon href="https://api.recurly.com/v2/coupons/special"/>
+      <account href="https://api.recurly.com/v2/accounts/1234567890abcdef"/>
+      <single_use type="boolean">false</single_use>
+      <total_discounted_in_cents type="integer">1238</total_discounted_in_cents>
+      <currency>USD</currency>
+      <state>active</state>
+      <created_at type="datetime">2014-01-14T13:27:53Z</created_at>
+    </redemption>
+</redemptions>

--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -30,6 +30,7 @@ require_once(dirname(__FILE__) . '/recurly/note_list.php');
 require_once(dirname(__FILE__) . '/recurly/plan.php');
 require_once(dirname(__FILE__) . '/recurly/plan_list.php');
 require_once(dirname(__FILE__) . '/recurly/redemption.php');
+require_once(dirname(__FILE__) . '/recurly/redemption_list.php');
 require_once(dirname(__FILE__) . '/recurly/subscription.php');
 require_once(dirname(__FILE__) . '/recurly/subscription_list.php');
 require_once(dirname(__FILE__) . '/recurly/subscription_addon.php');

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -169,6 +169,7 @@ abstract class Recurly_Base
     'plan_codes' => 'array',
     'pending_subscription' => 'Recurly_Subscription',
     'redemption' => 'Recurly_CouponRedemption',
+    'redemptions' => 'Recurly_CouponRedemptionList',
     'setup_fee_in_cents' => 'Recurly_CurrencyList',
     'subscription' => 'Recurly_Subscription',
     'subscriptions' => 'Recurly_SubscriptionList',

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -48,7 +48,8 @@ class Recurly_Client
   const PATH_ADJUSTMENTS = '/adjustments';
   const PATH_BILLING_INFO = '/billing_info';
   const PATH_COUPON = '/coupon';
-  const PATH_COUPON_REDEMPTION = '/redemptions';
+  const PATH_COUPON_REDEMPTION = '/redemption';
+  const PATH_COUPON_REDEMPTIONS = '/redemptions';
   const PATH_COUPONS = '/coupons';
   const PATH_INVOICES = '/invoices';
   const PATH_NOTES = '/notes';

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -48,7 +48,7 @@ class Recurly_Client
   const PATH_ADJUSTMENTS = '/adjustments';
   const PATH_BILLING_INFO = '/billing_info';
   const PATH_COUPON = '/coupon';
-  const PATH_COUPON_REDEMPTION = '/redemption';
+  const PATH_COUPON_REDEMPTION = '/redemptions';
   const PATH_COUPONS = '/coupons';
   const PATH_INVOICES = '/invoices';
   const PATH_NOTES = '/notes';

--- a/lib/recurly/redemption_list.php
+++ b/lib/recurly/redemption_list.php
@@ -4,8 +4,8 @@ class Recurly_CouponRedemptionList extends Recurly_Pager
 {
   public static function get($params = null, $client = null)
   {
-    $list = new Recurly_CouponRedemptionList(Recurly_Client::PATH_COUPON_REDEMPTION, $client);
-    $list->_loadFrom(Recurly_Client::PATH_COUPON_REDEMPTION, $params);
+    $list = new Recurly_CouponRedemptionList(Recurly_Client::PATH_COUPON_REDEMPTIONS, $client);
+    $list->_loadFrom(Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
     return $list;
   }
 

--- a/lib/recurly/redemption_list.php
+++ b/lib/recurly/redemption_list.php
@@ -1,0 +1,15 @@
+<?php
+
+class Recurly_CouponRedemptionList extends Recurly_Pager
+{
+  public static function get($params = null, $client = null)
+  {
+    $list = new Recurly_CouponRedemptionList(Recurly_Client::PATH_COUPON_REDEMPTION, $client);
+    $list->_loadFrom(Recurly_Client::PATH_COUPON_REDEMPTION, $params);
+    return $list;
+  }
+
+  protected function getNodeName() {
+    return 'redemptions';
+  }
+}


### PR DESCRIPTION
Currently you receive a Recurly_Stub for redemptions when getting the details of a coupon. When calling `->get()` on the redemptions field, this package can't find an appropriate class and fails. This adds in the missing class.