### PR TITLE
Warn on API deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for `original_transaction` to `Recurly_Transaction` [#238](https://github.com/recurly/recurly-client-php/pull/238)
 * Added `Recurly_AccountBalance` [#239](https://github.com/recurly/recurly-client-php/pull/239)
+* Print warnings when using a deprecated version of the API.
 
 ## Version 2.5.3 (July 5th, 2016)
 

--- a/Tests/Recurly/Client_Test.php
+++ b/Tests/Recurly/Client_Test.php
@@ -4,6 +4,13 @@
 class Recurly_ClientTest extends Recurly_TestCase
 {
 
+  public function testDeprecationError() {
+    $this->client->addResponse('GET', '/accounts', 'client/deprecated-200.xml');
+
+    // This should print an error but not raise.
+    $accounts = Recurly_AccountList::get(null, $this->client)->count();
+  }
+
   public function testUnauthorizedError() {
     $this->client->addResponse('GET', '/accounts/abcdef1234567890', 'client/unauthorized-401.xml');
 

--- a/Tests/fixtures/client/deprecated-200.xml
+++ b/Tests/fixtures/client/deprecated-200.xml
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+X-Api-Version: 1.999
+Recurly-Deprecated: true
+Recurly-Sunset-Date: 2014-01-01T00:00:00+00:00
+Content-Language: en-US
+X-RateLimit-Limit: 2000
+X-RateLimit-Remaining: 1998
+X-RateLimit-Reset: 1467912540
+X-Records: 3
+Link: <https://api.recurly.com/v2/accounts?order=asc&per_page=1>; rel="start", <https://api.recurly.com/v2/accounts?cursor=-1963376195782139893&order=asc&per_page=1>; rel="prev"
+ETag: "d41d8cd98f00b204e9800998ecf8427e"
+Content-Type: application/xml; charset=utf-8
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 6a8c07775f9dac83402cea1a28752a55
+X-Runtime: 0.048038
+Connection: close
+Transfer-Encoding: chunked
+
+<?xml version="1.0" encoding="UTF-8"?>
+<accounts type="array">
+</accounts>

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -33,6 +33,10 @@ class Recurly_ClientResponse
 
   public function assertValidResponse()
   {
+    if (!empty($this->headers['Recurly-Deprecated'])) {
+      error_log("WARNING: API version {$this->headers['X-Api-Version']} is deprecated and will only be available until {$this->headers['Recurly-Sunset-Date']}. Please upgrade the Recurly PHP client.");
+    }
+
     // Successful response code
     if ($this->statusCode >= 200 && $this->statusCode < 400)
       return;


### PR DESCRIPTION
This will start printing warning messages when a deprecated API version is detected. Ideally we'd be doing something like `trigger_error($message, E_USER_DEPRECATED)` but I'm worried people might not have `error_reporting()` set to a compatible level to avoid it being treated as a fatal error.