### PR TITLE
Add revenue_schedule_type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `order` accepts `desc` or `asc`, defaults to `desc`.
   - `begin_time` and `end_time` accepts an ISO 8601 date or date and time.
 * Changed `Recurly_AddonList::get()` and `Recurly_NoteList::get()` to add `$params` as the second parameter so sort, order and date filtering can be passed in [#249](https://github.com/recurly/recurly-client-php/pull/249)
+* Added support for `revenue_schedule_type` to `Recurly_Addon`, `Recurly_Adjustment`, `Recurly_Plan`, `Recurly_Subscription` and `Recurly_SubscriptionAddOn` classes [#257](https://github.com/recurly/recurly-client-php/pull/257)
 
 ## Version 2.5.3 (July 5th, 2016)
 

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -14,7 +14,7 @@ class Recurly_Addon extends Recurly_Resource
     Recurly_Addon::$_writeableAttributes = array(
       'add_on_code','name','display_quantity','default_quantity',
       'unit_amount_in_cents','accounting_code','tax_code',
-      'measured_unit_id','usage_type','add_on_type'
+      'measured_unit_id','usage_type','add_on_type','revenue_schedule_type'
     );
   }
 

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -8,7 +8,8 @@ class Recurly_Adjustment extends Recurly_Resource
   {
     Recurly_Adjustment::$_writeableAttributes = array(
       'currency','unit_amount_in_cents','quantity','description',
-      'accounting_code','tax_exempt','tax_code','start_date','end_date'
+      'accounting_code','tax_exempt','tax_code','start_date','end_date',
+      'revenue_schedule_type',
     );
   }
 

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -19,6 +19,7 @@ class Recurly_Plan extends Recurly_Resource
       'plan_interval_length','plan_interval_unit','trial_interval_length',
       'trial_interval_unit','unit_amount_in_cents','setup_fee_in_cents',
       'total_billing_cycles','accounting_code','setup_fee_accounting_code',
+      'revenue_schedule_type', 'setup_fee_revenue_schedule_type',
       'tax_exempt','tax_code'
     );
   }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -11,7 +11,7 @@ class Recurly_Subscription extends Recurly_Resource
       'currency','starts_at','trial_ends_at','total_billing_cycles', 'first_renewal_date',
       'timeframe', 'subscription_add_ons', 'net_terms', 'po_number', 'collection_method',
       'cost_in_cents', 'remaining_billing_cycles', 'bulk', 'terms_and_conditions', 'customer_notes',
-      'vat_reverse_charge_notes', 'bank_account_authorized_at'
+      'vat_reverse_charge_notes', 'bank_account_authorized_at', 'revenue_schedule_type',
     );
   }
 

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -11,7 +11,8 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
       'unit_amount_in_cents',
       'add_on_type',
       'usage_type',
-      'usage_percentage'
+      'usage_percentage',
+      'revenue_schedule_type',
     );
   }
 


### PR DESCRIPTION
```php
// Set the schedule types on a plan
$plan = Recurly_Plan::get('gold');
$plan->revenue_schedule_type = 'at_range_end';
$plan->setup_fee_revenue_schedule_type = 'at_range_start';
$plan->update();
```

```php
// Set the schedule type on an add-on
$add_on = Recurly_Addon::get('gold', 'ipaddresses');
$add_on->revenue_schedule_type = 'never';
$add_on->update();
```

```php
// Set the schedule type on a new adjustment
$charge = new Recurly_Adjustment();
$charge->account_code = '1';
$charge->description = 'Charge for extra bandwidth';
$charge->unit_amount_in_cents = 5000;
$charge->currency = 'USD';
$charge->revenue_schedule_type = 'at_range_start';
$charge->create();
```

```php
// Set the schedule on an subscription and add-on
$subscription = new Recurly_Subscription();
$subscription->plan_code = 'gold';
$subscription->currency = 'USD';
// Override the plan's value:
$subscription->revenue_schedule_type = 'at_range_end';
$addon = new Recurly_SubscriptionAddOn();
$addon->add_on_code = 'ipaddresses';
$addon->quantity = 3;
$addon->unit_amount_in_cents = 100;
// Override the add-on's value:
$addon->revenue_schedule_type = 'evenly';
$subscription->subscription_add_ons = array($addon);
$account = new Recurly_Account();
$account->account_code = '1';
$subscription->account = $account;
$subscription->create();
```