### PR TITLE
add tax_code, tax_exempt to transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `gateway_error_code` to `Transaction` [#163](https://github.com/recurly/recurly-client-php/pull/163)
 * Add support for `refund_apply_order` when performing an open amount or line item refund [#161](https://github.com/recurly/recurly-client-php/pull/161)]
+* Add `tax_exempt`, `tax_code` to `Transaction` [#166](https://github.com/recurly/recurly-client-php/pull/166)
 
 ## Version 2.4.3 (June 4th, 2015)
 

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -8,7 +8,7 @@ class Recurly_Transaction extends Recurly_Resource
   public static function init()
   {
     Recurly_Transaction::$_writeableAttributes = array(
-      'account','amount_in_cents','currency','description','accounting_code'
+      'account','amount_in_cents','currency','description','accounting_code', 'tax_exempt', 'tax_code'
     );
     Recurly_Transaction::$_nestedAttributes = array('account');
   }


### PR DESCRIPTION
cc/ @drewish 

tests:

- the following should create a tax exempt transaction:

```php
$transaction = new Recurly_Transaction();
$transaction->amount_in_cents = 1000; 
$transaction->currency = 'USD';
$transaction->tax_exempt = true;
$transaction->account = new Recurly_Account();
$transaction->account->account_code = '<account_code>';

$transaction->create();

print($transaction->uuid);
```