### PR TITLE
Support editing and restoring coupons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Recurly PHP Client Library CHANGELOG
 
 * Removed `nestedAttributes` [#191](https://github.com/recurly/recurly-client-php/pull/191)
+* Added support for coupon `update` and `restore` actions [#186](https://github.com/recurly/recurly-client-php/pull/186)
 
 ## Version 2.4.6 (September 15th, 2015)
 

--- a/Tests/fixtures/coupons/update-201.xml
+++ b/Tests/fixtures/coupons/update-201.xml
@@ -1,0 +1,31 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<coupon href="https://api.recurly.com/v2/coupons/special">
+  <redemptions href="https://api.recurly.com/v2/coupons/special/redemptions"/>
+  <coupon_code>special</coupon_code>
+  <name>My New Name</name>
+  <state>redeemable</state>
+  <description>New Description</description>
+  <discount_type>dollars</discount_type>
+  <discount_in_cents>
+    <USD type="integer">1000</USD>
+  </discount_in_cents>
+  <invoice_description>New Invoice Description</invoice_description>
+  <redeem_by_date type="datetime">2020-05-01T08:00:00Z</redeem_by_date>
+  <single_use type="boolean">true</single_use>
+  <applies_for_months type="integer">1</applies_for_months>
+  <max_redemptions type="integer">99</max_redemptions>
+  <applies_to_all_plans type="boolean">true</applies_to_all_plans>
+  <applies_to_non_plan_charges type="boolean">true</applies_to_non_plan_charges>
+  <redemption_resource>account</redemption_resource>
+  <created_at type="datetime">2011-04-30T08:00:00Z</created_at>
+  <duration>forever</duration>
+  <temporal_unit></temporal_unit>
+  <temporal_amount type="integer"></temporal_amount>
+  <max_redemptions_per_account type="integer">3</max_redemptions_per_account>
+  <plan_codes type="array">
+  </plan_codes>
+  <a name="redeem" href="https://api.recurly.com/v2/coupons/special/redeem" method="post"/>
+</coupon>

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -73,12 +73,17 @@ abstract class Recurly_Resource extends Recurly_Base
     return $this;
   }
 
-  protected function _save($method, $uri)
+  protected function _save($method, $uri, $data = null)
   {
     $this->_errors = array(); // reset errors
 
-    $response = $this->_client->request($method, $uri, $this->xml());
+    if (is_null($data)) {
+      $data = $this->xml();
+    }
+
+    $response = $this->_client->request($method, $uri, $data);
     $response->assertValidResponse();
+
     if (isset($response->body)) {
       Recurly_Resource::__parseXmlToUpdateObject($response->body);
     }


### PR DESCRIPTION
Adding support for editing and restoring coupons.

### Testing

* With an active coupon

```php
$coupon = Recurly_Coupon::get('ahhahshs');

$coupon->name = 'new name';
$coupon->max_redemptions = 99;
$coupon->max_redemptions_per_account = 3;
$coupon->redeem_by_date = '2025-09-09';
$coupon->description = 'derp description';
$coupon->invoice_description = 'derp description';

$coupon->update();

print $coupon->name . "\n";
print $coupon->max_redemptions . "\n";
print $coupon->max_redemptions_per_account . "\n";
print $coupon->description . "\n";
print $coupon->invoice_description . "\n";
```

* Do the same thing with an expired coupon but use `$coupon->restore()` instead of `$coupon->update()`

