### PR TITLE
Allow adjustments to specify an origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.7.0 (unreleased)
+
+
+
 ## Version 2.6.0 (unreleased)
 
 * Added support for `original_transaction` to `Recurly_Transaction` [#238](https://github.com/recurly/recurly-client-php/pull/238)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@
 
 * Added support for `original_transaction` to `Recurly_Transaction` [#238](https://github.com/recurly/recurly-client-php/pull/238)
 * Added `Recurly_AccountBalance` [#239](https://github.com/recurly/recurly-client-php/pull/239)
-* Print warnings when using a deprecated version of the API.
+* Print warnings when using a deprecated version of the API. [#250](https://github.com/recurly/recurly-client-php/pull/250):
+* Added support new pagination options [#249](https://github.com/recurly/recurly-client-php/pull/249):
+  - `sort` accepts `created_at` or `updated_at`, defaults to `created_at`.
+  - `order` accepts `desc` or `asc`, defaults to `desc`.
+  - `begin_time` and `end_time` accepts an ISO 8601 date or date and time.
+* Changed `Recurly_AddonList::get()` and `Recurly_NoteList::get()` to add `$params` as the second parameter so sort, order and date filtering can be passed in [#249](https://github.com/recurly/recurly-client-php/pull/249)
 
 ## Version 2.5.3 (July 5th, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `order` accepts `desc` or `asc`, defaults to `desc`.
   - `begin_time` and `end_time` accepts an ISO 8601 date or date and time.
 * Changed `Recurly_AddonList::get()` and `Recurly_NoteList::get()` to add `$params` as the second parameter so sort, order and date filtering can be passed in [#249](https://github.com/recurly/recurly-client-php/pull/249)
+* Added support for `revenue_schedule_type` to `Recurly_Addon`, `Recurly_Adjustment`, `Recurly_Plan`, `Recurly_Subscription` and `Recurly_SubscriptionAddOn` classes [#257](https://github.com/recurly/recurly-client-php/pull/257)
 
 ## Version 2.5.3 (July 5th, 2016)
 

--- a/Tests/Recurly/Adjustment_Test.php
+++ b/Tests/Recurly/Adjustment_Test.php
@@ -91,11 +91,12 @@ class Recurly_AdjustmentTest extends Recurly_TestCase
     $charge->accounting_code = 'bandwidth';
     $charge->tax_exempt = false;
     $charge->tax_code = 'fake-tax-code';
+    $charge->origin = 'external_gift_card';
 
     // This deprecated parameter should be ignored:
     $charge->taxable = 0;
 
-    $expected = "<?xml version=\"1.0\"?>\n<adjustment><currency>USD</currency><unit_amount_in_cents>5000</unit_amount_in_cents><quantity>1</quantity><description>Charge for extra bandwidth</description><accounting_code>bandwidth</accounting_code><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code></adjustment>\n";
+    $expected = "<?xml version=\"1.0\"?>\n<adjustment><currency>USD</currency><unit_amount_in_cents>5000</unit_amount_in_cents><quantity>1</quantity><description>Charge for extra bandwidth</description><accounting_code>bandwidth</accounting_code><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code><origin>external_gift_card</origin></adjustment>\n";
     $this->assertEquals($expected, $charge->xml());
   }
 }

--- a/Tests/Recurly/Note_List_Test.php
+++ b/Tests/Recurly/Note_List_Test.php
@@ -4,9 +4,9 @@
 class Recurly_NoteListTest extends Recurly_TestCase
 {
   public function testGetNotes() {
-    $this->client->addResponse('GET', '/accounts/abcdef1234567890/notes', 'notes/index-200.xml');
+    $this->client->addResponse('GET', '/accounts/abcdef1234567890/notes?', 'notes/index-200.xml');
 
-    $notes = Recurly_NoteList::get('abcdef1234567890', $this->client);
+    $notes = Recurly_NoteList::get('abcdef1234567890', array(), $this->client);
     $this->assertInstanceOf('Recurly_NoteList', $notes);
     $this->assertEquals($notes->count(), 2);
 

--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -6,8 +6,9 @@ class Mock_Pager extends Recurly_Pager {
     return 'mocks';
   }
 
-  public function _loadFrom($uri, $params = null) {
-    parent::_loadFrom($uri, $params);
+  // Overridden to make it public.
+  public function _loadFrom($uri) {
+    parent::_loadFrom($uri);
   }
 }
 Recurly_Resource::$class_map['mocks'] = 'Mock_Pager';

--- a/Tests/fixtures/accounts/create-201.xml
+++ b/Tests/fixtures/accounts/create-201.xml
@@ -18,4 +18,5 @@ Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
   <company_name>Home Box Office</company_name>
   <accept_language>en-US</accept_language>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <closed_at nil="nil"></closed_at>
 </account>

--- a/Tests/fixtures/accounts/index-200.xml
+++ b/Tests/fixtures/accounts/index-200.xml
@@ -19,6 +19,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api100_cn</company_name>
     <accept_language>api100_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api99">
     <adjustments href="https://api.recurly.com/v2/accounts/api99/adjustments"/>
@@ -34,6 +35,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api99_cn</company_name>
     <accept_language>api99_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api98">
     <adjustments href="https://api.recurly.com/v2/accounts/api98/adjustments"/>
@@ -49,6 +51,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api98_cn</company_name>
     <accept_language>api98_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api97">
     <adjustments href="https://api.recurly.com/v2/accounts/api97/adjustments"/>
@@ -64,6 +67,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api97_cn</company_name>
     <accept_language>api97_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api96">
     <adjustments href="https://api.recurly.com/v2/accounts/api96/adjustments"/>
@@ -79,6 +83,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api96_cn</company_name>
     <accept_language>api96_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api95">
     <adjustments href="https://api.recurly.com/v2/accounts/api95/adjustments"/>
@@ -94,6 +99,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api95_cn</company_name>
     <accept_language>api95_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api94">
     <adjustments href="https://api.recurly.com/v2/accounts/api94/adjustments"/>
@@ -109,6 +115,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api94_cn</company_name>
     <accept_language>api94_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api93">
     <adjustments href="https://api.recurly.com/v2/accounts/api93/adjustments"/>
@@ -124,6 +131,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api93_cn</company_name>
     <accept_language>api93_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api92">
     <adjustments href="https://api.recurly.com/v2/accounts/api92/adjustments"/>
@@ -139,6 +147,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api92_cn</company_name>
     <accept_language>api92_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api91">
     <adjustments href="https://api.recurly.com/v2/accounts/api91/adjustments"/>
@@ -154,6 +163,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api91_cn</company_name>
     <accept_language>api91_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api90">
     <adjustments href="https://api.recurly.com/v2/accounts/api90/adjustments"/>
@@ -169,6 +179,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api90_cn</company_name>
     <accept_language>api90_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api89">
     <adjustments href="https://api.recurly.com/v2/accounts/api89/adjustments"/>
@@ -184,6 +195,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api89_cn</company_name>
     <accept_language>api89_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api88">
     <adjustments href="https://api.recurly.com/v2/accounts/api88/adjustments"/>
@@ -199,6 +211,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api88_cn</company_name>
     <accept_language>api88_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api87">
     <adjustments href="https://api.recurly.com/v2/accounts/api87/adjustments"/>
@@ -214,6 +227,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api87_cn</company_name>
     <accept_language>api87_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api86">
     <adjustments href="https://api.recurly.com/v2/accounts/api86/adjustments"/>
@@ -229,6 +243,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api86_cn</company_name>
     <accept_language>api86_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api85">
     <adjustments href="https://api.recurly.com/v2/accounts/api85/adjustments"/>
@@ -244,6 +259,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api85_cn</company_name>
     <accept_language>api85_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api84">
     <adjustments href="https://api.recurly.com/v2/accounts/api84/adjustments"/>
@@ -259,6 +275,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api84_cn</company_name>
     <accept_language>api84_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api83">
     <adjustments href="https://api.recurly.com/v2/accounts/api83/adjustments"/>
@@ -274,6 +291,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api83_cn</company_name>
     <accept_language>api83_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api82">
     <adjustments href="https://api.recurly.com/v2/accounts/api82/adjustments"/>
@@ -289,6 +307,7 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api82_cn</company_name>
     <accept_language>api82_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
   <account href="https://api.recurly.com/v2/accounts/api81">
     <adjustments href="https://api.recurly.com/v2/accounts/api81/adjustments"/>
@@ -304,5 +323,6 @@ Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="
     <company_name>api81_cn</company_name>
     <accept_language>api81_al</accept_language>
     <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+    <closed_at nil="nil"></closed_at>
   </account>
 </accounts>

--- a/Tests/fixtures/accounts/show-200.xml
+++ b/Tests/fixtures/accounts/show-200.xml
@@ -29,5 +29,6 @@ Content-Type: application/xml; charset=utf-8
   </address>
   <accept_language>en-US</accept_language>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <closed_at nil="nil"></closed_at>
   <vat_location_valid type="boolean">true</vat_location_valid>
 </account>

--- a/Tests/fixtures/accounts/update-200.xml
+++ b/Tests/fixtures/accounts/update-200.xml
@@ -18,4 +18,5 @@ Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
   <company_name>Home Box Office</company_name>
   <accept_language>en-US</accept_language>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <closed_at nil="nil"></closed_at>
 </account>

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -14,7 +14,7 @@ class Recurly_Addon extends Recurly_Resource
     Recurly_Addon::$_writeableAttributes = array(
       'add_on_code','name','display_quantity','default_quantity',
       'unit_amount_in_cents','accounting_code','tax_code',
-      'measured_unit_id','usage_type','add_on_type'
+      'measured_unit_id','usage_type','add_on_type','revenue_schedule_type'
     );
   }
 

--- a/lib/recurly/addon_list.php
+++ b/lib/recurly/addon_list.php
@@ -2,9 +2,9 @@
 
 class Recurly_AddonList extends Recurly_Pager
 {
-  public static function get($planCode, $client = null)
+  public static function get($planCode, $params = null, $client = null)
   {
-    $uri = Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) . Recurly_Client::PATH_ADDONS;
+    $uri = self::_uriWithParams(Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) . Recurly_Client::PATH_ADDONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -9,7 +9,7 @@ class Recurly_Adjustment extends Recurly_Resource
     Recurly_Adjustment::$_writeableAttributes = array(
       'currency','unit_amount_in_cents','quantity','description',
       'accounting_code','tax_exempt','tax_code','start_date','end_date',
-      'revenue_schedule_type',
+      'revenue_schedule_type', 'origin'
     );
   }
 

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -8,7 +8,8 @@ class Recurly_Adjustment extends Recurly_Resource
   {
     Recurly_Adjustment::$_writeableAttributes = array(
       'currency','unit_amount_in_cents','quantity','description',
-      'accounting_code','tax_exempt','tax_code','start_date','end_date'
+      'accounting_code','tax_exempt','tax_code','start_date','end_date',
+      'revenue_schedule_type',
     );
   }
 

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.3';
+  public static $apiVersion = '2.4';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/note_list.php
+++ b/lib/recurly/note_list.php
@@ -2,12 +2,9 @@
 
 class Recurly_NoteList extends Recurly_Pager
 {
-  public static function get($accountCode, $client = null) {
-    return Recurly_Base::_get(Recurly_NoteList::uriForNotes($accountCode), $client);
-  }
-
-  protected static function uriForNotes($accountCode) {
-    return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_NOTES;
+  public static function get($accountCode, $params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_NOTES, $params);
+    return new self($uri, $client);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -86,12 +86,11 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   /**
    * Load another page of results into this pager.
    */
-  protected function _loadFrom($uri, $params = null) {
+  protected function _loadFrom($uri) {
     if (empty($uri)) {
       return;
     }
 
-    $uri = Recurly_Base::_uriWithParams($uri, $params);
     $response = $this->_client->request(Recurly_Client::GET, $uri);
     $response->assertValidResponse();
 

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -100,9 +100,9 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   }
 
   protected function _afterParseResponse($response, $uri) {
-    $this->_href = $uri;
     $this->_loadRecordCount($response);
     $this->_loadLinks($response);
+    $this->_href = isset($this->_links['start']) ? $this->_links['start'] : $uri;
   }
 
   protected static function _setState($params, $state) {

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -19,6 +19,7 @@ class Recurly_Plan extends Recurly_Resource
       'plan_interval_length','plan_interval_unit','trial_interval_length',
       'trial_interval_unit','unit_amount_in_cents','setup_fee_in_cents',
       'total_billing_cycles','accounting_code','setup_fee_accounting_code',
+      'revenue_schedule_type', 'setup_fee_revenue_schedule_type',
       'tax_exempt','tax_code'
     );
   }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -11,7 +11,7 @@ class Recurly_Subscription extends Recurly_Resource
       'currency','starts_at','trial_ends_at','total_billing_cycles', 'first_renewal_date',
       'timeframe', 'subscription_add_ons', 'net_terms', 'po_number', 'collection_method',
       'cost_in_cents', 'remaining_billing_cycles', 'bulk', 'terms_and_conditions', 'customer_notes',
-      'vat_reverse_charge_notes', 'bank_account_authorized_at'
+      'vat_reverse_charge_notes', 'bank_account_authorized_at', 'revenue_schedule_type',
     );
   }
 

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -11,7 +11,8 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
       'unit_amount_in_cents',
       'add_on_type',
       'usage_type',
-      'usage_percentage'
+      'usage_percentage',
+      'revenue_schedule_type',
     );
   }
 


### PR DESCRIPTION
Adjustment objects will soon be allowed to specify the custom origin of `external_gift_card` for credits on an account originating from an external (3rd party) gift card provider. This allows merchants to accept gift cards and collect funds from them outside of Recurly, but enter credits for those gift cards into Recurly to be used to pay for subscriptions. This origin will not work for charges, only credits.

Existing clients will see no change in their integration as an origin will be chosen for their adjustments automatically as it has been done in the past.

This feature is not currently GA and will need to be enabled by contacting sales/support.