### PR TITLE
Use semi-colon for delimiter

### DIFF
--- a/lib/recurly/errors.php
+++ b/lib/recurly/errors.php
@@ -43,7 +43,7 @@ class Recurly_ValidationError extends Recurly_Error
       else
         $errs[] = strval($err);
     }
-    $message = ucfirst(implode($errs, ', '));
+    $message = ucfirst(implode($errs, '; '));
     if (substr($message, -1) != '.')
       $message .= '.';
     parent::__construct($message);


### PR DESCRIPTION
Here are 3 errors returned from Recurly servers. Notice the first has commas. Using comma as a delimiter breaks parsing of that message.
- This account is already subscribed to this plan. To avoid accidental duplicate subscriptions, a short delay is required between subscriptions. If you are sure you want to subscribe this account to the same plan more than once, please wait 60 seconds before subscribing again.
- Coupon code is invalid.
- Your transaction was declined. Please use a different card or contact your bank.
