### PR TITLE
Parse Fraud object when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Recurly PHP Client Library CHANGELOG
 
+* Added support for parsing `fraud` attribute on the `Transaction` class [#228](https://github.com/recurly/recurly-client-php/pull/228)
+
 ## Version 2.5.1 (February 19th, 2016)
 
 * Added support for `cc_emails` attribute on the `Account` class [#202](https://github.com/recurly/recurly-client-php/pull/202)

--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -20,6 +20,10 @@ class Recurly_TransactionTest extends Recurly_TestCase
 
     $this->assertEquals($transaction->account->getHref(), 'https://api.recurly.com/v2/accounts/verena');
     $this->assertEquals($transaction->ip_address, '127.0.0.1');
+
+    $this->assertInstanceOf('Recurly_FraudInfo', $transaction->fraud);
+    $this->assertEquals($transaction->fraud->score, 99);
+    $this->assertEquals($transaction->fraud->decision, 'DECLINE');
   }
 
   public function testCreateTransactionFailed() {

--- a/Tests/fixtures/transactions/show-200.xml
+++ b/Tests/fixtures/transactions/show-200.xml
@@ -51,4 +51,8 @@ Content-Type: application/xml; charset=utf-8
       </billing_info>
     </account>
   </details>
+  <fraud>
+    <score type="integer">99</score>
+    <decision>DECLINE</decision>
+  </fraud>
 </transaction>

--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/recurly/currency.php');
 require_once(dirname(__FILE__) . '/recurly/currency_list.php');
 require_once(dirname(__FILE__) . '/recurly/error_list.php');
 require_once(dirname(__FILE__) . '/recurly/errors.php');
+require_once(dirname(__FILE__) . '/recurly/fraud_info.php');
 require_once(dirname(__FILE__) . '/recurly/link.php');
 require_once(dirname(__FILE__) . '/recurly/pager.php');
 require_once(dirname(__FILE__) . '/recurly/response.php');

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -179,6 +179,7 @@ abstract class Recurly_Base
     'discount_in_cents' => 'Recurly_CurrencyList',
     'error' => 'Recurly_FieldError',
     'errors' => 'Recurly_ErrorList',
+    'fraud' => 'Recurly_FraudInfo',
     'invoice' => 'Recurly_Invoice',
     'invoices' => 'Recurly_InvoiceList',
     'line_items' => 'array',

--- a/lib/recurly/currency.php
+++ b/lib/recurly/currency.php
@@ -7,7 +7,7 @@ class Recurly_Currency
 {
   var $currencyCode;
   var $amount_in_cents;
-  
+
   function __construct($currencyCode, $amountInCents) {
     $this->currencyCode = $currencyCode;
     $this->amount_in_cents = $amountInCents;

--- a/lib/recurly/fraud_info.php
+++ b/lib/recurly/fraud_info.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Represents the <fraud> object in a transaction
+ */
+class Recurly_FraudInfo
+{
+  var $score;
+  var $decision;
+
+  public function __toString() {
+    return "<Recurly_FraudInfo score=\"{$this->score}\" decision={$this->decision}>";
+  }
+}


### PR DESCRIPTION
If it's available, the transaction may contain a fraud object with some fraud information.

Ruby PR: recurly/recurly-client-ruby#244
