### PR TITLE
Support bulk coupons and generate codes

### DIFF
--- a/Tests/Recurly/Coupon_Test.php
+++ b/Tests/Recurly/Coupon_Test.php
@@ -145,4 +145,15 @@ class Recurly_CouponTest extends Recurly_TestCase
       $coupon->createUpdateXML()
     );
   }
+
+  public function testGenerate() {
+    $this->client->addResponse('POST', '/coupons/fifteen-off/generate', 'unique_coupons/generate-201.xml');
+    $this->client->addResponse('GET', 'https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20', 'unique_coupons/index-200.xml');
+
+    $coupon = new Recurly_Coupon(null, $this->client);
+    $coupon->coupon_code = 'fifteen-off';
+
+    $coupons = $coupon->generate(10);
+    $this->assertEquals(count($coupons), 10);
+  }
 }

--- a/Tests/fixtures/unique_coupons/generate-201.xml
+++ b/Tests/fixtures/unique_coupons/generate-201.xml
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 2
+Link: <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="start", <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="next"
+Location: https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20

--- a/Tests/fixtures/unique_coupons/index-200.xml
+++ b/Tests/fixtures/unique_coupons/index-200.xml
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 2
+Link: <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="start", <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="next"
+
+<?xml version="1.0" encoding="UTF-8"?>
+<unique_coupon_codes>
+  <coupon href="https://api.recurly.com/v2/coupons/fifteen-off-aaaaaa">
+    <coupon_code>fifteen-off-aaaaaa</coupon_code>
+    <a name="redeem" href="https://api.recurly.com/v2/coupons//fifteen-off-aaaaaa/redeem" method="post"/>
+  </coupon>
+  <coupon href="https://api.recurly.com/v2/coupons/fifteen-off-bbbbbb">
+    <coupon_code>fifteen-off-bbbbbb</coupon_code>
+    <a name="redeem" href="https://api.recurly.com/v2/coupons//fifteen-off-bbbbbb/redeem" method="post"/>
+  </coupon>
+</unique_coupon_codes>

--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -23,6 +23,7 @@ require_once(dirname(__FILE__) . '/recurly/adjustment_list.php');
 require_once(dirname(__FILE__) . '/recurly/billing_info.php');
 require_once(dirname(__FILE__) . '/recurly/coupon.php');
 require_once(dirname(__FILE__) . '/recurly/coupon_list.php');
+require_once(dirname(__FILE__) . '/recurly/unique_coupon_code_list.php');
 require_once(dirname(__FILE__) . '/recurly/invoice.php');
 require_once(dirname(__FILE__) . '/recurly/invoice_list.php');
 require_once(dirname(__FILE__) . '/recurly/note.php');

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -173,6 +173,7 @@ abstract class Recurly_Base
     'adjustment' => 'Recurly_Adjustment',
     'adjustments' => 'Recurly_AdjustmentList',
     'coupon' => 'Recurly_Coupon',
+    'unique_coupon_codes' => 'Recurly_UniqueCouponCodeList',
     'currency' => 'Recurly_Currency',
     'details' => 'array',
     'discount_in_cents' => 'Recurly_CurrencyList',

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -61,6 +61,7 @@ class Recurly_Client
   const PATH_COUPON_REDEMPTION = '/redemption';
   const PATH_COUPON_REDEMPTIONS = '/redemptions';
   const PATH_COUPONS = '/coupons';
+  const PATH_UNIQUE_COUPONS = '/unique_coupon_codes';
   const PATH_INVOICES = '/invoices';
   const PATH_NOTES = '/notes';
   const PATH_PLANS = '/plans';

--- a/lib/recurly/unique_coupon_code_list.php
+++ b/lib/recurly/unique_coupon_code_list.php
@@ -1,0 +1,14 @@
+<?php
+
+class Recurly_UniqueCouponCodeList extends Recurly_Pager
+{
+
+  public static function get($params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_UNIQUE_COUPONS, $params);
+    return new self($uri, $client);
+  }
+
+  protected function getNodeName() {
+    return 'unique_coupon_codes';
+  }
+}


### PR DESCRIPTION
Adds support for creating bulk coupons and also generating coupon codes.

### Testing

* Generate a bulk coupon and make sure there is room to generate some additional test codes
* This should generate 10 codes and return an array of the 10 coupons

```php
$coupon = Recurly_Coupon::get('mybulkcoupon');
$coupon_list = $coupon->generate(10);

foreach ($coupon_list as $coupon) {
   print $coupon->coupon_code . "\n";
}
```

* This code should iterate through all the unique codes assigned to the parent bulk code.

```php
$coupon = Recurly_Coupon::get('mybulkcoupon');
$codes = $coupon->unique_coupon_codes->get();

foreach ($codes as $coup) {
  print $coup->coupon_code . "\n";
}
```