### PR TITLE
Use PHPUnit configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can run our unit tests by using Composer to install PHPUnit:
 ```
 $ curl -s https://getcomposer.org/installer | php
 $ php composer.phar install --dev
-$ vendor/phpunit/phpunit/phpunit Tests/
+$ vendor/bin/phpunit
 ```
 
 ## Support

--- a/Tests/Recurly/Account_List_Test.php
+++ b/Tests/Recurly/Account_List_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_AccountListTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_AccountTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Addon_Test.php
+++ b/Tests/Recurly/Addon_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_AddonTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Adjustment_Test.php
+++ b/Tests/Recurly/Adjustment_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_AdjustmentTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_BaseTest extends Recurly_TestCase {
 

--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_BillingInfoTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Client_Test.php
+++ b/Tests/Recurly/Client_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_ClientTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Coupon_Redemption_Test.php
+++ b/Tests/Recurly/Coupon_Redemption_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_CouponRedemptionTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Coupon_Test.php
+++ b/Tests/Recurly/Coupon_Test.php
@@ -1,5 +1,4 @@
 <?php
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_CouponTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Currency_List_Test.php
+++ b/Tests/Recurly/Currency_List_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_CurrecyListTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Invoice_List_Test.php
+++ b/Tests/Recurly/Invoice_List_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_InvoiceListTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_InvoiceTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/MeasuredUnit_List_Test.php
+++ b/Tests/Recurly/MeasuredUnit_List_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_MeasuredUnitListTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/MeasuredUnit_Test.php
+++ b/Tests/Recurly/MeasuredUnit_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_MeasuredUnitTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Note_List_Test.php
+++ b/Tests/Recurly/Note_List_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_NoteListTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Mock_Pager extends Recurly_Pager {
   protected function getNodeName() {

--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_PlanTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Resource_Test.php
+++ b/Tests/Recurly/Resource_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Mock_Resource extends Recurly_Resource {
   protected function getNodeName() {

--- a/Tests/Recurly/Subscription_List_Test.php
+++ b/Tests/Recurly/Subscription_List_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_SubscriptionListTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_SubscriptionTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Transaction_List_Test.php
+++ b/Tests/Recurly/Transaction_List_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_TransactionListTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_TransactionTest extends Recurly_TestCase
 {

--- a/Tests/Recurly/Usage_Test.php
+++ b/Tests/Recurly/Usage_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../test_helpers.php');
 
 class Recurly_UsageTest extends Recurly_TestCase
 {

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(__DIR__ . '/../vendor/autoload.php');
 
 error_reporting(E_ALL);
 ini_set('display_errors','On');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
+         backupGlobals="true"
+         backupStaticAttributes="false"
+         bootstrap="Tests/bootstrap.php"
+         cacheTokens="false"
+         colors="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         mapTestClassNameToCoveredClassName="false"
+         printerClass="PHPUnit_TextUI_ResultPrinter"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         stopOnRisky="false"
+         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+         timeoutForSmallTests="1"
+         timeoutForMediumTests="10"
+         timeoutForLargeTests="60"
+         verbose="false">
+
+    <testsuites>
+        <testsuite name="My Test Suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>


### PR DESCRIPTION
Standard practice, when I move in to work on a project that I can see uses PHPUnit from the `composer install` output, I expect to be able to run `vendor/bin/phpunit` from the root of the project and the default test suite to be executed. Given I was creating the PHPUnit configuration, I leveraged it to avoid having to manually require the support code.