### PR TITLE
Coupon lists require a parent object

### DIFF
--- a/lib/recurly/redemption_list.php
+++ b/lib/recurly/redemption_list.php
@@ -2,8 +2,18 @@
 
 class Recurly_CouponRedemptionList extends Recurly_Pager
 {
-  public static function get($params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
+  public static function getForAccount($accountCode, $params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
+    return new self($uri, $client);
+  }
+
+  public static function getForInvoice($invoiceNumber, $params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_INVOICES . '/' . rawurlencode($invoiceNumber) . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
+    return new self($uri, $client);
+  }
+
+  public static function getForSubscription($subscriptionUuid, $params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_SUBSCRIPTIONS . '/' . rawurlencode($subscriptionUuid) . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/unique_coupon_code_list.php
+++ b/lib/recurly/unique_coupon_code_list.php
@@ -3,8 +3,8 @@
 class Recurly_UniqueCouponCodeList extends Recurly_Pager
 {
 
-  public static function get($params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_UNIQUE_COUPONS, $params);
+  public static function get($couponCode, $params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_COUPONS . '/' . rawurlencode($couponCode) . Recurly_Client::PATH_UNIQUE_COUPONS, $params);
     return new self($uri, $client);
   }
 


### PR DESCRIPTION
The coupon listings all require a parent object. Both of these functions that are being removed generate calls to invalid paths and result in 404s:
```php
Recurly_CouponRedemptionList::get()->count();
Recurly_UniqueCouponCodeList::get()->count();
```

In comparison these will return data:
```php
$accountCode = Recurly_AccountList::get()->current()->account_code;
$invoiceNumber = Recurly_InvoiceList::get()->current()->invoice_number;
$subscriptionUuid = Recurly_SubscriptionList::get()->current()->uuid;
Recurly_CouponRedemptionList::getForAccount($accountCode, $options)->count();
Recurly_CouponRedemptionList::getForInvoice($invoiceNumber, $options)->count();
Recurly_CouponRedemptionList::getForSubscription($subscriptionUuid, $options)->count();

Recurly_UniqueCouponCodeList::get($subscriptionCouponCode, $options);
```