### PR TITLE
Add support for cc_emails on Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Unreleased
+
+* Added support for `cc_emails` attribute on the `Account` class [#202](https://github.com/recurly/recurly-client-php/pull/202)
+
 ## Version 2.5.0 (January 13th, 2016)
 
 * Removed `nestedAttributes` [#191](https://github.com/recurly/recurly-client-php/pull/191)

--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -30,6 +30,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $this->assertTrue($account->tax_exempt);
     $this->assertEquals($account->entity_use_code, 'I');
     $this->assertEquals($account->vat_location_valid, true);
+    $this->assertEquals($account->cc_emails, 'cheryl.hines@example.com,richard.lewis@example.com');
   }
 
   public function testCloseAccount() {

--- a/Tests/fixtures/accounts/create-201.xml
+++ b/Tests/fixtures/accounts/create-201.xml
@@ -12,6 +12,7 @@ Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
   <account_code>abcdef1234567890</account_code>
   <username>shmohawk58</username>
   <email>larry.david@example.com</email>
+  <cc_emails>cheryl.hines@example.com,richard.lewis@example.com</cc_emails>
   <first_name>Larry</first_name>
   <last_name>David</last_name>
   <company_name>Home Box Office</company_name>

--- a/Tests/fixtures/accounts/show-200.xml
+++ b/Tests/fixtures/accounts/show-200.xml
@@ -11,6 +11,7 @@ Content-Type: application/xml; charset=utf-8
   <account_code>abcdef1234567890</account_code>
   <username>shmohawk58</username>
   <email>larry.david@example.com</email>
+  <cc_emails>cheryl.hines@example.com,richard.lewis@example.com</cc_emails>
   <first_name>Larry</first_name>
   <last_name>David</last_name>
   <company_name>Home Box Office</company_name>

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -16,7 +16,8 @@ class Recurly_Account extends Recurly_Resource
   {
     Recurly_Account::$_writeableAttributes = array(
       'account_code','username','first_name','last_name','vat_number',
-      'email','company_name','accept_language','billing_info','address','tax_exempt', 'entity_use_code'
+      'email','company_name','accept_language','billing_info','address',
+      'tax_exempt','entity_use_code','cc_emails'
     );
     Recurly_Account::$_requiredAttributes = array(
       'account_code'


### PR DESCRIPTION
Adding support for writing the `cc_emails` attribute on the `Account` class

### Testing

```php
$account = Recurly_Account::get('benjamin');
$account->cc_emails = 'test3@example.com,test4@example.com';
$account->update();

// Refetch the account
$account = Recurly_Account::get('benjamin');
print $account->cc_emails;
```