### PR TITLE
Allow developer to add curl options to Recurly Client to get around TLS negotiating problem on RHEL 7.1 and less

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -124,7 +124,7 @@ class Recurly_Client
     curl_setopt($ch, CURLOPT_URL, $uri);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-    curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+    curl_setopt($ch, CURLOPT_SSLVERSION, 6);
     if (self::$CACertPath) {
       curl_setopt($ch, CURLOPT_CAINFO, self::$CACertPath);
     }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -35,6 +35,12 @@ class Recurly_Client
   public static $CACertPath = false;
 
   /**
+   * Associtative array of curl options to add or override default curl options. Use only if needed (if you can't fix libcurl/php).
+   * Recurly_Client::$curloptionsArray = array(CURLOPT_SSLVERSION => 6);  //6 - CURL_SSLVERSION_TLSv1_2
+   */
+  public static $curloptionsArray = array();
+
+  /**
    * API Key instance, may differ from the static key
    */
   private $_apiKey;
@@ -124,7 +130,6 @@ class Recurly_Client
     curl_setopt($ch, CURLOPT_URL, $uri);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-    curl_setopt($ch, CURLOPT_SSLVERSION, 6);
     if (self::$CACertPath) {
       curl_setopt($ch, CURLOPT_CAINFO, self::$CACertPath);
     }
@@ -157,7 +162,12 @@ class Recurly_Client
     {
       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
     }
-
+    
+    if(!empty($curloptionsArray))
+    {
+      curl_setopt_array($ch, $curloptionsArray);
+    }
+    
     $response = curl_exec($ch);
 
     if ($response === false)

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -124,6 +124,7 @@ class Recurly_Client
     curl_setopt($ch, CURLOPT_URL, $uri);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+    curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
     if (self::$CACertPath) {
       curl_setopt($ch, CURLOPT_CAINFO, self::$CACertPath);
     }


### PR DESCRIPTION
We should either force curl to run on 
curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1);
or 
curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);

As this will be a requirement June 30, 2016 to work with the Recurly API.
