### PR TITLE
Add a note about supporting TLS in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ OpenSSL support. Open up a `phpinfo();` page and verify that under the curl
 section, there's a line that says something like:
 
 ```
-libcurl/7.19.5 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.15
+libcurl/7.19.5 OpenSSL/1.0.1g zlib/1.2.3.3 libidn/1.15
 ```
+
+Please ensure that your OpenSSL version supports TLS v1.1 or higher. At a minimum use v1.0.1g, however we recommend v1.1.0 and up.
 
 ### Timezone
 You will need to specify your server's timezone before using the Recurly PHP client. This is necessary for the library to properly handle datetime conversions. You can do this in your `php.ini` file:


### PR DESCRIPTION
I think it would be helpful for users of this library to know they should utilize an OpenSSL version to one that is using TLS v1.1+ since Recurly will slowly be deprecating any protocols that do not use TLS v1.1.