### PR TITLE
updates Recurly_Coupon for free trial coupons

### DIFF
--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -18,7 +18,8 @@ class Recurly_Coupon extends Recurly_Resource
       'duration', 'temporal_unit', 'temporal_amount',
       'max_redemptions','applies_to_all_plans','discount_percent','discount_in_cents','plan_codes',
       'hosted_description','invoice_description', 'applies_to_non_plan_charges', 'redemption_resource',
-      'max_redemptions_per_account', 'coupon_type', 'unique_code_template', 'unique_coupon_codes'
+      'max_redemptions_per_account', 'coupon_type', 'unique_code_template', 'unique_coupon_codes',
+      'discount_type', 'free_trial_amount', 'free_trial_unit'
     );
     Recurly_Coupon::$_updatableAttributes = array('name', 'max_redemptions',
       'max_redemptions_per_account', 'hosted_description', 'invoice_description', 'redeem_by_date'


### PR DESCRIPTION
Description: Adds attributes for free trial coupons.

Testing the change:
create a free trial coupon by creating a coupon with the following attributes and using "free_trial" for the discount type

```
$coupon->discount_type = 'free_trial';
$coupon->free_trial_amount = 5;
$coupon->free_trial_unit = "month";
```
once the coupon is created, get, update, and delete the coupon

