### PR TITLE
Provide default getWriteableAttributes()

### DIFF
--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -16,7 +16,6 @@ Recurly_Resource::$class_map['mocks'] = 'Mock_Pager';
 class Mock_Item extends Recurly_Resource {
   protected function getNodeName()            { return 'mock'; }
   protected function getWriteableAttributes() { return array(); }
-  protected function getRequiredAttributes()  { return array(); }
 }
 Recurly_Resource::$class_map['mock'] = 'Mock_Item';
 

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -51,9 +51,6 @@ class Recurly_Addon extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Addon::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_Addon::init();

--- a/lib/recurly/address.php
+++ b/lib/recurly/address.php
@@ -19,10 +19,6 @@ class Recurly_Address extends Recurly_Resource {
   protected function getWriteableAttributes() {
     return Recurly_Address::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
-
 }
 
 Recurly_Address::init();

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -69,9 +69,6 @@ class Recurly_Adjustment extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Adjustment::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_Adjustment::init();

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -52,9 +52,6 @@ class Recurly_BillingInfo extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_BillingInfo::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_BillingInfo::init();

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -123,9 +123,6 @@ class Recurly_Coupon extends Recurly_Resource
   protected function getUpdatableAttributes() {
     return Recurly_Coupon::$_updatableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_Coupon::init();

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -123,9 +123,6 @@ class Recurly_Invoice extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Invoice::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
   protected function uri() {
     $invoiceNumberWithPrefix = $this->invoiceNumberWithPrefix();
     if (!empty($this->_href))

--- a/lib/recurly/measured_unit.php
+++ b/lib/recurly/measured_unit.php
@@ -35,9 +35,6 @@ class Recurly_MeasuredUnit extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_MeasuredUnit::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_MeasuredUnit::init();

--- a/lib/recurly/note.php
+++ b/lib/recurly/note.php
@@ -9,8 +9,4 @@ class Recurly_Note extends Recurly_Resource
   protected function getWriteableAttributes() {
    return array();
   }
-  
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -57,9 +57,6 @@ class Recurly_Plan extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Plan::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_Plan::init();

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -8,7 +8,10 @@ abstract class Recurly_Resource extends Recurly_Base
 
   abstract protected function getNodeName();
   abstract protected function getWriteableAttributes();
-  abstract protected function getRequiredAttributes();
+  protected function getRequiredAttributes()
+  {
+    return array();
+  }
 
   public function __construct($href = null, $client = null)
   {

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -134,9 +134,6 @@ class Recurly_Subscription extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Subscription::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_Subscription::init();

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -22,9 +22,6 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
   protected function getWriteableAttributes() {
     return Recurly_SubscriptionAddOn::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 
   protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {
     $addonNode = $node->appendChild($doc->createElement($this->getNodeName()));

--- a/lib/recurly/tax_detail.php
+++ b/lib/recurly/tax_detail.php
@@ -7,7 +7,4 @@ class Recurly_Tax_Detail extends Recurly_Resource {
   protected function getWriteableAttributes() {
     return array();
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -56,9 +56,6 @@ class Recurly_Transaction extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Transaction::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_Transaction::init();

--- a/lib/recurly/usage.php
+++ b/lib/recurly/usage.php
@@ -52,9 +52,6 @@ class Recurly_Usage extends Recurly_Resource
   protected function getWriteableAttributes() {
     return Recurly_Usage::$_writeableAttributes;
   }
-  protected function getRequiredAttributes() {
-    return array();
-  }
 }
 
 Recurly_Usage::init();


### PR DESCRIPTION
Follow up to https://github.com/recurly/recurly-client-php/pull/227/files#r65484206

Let's cut down on some of the boilerplate code in every class by providing a default implementation. We could probably just remove the function entirely but I'll leave that for another PR.