### PR TITLE
Fix Account redemption stub

### DIFF
--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -31,7 +31,7 @@ class Recurly_Account extends Recurly_Resource
   public function &__get($key)
   {
     if ($key == 'redemption' && parent::__isset('redemptions')) {
-      return new Recurly_Stub($redemption, $this->_href . "/redemption", $this->_client);
+      return new Recurly_Stub('redemption', $this->_href . "/redemption", $this->_client);
     } else {
       return parent::__get($key);
     }


### PR DESCRIPTION
This fixes issue https://github.com/recurly/recurly-client-php/issues/187 reported by @matylla.

Need @shulmang to confirm the intent as he is the original author.

### Testing

The code below will throw the error described by @matylla when referencing `$account->redemption`. The fix should correctly build the stub and calling `get()` on the stub should correctly fetch the redemption.

```php
// choose an account with a redemption
$account = Recurly_Account::get('myaccountcode');

print $account->redemption;
print $account->redemption->get();
```