### PR TITLE
Add option for setting CA cert path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `max_redemptions_per_account` to `Coupon`
 * Add `redemptions` to `Subscription`
 * Add support for `coupon_codes` to `Subscription` [#15](https://github.com/recurly/recurly-client-php-internal/pull/15)
+* Added `CACertPath` to `Recurly_Client`
 
 ## Version 2.4.5 (August 3, 2015)
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ Recurly_Client::$subdomain = 'your-subdomain';
 Recurly_Client::$apiKey = '012345678901234567890123456789ab';
 ```
 
+If you are getting certificate verification errors that look like this:
+
+```
+Fatal error: Uncaught exception 'Recurly_ConnectionError' with message 'Could not verify Recurly's SSL certificate.'
+```
+
+Then there is likely a problem with your php or libcurl package and it cannot find your system's root CA certificates.
+Ideally you would want to fix your installation but if you cannot you can override the path manually:
+
+```php
+// Example on my OS X system, the path will be dependent on your system so ask your sysadmin
+Recurly_Client::$CACertPath = '/usr/local/etc/openssl/cert.pem';
+```
+
 ## API Documentation
 
 Please see the [Recurly API](https://dev.recurly.com/docs/getting-started) for more information.

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -30,6 +30,11 @@ class Recurly_Client
   public static $apiVersion = '2.1';
 
   /**
+   * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).
+   */
+  public static $CACertPath = false;
+
+  /**
    * API Key instance, may differ from the static key
    */
   private $_apiKey;
@@ -118,6 +123,9 @@ class Recurly_Client
     curl_setopt($ch, CURLOPT_URL, $uri);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+    if (self::$CACertPath) {
+      curl_setopt($ch, CURLOPT_CAINFO, self::$CACertPath);
+    }
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, FALSE);
     curl_setopt($ch, CURLOPT_MAXREDIRS, 1);
     curl_setopt($ch, CURLOPT_HEADER, TRUE);


### PR DESCRIPTION
This is meant to address https://github.com/recurly/recurly-client-php/issues/173

@drewish and I have discussed and changed this to accept a path rather than a bundle. I'm going to monitor how well this solves the problem and only reconsider the bundle if enough people need it.

@csmb and I will verify that this work in his bad php installation.

Approvers: @csmb @drewish