### PR TITLE
Bugfix: Unexpected Link to HTTP leads to unhandled redirect.

### DIFF
--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -26,9 +26,9 @@ class Recurly_PagerTest extends Recurly_TestCase
   function defaultResponses() {
     return array(
       array('GET', '/mocks', 'pager/index-1-200.xml'),
-      array('GET', 'http://example.com/mocks?cursor=1', 'pager/index-1-200.xml'),
-      array('GET', 'http://example.com/mocks?cursor=2', 'pager/index-2-200.xml'),
-      array('GET', 'http://example.com/mocks?cursor=3', 'pager/index-3-200.xml'),
+      array('GET', 'https://example.com/mocks?cursor=1', 'pager/index-1-200.xml'),
+      array('GET', 'https://example.com/mocks?cursor=2', 'pager/index-2-200.xml'),
+      array('GET', 'https://example.com/mocks?cursor=3', 'pager/index-3-200.xml'),
     );
   }
 

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -123,6 +123,7 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {
+          $matches[1][$i] = str_replace('http://', 'https://', $matches[1][$i]);
           $this->_links[$matches[2][$i]] = $matches[1][$i];
         }
       }

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -34,7 +34,7 @@ class Recurly_ClientResponse
   public function assertValidResponse()
   {
     // Successful response code
-    if ($this->statusCode >= 200 && $this->statusCode < 400)
+    if ($this->statusCode >= 200 && $this->statusCode < 300)
       return;
 
     // Do not fail here if the response is not valid XML
@@ -43,6 +43,9 @@ class Recurly_ClientResponse
     switch ($this->statusCode) {
       case 0:
         throw new Recurly_ConnectionError('An error occurred while connecting to Recurly.');
+      case 301:
+      case 302:
+        throw new Recurly_Error('Unexpected redirection to ' . $this->headers['Location'] . ', we where expecting a response.');
       case 400:
         $message = (is_null($error) ? 'Bad API Request' : $error->description);
         throw new Recurly_Error($message);


### PR DESCRIPTION
I don't know what caused this, but this night I suddenly got infinite recursions in `\Recurly_SubscriptionList::get()` due to the cursor related code.

The first response returns a link pointing to `http://`:

```
["Link"]=>
  string(80) "<http://api.recurly.com/v2/subscriptions?cursor=1234567>; rel="next""
```

The `pager.php` then tries to load this link when iterating the items, leading to a HTML based 301 Moved permanently response. But since `client.php` has followdirects disabled it passes this HTML to the xml decoder.

The XML decoder fails with a PHP notice, but swallows that one without throwing an exception. Iterating this broken pager then leads to an infinite recursion or some other kind of blocking (couldn't find out where).

This pull request fixes the problem on two levels:

1. Convert http links to https before paginating them. But really Recurly API should return https Links themselves.
2. Throw an exception when a 301/302 response is returned, because we know we don't follow redirects, this is actually an invalid response in the sense of `$response->assertIsValid()` => No we didn't expect it!

Another additional fix is in recurly/base.php `__parseXmlToUpdateObject` should throw an exception if the XML is invalid instead of just swallowing the PHP notice and doing nothing. This requires some more thorough testing though if this doesn't lead to other problems, especially the `empty($xml) ||` check here looked of to me, so I didn't want to change the code.