### PR TITLE
Return correct node name for Recurly_NoteList

### DIFF
--- a/Tests/fixtures/notes/index-200.xml
+++ b/Tests/fixtures/notes/index-200.xml
@@ -4,14 +4,14 @@ X-Records: 2
 Link: <https://api.recurly.com/v2/accounts/abcdef1234567890/notes?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts/abcdef1234567890/notes?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>
-<notes>
+<notes type="array">
   <note>
-    <account href="api.recurly.com/v2/accounts/abcdef1234567890"/>
+    <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
     <message>this account needs an account manager</message>
     <created_at type="datetime">2013-03-12T18:35:00Z</created_at>
   </note>
   <note>
-    <account href="api.recurly.com/v2/accounts/abcdef1234567890"/>
+    <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
     <message>Some message</message>
     <created_at type="datetime">2012-04-30T12:35:00Z</created_at>
   </note>

--- a/lib/recurly/note_list.php
+++ b/lib/recurly/note_list.php
@@ -11,6 +11,6 @@ class Recurly_NoteList extends Recurly_Pager
   }
 
   protected function getNodeName() {
-    return 'note';
+    return 'notes';
   }
 }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -49,10 +49,13 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
       return null;
     }
 
-    while ($this->_position >= sizeof($this->_objects)) {
+    if ($this->_position >= sizeof($this->_objects)) {
       if (isset($this->_links['next'])) {
         $this->_loadFrom($this->_links['next']);
         $this->_position = 0;
+      }
+      else {
+        throw new Recurly_Error("Pager is not in a valid state");
       }
     }
 


### PR DESCRIPTION
Notes weren't loaded after rewind() was called. The name didn't match what
was in the XML so __parseXmlToObject() was never called and hence the object
were never added to $this->_objects.

While I'm here I fixed a bug in the pager where it'd keep checking for a
next link so it could reload... that wasn't ever going to happen so it's
better to give a hard error.

Test this by trying to run the [notes sample code in our docs](https://dev.recurly.com/docs/list-account-notes):
```php
try {
  $notes = Recurly_NoteList::get('b6f5783');
  foreach ($notes as $note) {
    print "Note: {$note->message}\n";
  }
} catch (Recurly_NotFoundError $e) {
  print "Invalid account code: $e";
}
```