### PR TITLE
Adding currency attribute to BillingInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for `cc_emails` attribute on the `Account` class [#202](https://github.com/recurly/recurly-client-php/pull/202)
 * Fix bug with incorrect `delete_uri` on the `Redemption` class [#201](https://github.com/recurly/recurly-client-php/pull/201)
+* Added `currency` attribute to `BillingInfo` [#205](https://github.com/recurly/recurly-client-php/pull/205)
 
 ## Version 2.5.0 (January 13th, 2016)
 

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -11,7 +11,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       'address1','address2','city','state','country','zip','phone','vat_number',
       'number','month','year','verification_value','start_year','start_month','issue_number',
       'account_number','routing_number','account_type',
-      'paypal_billing_agreement_id', 'amazon_billing_agreement_id',
+      'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id'
     );
   }


### PR DESCRIPTION
This allows the merchant to send a custom currency on billing info creation and update for verification purposes. For instance, if your site default is USD and you are trying to verify for EUR, you may end up having two verifications.

### Testing

You only need to set the `currency` attribute on the billing info object. You can do this on create or update. Also works if you are using a token instead of the card info.

```php
try {
  $billing_info = new Recurly_BillingInfo();

  $billing_info->account_code = 'other_account';
  $billing_info->first_name = 'Verena';
  $billing_info->last_name = 'Example';
  $billing_info->number = '4111-1111-1111-1111';
  $billing_info->verification_value = '123';
  $billing_info->month = 11;
  $billing_info->year = 2019;
  $billing_info->currency = 'EUR';
  $billing_info->create();

  print "Billing Info: $billing_info";
} catch (Recurly_ValidationError $e) {
  print "Invalid data or card: $e";
} catch (Recurly_NotFoundError $e) {
  print "Not Found: $e";
}
```
