### PR TITLE
Redemptions now point to the correct url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added support for `cc_emails` attribute on the `Account` class [#202](https://github.com/recurly/recurly-client-php/pull/202)
+* Fix bug with incorrect `delete_uri` on the `Redemption` class [#201](https://github.com/recurly/recurly-client-php/pull/201)
 
 ## Version 2.5.0 (January 13th, 2016)
 

--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -15,7 +15,7 @@ class Recurly_CouponRedemption extends Recurly_Resource
   }
 
   public function delete($accountCode = null) {
-    return Recurly_Base::_delete($this->delete_uri($accountCode), $this->_client);
+    return Recurly_Base::_delete($this->uri($accountCode), $this->_client);
   }
 
   protected function uri($accountCode = null) {
@@ -25,10 +25,6 @@ class Recurly_CouponRedemption extends Recurly_Resource
       return Recurly_CouponRedemption::uriForAccount($accountCode);
     else
       return false;
-  }
-
-  protected function delete_uri($accountCode) {
-    return $this->uri($accountCode) . "s/" . $this->uuid;
   }
 
   protected static function uriForAccount($accountCode) {


### PR DESCRIPTION
I believe this may be related to Issue https://github.com/recurly/recurly-client-php/issues/196

The delete_url was looking like this:

`/v2/accounts/<accountcode>/redemptions/33ee88ee7d4124a7f9ca9c488d8d4018s/33ee88ee7d4124a7f9ca9c488d8d4018`

b/c it expected the resource location to still be the singular like so: `/v2/accounts/<accountcode>/redemption`

Using this code to test:

```php
try {
  $account = Recurly_Account::get('test8');
  $r = $account->redemption->get();

  $r->delete($account->account_code);
} catch (Recurly_NotFoundError $e) {
  print "Account not found: $e";
}
```
