### PR TITLE
Adding setup_fee_accounting_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Unreleased
+* Added `setup_fee_accounting_code` to `Plan`
+
 ## Version 2.4.5 (August 3, 2015)
 
 * Added `duration`, `temporal_unit`, & `temporal_amount` to `Coupon` [#171](https://github.com/recurly/recurly-client-php/pull/171)

--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -22,6 +22,7 @@ class Recurly_PlanTest extends Recurly_TestCase
     $this->assertEquals(15, $plan->trial_interval_length);
     $this->assertEquals('days', $plan->trial_interval_unit);
     $this->assertEquals(6, $plan->total_billing_cycles);
+    $this->assertEquals("Setup Fee AC", $plan->setup_fee_accounting_code);
 
     $this->assertInstanceOf('Recurly_CurrencyList', $plan->unit_amount_in_cents);
     $this->assertEquals(1000, $plan->unit_amount_in_cents['USD']->amount_in_cents);

--- a/Tests/fixtures/plans/show-200.xml
+++ b/Tests/fixtures/plans/show-200.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <trial_interval_unit>days</trial_interval_unit>
   <total_billing_cycles type="integer">6</total_billing_cycles>
   <accounting_code nil="nil"></accounting_code>
+  <setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>
   <created_at type="datetime">2011-04-19T07:00:00Z</created_at>
   <tax_exempt type="boolean">true</tax_exempt>
   <unit_amount_in_cents>

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -19,7 +19,8 @@ class Recurly_Plan extends Recurly_Resource
       'bypass_hosted_confirmation','unit_name','payment_page_tos_link',
       'plan_interval_length','plan_interval_unit','trial_interval_length',
       'trial_interval_unit','unit_amount_in_cents','setup_fee_in_cents',
-      'total_billing_cycles','accounting_code','tax_exempt','tax_code'
+      'total_billing_cycles','accounting_code','setup_fee_accounting_code',
+      'tax_exempt','tax_code'
     );
     Recurly_Plan::$_nestedAttributes = array(
       'add_ons'


### PR DESCRIPTION
Exposing a `setup_fee_accounting` code to the client library since it's now available. 