### PR TITLE
Fix subscription updates when subcription has add_ons

### DIFF
--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -194,6 +194,18 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     }
   }
 
+  public function testUpdateSubscriptionWithAddOns() {
+    $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200.xml');
+    $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
+
+    $subscription->quantity = 2;
+
+    $this->assertEquals(
+      "<?xml version=\"1.0\"?>\n<subscription><quantity>2</quantity><subscription_add_ons><subscription_add_on><add_on_code>marketing_emails</add_on_code><unit_amount_in_cents>5</unit_amount_in_cents><quantity>1</quantity></subscription_add_on></subscription_add_ons></subscription>\n",
+      $subscription->xml()
+    );
+  }
+
   public function testGetSubscriptionRedemptions() {
     $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200.xml');
     $this->client->addResponse('GET', 'https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/redemptions', 'subscriptions/redemptions-200.xml');

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -32,8 +32,15 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
   }
 
   protected function getChangedAttributes($nested = false) {
-    // Ignore the name, it can't be changed.
-    return array_diff_key($this->_values, array('name' => 0));
+    // Ignore attributes that can't be updated
+    $immutable = array(
+      'name' => 0,
+      'add_on_type' => 0,
+      'usage_type' => 0,
+      'usage' => 0,
+      'measured_unit' => 0,
+    );
+    return array_diff_key($this->_values, $immutable);
   }
 
   /**


### PR DESCRIPTION
Addresses https://github.com/recurly/recurly-client-php/issues/240
Reported By: @ScottSpittle 

We are seeing an issue with updating subscriptions containing add ons. Using the `updateImmediately` method was generating some xml which was trying to update immutable fields for the subscription add ons on the backend. The update payload was looking something like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<subscription>
   <quantity>2</quantity>
   <timeframe>now</timeframe>
   <subscription_add_ons>
      <subscription_add_on>
         <add_on_code>marketing_emails</add_on_code>
         <add_on_type>fixed</add_on_type>
         <quantity>1</quantity>
         <unit_amount_in_cents>5</unit_amount_in_cents>
      </subscription_add_on>
   </subscription_add_ons>
</subscription>
```

And the resulting error:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<error>
  <symbol>invalid_xml</symbol>
  <description>The provided XML was invalid.</description>
  <details>Unacceptable tag &lt;add_on_type&gt;</details>
</error>
```

I added some code to ignore the immutable fields on update but I think this is a larger problem around changes to arrays not being tracked. We shouldn't be rendering the subscription add ons unless they have changed.

So while this should be a fine solution to this problem, I think a follow up should be made to investigate how we handle tracking of changes on arrays of objects.