### PR TITLE
add fraud_session_id to billing_info writeable attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Unreleased
+
+* Added support for `fraud_session_id` attribute on `BillingInfo` class [#214](https://github.com/recurly/recurly-client-php/pull/214)
+
 ## Version 2.5.1 (February 19th, 2016)
 
 * Added support for `cc_emails` attribute on the `Account` class [#202](https://github.com/recurly/recurly-client-php/pull/202)

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -12,7 +12,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       'number','month','year','verification_value','start_year','start_month','issue_number',
       'account_number','routing_number','account_type',
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
-      'token_id'
+      'token_id', 'fraud_session_id'
     );
   }
 


### PR DESCRIPTION
This allows a session_id to be passed with updates to billing_infos in order to take advantage of the forthcoming Kount Data Collector functionality.
