### PR TITLE
Allow adjustments to specify an origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.7.0 (unreleased)
 
 * Upgraded to API V2.4: https://dev.recurly.com/v2.4/docs
+* Allow credit adjustments (`Recurly_Adjustment`) to specify an `origin` of `external_gift_card` [#263](https://github.com/recurly/recurly-client-php/pull/263)
 
 ## Version 2.6.0 (August 9th, 2016)
 

--- a/Tests/Recurly/Adjustment_Test.php
+++ b/Tests/Recurly/Adjustment_Test.php
@@ -91,11 +91,12 @@ class Recurly_AdjustmentTest extends Recurly_TestCase
     $charge->accounting_code = 'bandwidth';
     $charge->tax_exempt = false;
     $charge->tax_code = 'fake-tax-code';
+    $charge->origin = 'external_gift_card';
 
     // This deprecated parameter should be ignored:
     $charge->taxable = 0;
 
-    $expected = "<?xml version=\"1.0\"?>\n<adjustment><currency>USD</currency><unit_amount_in_cents>5000</unit_amount_in_cents><quantity>1</quantity><description>Charge for extra bandwidth</description><accounting_code>bandwidth</accounting_code><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code></adjustment>\n";
+    $expected = "<?xml version=\"1.0\"?>\n<adjustment><currency>USD</currency><unit_amount_in_cents>5000</unit_amount_in_cents><quantity>1</quantity><description>Charge for extra bandwidth</description><accounting_code>bandwidth</accounting_code><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code><origin>external_gift_card</origin></adjustment>\n";
     $this->assertEquals($expected, $charge->xml());
   }
 }

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -9,7 +9,7 @@ class Recurly_Adjustment extends Recurly_Resource
     Recurly_Adjustment::$_writeableAttributes = array(
       'currency','unit_amount_in_cents','quantity','description',
       'accounting_code','tax_exempt','tax_code','start_date','end_date',
-      'revenue_schedule_type',
+      'revenue_schedule_type', 'origin'
     );
   }
 


### PR DESCRIPTION
Adjustment objects will soon be allowed to specify the custom origin of `external_gift_card` for credits on an account originating from an external (3rd party) gift card provider. This allows merchants to accept gift cards and collect funds from them outside of Recurly, but enter credits for those gift cards into Recurly to be used to pay for subscriptions. This origin will not work for charges, only credits.

Existing clients will see no change in their integration as an origin will be chosen for their adjustments automatically as it has been done in the past.

This feature is not currently GA and will need to be enabled by contacting sales/support.