### PR TITLE
only redo initial request if necessary.

### DIFF
--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -34,7 +34,9 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
    * Rewind to the beginning
    */
   public function rewind() {
-    $this->_loadFrom($this->_href);
+    if ( ! isset( $this->_objects ) ) {
+      $this->_loadFrom($this->_href);
+    }
     $this->_position = 0;
   }
 


### PR DESCRIPTION
If there are already cached objects in the resource, then there's no need to redo the api request.
Fixes #212