### PR TITLE
Add support for new pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 * Added support for `original_transaction` to `Recurly_Transaction` [#238](https://github.com/recurly/recurly-client-php/pull/238)
 * Added `Recurly_AccountBalance` [#239](https://github.com/recurly/recurly-client-php/pull/239)
-* Print warnings when using a deprecated version of the API.
+* Print warnings when using a deprecated version of the API. [#250](https://github.com/recurly/recurly-client-php/pull/250):
+* Added support new pagination options [#249](https://github.com/recurly/recurly-client-php/pull/249):
+  - `sort` accepts `created_at` or `updated_at`, defaults to `created_at`.
+  - `order` accepts `desc` or `asc`, defaults to `desc`.
+  - `begin_time` and `end_time` accepts an ISO 8601 date or date and time.
+* Changed `Recurly_AddonList::get()` and `Recurly_NoteList::get()` to add `$params` as the second parameter so sort, order and date filtering can be passed in [#249](https://github.com/recurly/recurly-client-php/pull/249)
 
 ## Version 2.5.3 (July 5th, 2016)
 

--- a/Tests/Recurly/Note_List_Test.php
+++ b/Tests/Recurly/Note_List_Test.php
@@ -4,9 +4,9 @@
 class Recurly_NoteListTest extends Recurly_TestCase
 {
   public function testGetNotes() {
-    $this->client->addResponse('GET', '/accounts/abcdef1234567890/notes', 'notes/index-200.xml');
+    $this->client->addResponse('GET', '/accounts/abcdef1234567890/notes?', 'notes/index-200.xml');
 
-    $notes = Recurly_NoteList::get('abcdef1234567890', $this->client);
+    $notes = Recurly_NoteList::get('abcdef1234567890', array(), $this->client);
     $this->assertInstanceOf('Recurly_NoteList', $notes);
     $this->assertEquals($notes->count(), 2);
 

--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -6,8 +6,9 @@ class Mock_Pager extends Recurly_Pager {
     return 'mocks';
   }
 
-  public function _loadFrom($uri, $params = null) {
-    parent::_loadFrom($uri, $params);
+  // Overridden to make it public.
+  public function _loadFrom($uri) {
+    parent::_loadFrom($uri);
   }
 }
 Recurly_Resource::$class_map['mocks'] = 'Mock_Pager';

--- a/lib/recurly/addon_list.php
+++ b/lib/recurly/addon_list.php
@@ -2,9 +2,9 @@
 
 class Recurly_AddonList extends Recurly_Pager
 {
-  public static function get($planCode, $client = null)
+  public static function get($planCode, $params = null, $client = null)
   {
-    $uri = Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) . Recurly_Client::PATH_ADDONS;
+    $uri = self::_uriWithParams(Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) . Recurly_Client::PATH_ADDONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/note_list.php
+++ b/lib/recurly/note_list.php
@@ -2,12 +2,9 @@
 
 class Recurly_NoteList extends Recurly_Pager
 {
-  public static function get($accountCode, $client = null) {
-    return Recurly_Base::_get(Recurly_NoteList::uriForNotes($accountCode), $client);
-  }
-
-  protected static function uriForNotes($accountCode) {
-    return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_NOTES;
+  public static function get($accountCode, $params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_NOTES, $params);
+    return new self($uri, $client);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -86,12 +86,11 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   /**
    * Load another page of results into this pager.
    */
-  protected function _loadFrom($uri, $params = null) {
+  protected function _loadFrom($uri) {
     if (empty($uri)) {
       return;
     }
 
-    $uri = Recurly_Base::_uriWithParams($uri, $params);
     $response = $this->_client->request(Recurly_Client::GET, $uri);
     $response->assertValidResponse();
 

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -100,9 +100,9 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   }
 
   protected function _afterParseResponse($response, $uri) {
-    $this->_href = $uri;
     $this->_loadRecordCount($response);
     $this->_loadLinks($response);
+    $this->_href = isset($this->_links['start']) ? $this->_links['start'] : $uri;
   }
 
   protected static function _setState($params, $state) {


### PR DESCRIPTION
Here's the testing code I was using to check this out
```php
function fetchIt($list) {
  $initialCount = $list->count();
  print "\thas {$initialCount} rows\n";
  // print "links:\n"; var_dump($list->getLinks());
  // print "href:\n"; var_dump($list->getHref());
  $first = $list->current()->getHref();
  print "\tfirst is {$first}\n";

  $count = 0;
  foreach ($list as $item) {
    ++$count;
  }
  assert($initialCount == $count);

  $list->rewind();

  print "\tfirst is {$list->current()->getHref()}\n\n";
  assert($first == $list->current()->getHref());
}

$accountCode = 'd4a354bb326f3b7386ad351d7c0750';
$planCode = 'perferendis_in8';

$options = array('per_page' => 200, 'sort' => 'updated_at', 'order' => 'asc', 'begin_time' => '2016-01-01');

fetchIt(Recurly_AccountList::get($options));

fetchIt(Recurly_AdjustmentList::get($accountCode, $options));

fetchIt(Recurly_CouponList::get($options));

fetchIt(Recurly_InvoiceList::get($options));
fetchIt(Recurly_InvoiceList::getForAccount($accountCode, $options));

fetchIt(Recurly_NoteList::get($accountCode));//, $options));

fetchIt(Recurly_PlanList::get($options));

fetchIt(Recurly_AddonList::get($planCode, $options));

fetchIt(Recurly_CouponRedemptionList::getForAccount($accountCode, $options));
fetchIt(Recurly_CouponRedemptionList::getForInvoice('10343', $options));
fetchIt(Recurly_CouponRedemptionList::getForSubscription('2d0c6ac7430b27b0780dd34a03b1607d', $options));

fetchIt(Recurly_SubscriptionList::get($options));
fetchIt(Recurly_SubscriptionList::getForAccount($accountCode, $options));

fetchIt(Recurly_TransactionList::get($options));
fetchIt(Recurly_TransactionList::getForAccount($accountCode, $options));

fetchIt(Recurly_UniqueCouponCodeList::get('for_subs', $options));
```