### PR TITLE
adds way to get multiple coupon redemptions and specific coupon redem…

### DIFF
--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -14,6 +14,14 @@ class Recurly_CouponRedemption extends Recurly_Resource
     return Recurly_Base::_get(Recurly_CouponRedemption::uriForAccount($accountCode), $client);
   }
 
+  public static function getRedemptions($accountCode, $client = null) {
+    return Recurly_Base::_get(Recurly_CouponRedemption::uriForAccountRedemptions($accountCode), $client);
+  }
+
+  public static function getRedemptionByUuid($accountCode, $uuid, $client = null) {
+    return Recurly_Base::_get(Recurly_CouponRedemption::uriForAccountRedemptions($accountCode, $uuid), $client);
+  }
+
   public function delete($accountCode = null) {
     return Recurly_Base::_delete($this->uri($accountCode), $this->_client);
   }
@@ -29,6 +37,14 @@ class Recurly_CouponRedemption extends Recurly_Resource
 
   protected static function uriForAccount($accountCode) {
     return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_COUPON_REDEMPTION;
+  }
+
+  protected static function uriForAccountRedemptions($accountCode, $uuid = null) {
+    if ($uuid == null) {
+      return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_COUPON_REDEMPTIONS;
+    } else {
+      return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_COUPON_REDEMPTIONS . '/' . $uuid;
+    }
   }
 
   protected function getNodeName() {


### PR DESCRIPTION
Description:  Adds another way to get multiple coupon redemptions from an account and a way to get a specific coupon redemption from an account. Allows a specific coupon redemption to be deleted from an account.

To recreate current situation:
* Create an account with multiple coupon redemptions.
```php
$redemption = Recurly_CouponRedemption::get('account_with_multiple_coupon_redemptions');
$redemption->delete();
```

Result: The last coupon redemption on the account is returned by the get method. The last coupon redemption on the account is deleted.

Testing the changes:
* Create an account with multiple coupon redemptions.
* Get all of the redemptions on the account.
* Get a specific redemption using the uuid of the redemption.
* Delete the redemption.
```php
$redemptions = Recurly_CouponRedemption::getRedemptions('account_with_multiple_coupon_redemptions');

$redemption = Recurly_CouponRedemption::getRedemptionByUuid('account_wit_multiple_coupon_redemptions', 'uuid…');
$redemption->delete();
```