### PR TITLE
Updating docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The Recurly PHP Client library is an open source library to interact with
 Recurly's subscription management from your PHP website. The library interacts
-with Recurly's [REST API](http://support.recurly.com/faqs/api).
+with Recurly's [REST API](https://dev.recurly.com/docs/getting-started).
 
 **Note:** This version uses Recurly API v2. There are substantial differences
 between this version of the client library and versions before _0.5.0_. Please
@@ -81,7 +81,7 @@ Recurly_Client::$apiKey = '012345678901234567890123456789ab';
 
 ## API Documentation
 
-Please see the [Recurly API](http://docs.recurly.com/api) for more information.
+Please see the [Recurly API](https://dev.recurly.com/docs/getting-started) for more information.
 
 ## Unit tests
 

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Recurly_Client provides methods for interacting with the {@link http://docs.recurly.com/api Recurly} API.
+ * Recurly_Client provides methods for interacting with the {@link https://dev.recurly.com/docs/getting-started Recurly} API.
  *
  * @category   Recurly
  * @package    Recurly_Client_PHP

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -57,7 +57,7 @@ class Recurly_ClientResponse
         // Handled in assertSuccessResponse()
         return;
       case 429:
-        throw new Recurly_ApiRateLimitError('You have made too many API requests in the last 5 minutes. Future API requests may be ignored until your rate limit resets in 5 minutes. Please visit: https://docs.recurly.com/api/basics/rate-limits');
+        throw new Recurly_ApiRateLimitError('You have made too many API requests in the last 5 minutes. Future API requests may be ignored until your rate limit resets in 5 minutes. Please visit: https://dev.recurly.com/docs/rate-limits');
       case 500:
         $message = (is_null($error) ? 'An error occurred while connecting to Recurly' :
                    'An error occurred while connecting to Recurly: ' . $error->description);


### PR DESCRIPTION
Updating all links that referenced the old docs url.

Before: https://docs.recurly.com/api

After: https://dev.recurly.com

cc: @bhelx 