### PR TITLE
Simplify writable attributes

### DIFF
--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -2,27 +2,11 @@
 
 class Recurly_Account extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-  protected static $_requiredAttributes;
-
   function __construct($accountCode = null, $client = null) {
     parent::__construct(null, $client);
     if (!is_null($accountCode))
       $this->account_code = $accountCode;
     $this->address = new Recurly_Address();
-  }
-
-  public static function init()
-  {
-    Recurly_Account::$_writeableAttributes = array(
-      'account_code','username','first_name','last_name','vat_number',
-      'email','company_name','accept_language','billing_info','address',
-      'tax_exempt','entity_use_code','cc_emails'
-    );
-    Recurly_Account::$_requiredAttributes = array(
-      'account_code'
-    );
-
   }
 
   public function &__get($key)
@@ -75,11 +59,15 @@ class Recurly_Account extends Recurly_Resource
     return 'account';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Account::$_writeableAttributes;
+    return array(
+      'account_code', 'username', 'first_name', 'last_name', 'vat_number',
+      'email', 'company_name', 'accept_language', 'billing_info', 'address',
+      'tax_exempt', 'entity_use_code', 'cc_emails'
+    );
   }
   protected function getRequiredAttributes() {
-    return Recurly_Account::$_requiredAttributes;
+    return array(
+      'account_code'
+    );
   }
 }
-
-Recurly_Account::init();

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -2,20 +2,9 @@
 
 class Recurly_Addon extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
   function __construct() {
     parent::__construct();
     $this->unit_amount_in_cents = new Recurly_CurrencyList('unit_amount_in_cents');
-  }
-
-  public static function init()
-  {
-    Recurly_Addon::$_writeableAttributes = array(
-      'add_on_code','name','display_quantity','default_quantity',
-      'unit_amount_in_cents','accounting_code','tax_code',
-      'measured_unit_id','usage_type','add_on_type','revenue_schedule_type'
-    );
   }
 
   public static function get($planCode, $addonCode, $client = null) {
@@ -49,8 +38,10 @@ class Recurly_Addon extends Recurly_Resource
     return 'add_on';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Addon::$_writeableAttributes;
+    array(
+      'add_on_code', 'name', 'display_quantity', 'default_quantity',
+      'unit_amount_in_cents', 'accounting_code', 'tax_code',
+      'measured_unit_id', 'usage_type', 'add_on_type', 'revenue_schedule_type'
+    );
   }
 }
-
-Recurly_Addon::init();

--- a/lib/recurly/address.php
+++ b/lib/recurly/address.php
@@ -2,23 +2,13 @@
 
 class Recurly_Address extends Recurly_Resource {
 
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_Address::$_writeableAttributes = array(
-      'address1','address2','city','state',
-      'zip','country','phone'
-    );
-
-  }
-
   protected function getNodeName() {
     return 'address';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Address::$_writeableAttributes;
+    return array(
+      'address1', 'address2', 'city', 'state',
+      'zip', 'country', 'phone'
+    );
   }
 }
-
-Recurly_Address::init();

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -2,17 +2,6 @@
 
 class Recurly_Adjustment extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_Adjustment::$_writeableAttributes = array(
-      'currency','unit_amount_in_cents','quantity','description',
-      'accounting_code','tax_exempt','tax_code','start_date','end_date',
-      'revenue_schedule_type',
-    );
-  }
-
   public static function get($adjustment_uuid, $client = null) {
     return Recurly_Base::_get(Recurly_Client::PATH_ADJUSTMENTS . '/' . rawurlencode($adjustment_uuid), $client);
   }
@@ -68,8 +57,10 @@ class Recurly_Adjustment extends Recurly_Resource
     return 'adjustment';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Adjustment::$_writeableAttributes;
+    return array(
+      'currency', 'unit_amount_in_cents', 'quantity', 'description',
+      'accounting_code', 'tax_exempt', 'tax_code', 'start_date', 'end_date',
+      'revenue_schedule_type',
+    );
   }
 }
-
-Recurly_Adjustment::init();

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -2,20 +2,6 @@
 
 class Recurly_BillingInfo extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_BillingInfo::$_writeableAttributes = array(
-      'first_name','last_name','name_on_account','ip_address',
-      'address1','address2','city','state','country','zip','phone','vat_number',
-      'number','month','year','verification_value','start_year','start_month','issue_number',
-      'account_number','routing_number','account_type',
-      'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
-      'token_id'
-    );
-  }
-
   public static function get($accountCode, $client = null) {
     return Recurly_Base::_get(Recurly_BillingInfo::uriForBillingInfo($accountCode), $client);
   }
@@ -50,8 +36,13 @@ class Recurly_BillingInfo extends Recurly_Resource
     return 'billing_info';
   }
   protected function getWriteableAttributes() {
-    return Recurly_BillingInfo::$_writeableAttributes;
+    return array(
+      'first_name', 'last_name', 'name_on_account', 'ip_address',
+      'address1', 'address2', 'city', 'state', 'country', 'zip', 'phone',
+      'vat_number', 'number', 'month', 'year', 'verification_value',
+      'account_number', 'routing_number', 'account_type',
+      'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
+      'token_id'
+    );
   }
 }
-
-Recurly_BillingInfo::init();

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -2,28 +2,11 @@
 
 class Recurly_Coupon extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-  protected static $_updatableAttributes;
   protected $_redeemUrl;
 
   function __construct($href = null, $client = null) {
     parent::__construct($href, $client);
     $this->discount_in_cents = new Recurly_CurrencyList('discount_in_cents');
-  }
-
-  public static function init()
-  {
-    Recurly_Coupon::$_writeableAttributes = array(
-      'coupon_code','name','discount_type','redeem_by_date','single_use','applies_for_months',
-      'duration', 'temporal_unit', 'temporal_amount',
-      'max_redemptions','applies_to_all_plans','discount_percent','discount_in_cents','plan_codes',
-      'hosted_description','invoice_description', 'applies_to_non_plan_charges', 'redemption_resource',
-      'max_redemptions_per_account', 'coupon_type', 'unique_code_template', 'unique_coupon_codes',
-      'discount_type', 'free_trial_amount', 'free_trial_unit'
-    );
-    Recurly_Coupon::$_updatableAttributes = array('name', 'max_redemptions',
-      'max_redemptions_per_account', 'hosted_description', 'invoice_description', 'redeem_by_date'
-    );
   }
 
   public static function get($couponCode, $client = null) {
@@ -119,11 +102,21 @@ class Recurly_Coupon extends Recurly_Resource
     return 'coupon';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Coupon::$_writeableAttributes;
+    return array(
+      'coupon_code', 'name', 'discount_type', 'redeem_by_date', 'single_use',
+      'applies_for_months', 'duration', 'temporal_unit', 'temporal_amount',
+      'max_redemptions', 'applies_to_all_plans', 'discount_percent',
+      'discount_in_cents', 'plan_codes', 'hosted_description',
+      'invoice_description', 'applies_to_non_plan_charges', 'redemption_resource',
+      'max_redemptions_per_account', 'coupon_type', 'unique_code_template',
+      'unique_coupon_codes', 'discount_type', 'free_trial_amount',
+      'free_trial_unit'
+    );
   }
   protected function getUpdatableAttributes() {
-    return Recurly_Coupon::$_updatableAttributes;
+    return array(
+      'name', 'max_redemptions', 'max_redemptions_per_account',
+      'hosted_description', 'invoice_description', 'redeem_by_date'
+    );
   }
 }
-
-Recurly_Coupon::init();

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -2,13 +2,6 @@
 
 class Recurly_Invoice extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_Invoice::$_writeableAttributes = array('terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes', 'collection_method', 'net_terms', 'po_number');
-  }
-
   /**
    * Lookup an invoice by its ID
    * @param string Invoice number
@@ -121,7 +114,10 @@ class Recurly_Invoice extends Recurly_Resource
     return 'invoice';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Invoice::$_writeableAttributes;
+    return array(
+      'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
+      'collection_method', 'net_terms', 'po_number'
+    );
   }
   protected function uri() {
     $invoiceNumberWithPrefix = $this->invoiceNumberWithPrefix();
@@ -136,5 +132,3 @@ class Recurly_Invoice extends Recurly_Resource
     return Recurly_Client::PATH_INVOICES . '/' . rawurlencode($invoiceNumber);
   }
 }
-
-Recurly_Invoice::init();

--- a/lib/recurly/measured_unit.php
+++ b/lib/recurly/measured_unit.php
@@ -2,15 +2,6 @@
 
 class Recurly_MeasuredUnit extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_MeasuredUnit::$_writeableAttributes = array(
-      'name','display_name','description'
-    );
-  }
-
   public function create() {
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_MEASURED_UNITS);
   }
@@ -33,8 +24,8 @@ class Recurly_MeasuredUnit extends Recurly_Resource
     return 'measured_unit';
   }
   protected function getWriteableAttributes() {
-    return Recurly_MeasuredUnit::$_writeableAttributes;
+    return array(
+      'name', 'display_name', 'description'
+    );
   }
 }
-
-Recurly_MeasuredUnit::init();

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -2,26 +2,10 @@
 
 class Recurly_Plan extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
   function __construct() {
     parent::__construct();
     $this->setup_fee_in_cents = new Recurly_CurrencyList('setup_fee_in_cents');
     $this->unit_amount_in_cents = new Recurly_CurrencyList('unit_amount_in_cents');
-  }
-
-  public static function init()
-  {
-    Recurly_Plan::$_writeableAttributes = array(
-      'plan_code','name','description','success_url','cancel_url',
-      'display_donation_amounts','display_quantity','display_phone_number',
-      'bypass_hosted_confirmation','unit_name','payment_page_tos_link',
-      'plan_interval_length','plan_interval_unit','trial_interval_length',
-      'trial_interval_unit','unit_amount_in_cents','setup_fee_in_cents',
-      'total_billing_cycles','accounting_code','setup_fee_accounting_code',
-      'revenue_schedule_type', 'setup_fee_revenue_schedule_type',
-      'tax_exempt','tax_code'
-    );
   }
 
   public static function get($planCode, $client = null) {
@@ -56,8 +40,15 @@ class Recurly_Plan extends Recurly_Resource
     return 'plan';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Plan::$_writeableAttributes;
+    return array(
+      'plan_code', 'name', 'description', 'success_url', 'cancel_url',
+      'display_donation_amounts', 'display_quantity', 'display_phone_number',
+      'bypass_hosted_confirmation', 'unit_name', 'payment_page_tos_link',
+      'plan_interval_length', 'plan_interval_unit', 'trial_interval_length',
+      'trial_interval_unit', 'unit_amount_in_cents', 'setup_fee_in_cents',
+      'total_billing_cycles', 'accounting_code', 'setup_fee_accounting_code',
+      'revenue_schedule_type', 'setup_fee_revenue_schedule_type',
+      'tax_exempt', 'tax_code'
+    );
   }
 }
-
-Recurly_Plan::init();

--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -2,13 +2,7 @@
 
 class Recurly_CouponRedemption extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
   protected static $_redeemUrl;
-
-  public static function init()
-  {
-    Recurly_CouponRedemption::$_writeableAttributes = array('account_code','currency','subscription_uuid');
-  }
 
   public static function get($accountCode, $client = null) {
     return Recurly_Base::_get(Recurly_CouponRedemption::uriForAccount($accountCode), $client);
@@ -35,11 +29,6 @@ class Recurly_CouponRedemption extends Recurly_Resource
     return 'redemption';
   }
   protected function getWriteableAttributes() {
-    return Recurly_CouponRedemption::$_writeableAttributes;
-  }
-  protected function getRequiredAttributes() {
-    return array();
+    return array('account_code', 'currency', 'subscription_uuid');
   }
 }
-
-Recurly_CouponRedemption::init();

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -2,19 +2,6 @@
 
 class Recurly_Subscription extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_Subscription::$_writeableAttributes = array(
-      'account','plan_code','coupon_code','coupon_codes','unit_amount_in_cents','quantity',
-      'currency','starts_at','trial_ends_at','total_billing_cycles', 'first_renewal_date',
-      'timeframe', 'subscription_add_ons', 'net_terms', 'po_number', 'collection_method',
-      'cost_in_cents', 'remaining_billing_cycles', 'bulk', 'terms_and_conditions', 'customer_notes',
-      'vat_reverse_charge_notes', 'bank_account_authorized_at', 'revenue_schedule_type',
-    );
-  }
-
   public function __construct($href = null, $client = null) {
     parent::__construct($href, $client);
     $this->subscription_add_ons = array();
@@ -132,8 +119,14 @@ class Recurly_Subscription extends Recurly_Resource
     return 'subscription';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Subscription::$_writeableAttributes;
+    return array(
+      'account', 'plan_code', 'coupon_code', 'coupon_codes',
+      'unit_amount_in_cents', 'quantity', 'currency', 'starts_at',
+      'trial_ends_at', 'total_billing_cycles', 'first_renewal_date',
+      'timeframe', 'subscription_add_ons', 'net_terms', 'po_number',
+      'collection_method', 'cost_in_cents', 'remaining_billing_cycles', 'bulk',
+      'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
+      'bank_account_authorized_at', 'revenue_schedule_type',
+    );
   }
 }
-
-Recurly_Subscription::init();

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -2,10 +2,12 @@
 
 class Recurly_SubscriptionAddOn extends Recurly_Resource {
 
-  protected static $_writeableAttributes;
+  protected function getNodeName() {
+    return 'subscription_add_on';
+  }
 
-  public static function init() {
-    Recurly_SubscriptionAddOn::$_writeableAttributes = array(
+  protected function getWriteableAttributes() {
+    return array(
       'add_on_code',
       'quantity',
       'unit_amount_in_cents',
@@ -14,14 +16,6 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
       'usage_percentage',
       'revenue_schedule_type',
     );
-  }
-
-  protected function getNodeName() {
-    return 'subscription_add_on';
-  }
-
-  protected function getWriteableAttributes() {
-    return Recurly_SubscriptionAddOn::$_writeableAttributes;
   }
 
   protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {
@@ -51,6 +45,3 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource {
     return "<$class $values>";
   }
 }
-
-Recurly_SubscriptionAddOn::init();
-

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -2,15 +2,6 @@
 
 class Recurly_Transaction extends Recurly_Resource
 {
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_Transaction::$_writeableAttributes = array(
-      'account','amount_in_cents','currency','description','accounting_code', 'tax_exempt', 'tax_code'
-    );
-  }
-
   public static function get($uuid, $client = null) {
     return Recurly_Base::_get(Recurly_Transaction::uriForTransaction($uuid), $client);
   }
@@ -54,8 +45,9 @@ class Recurly_Transaction extends Recurly_Resource
     return 'transaction';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Transaction::$_writeableAttributes;
+    return array(
+      'account', 'amount_in_cents', 'currency', 'description', 'accounting_code',
+      'tax_exempt', 'tax_code'
+    );
   }
 }
-
-Recurly_Transaction::init();

--- a/lib/recurly/usage.php
+++ b/lib/recurly/usage.php
@@ -5,16 +5,6 @@ class Recurly_Usage extends Recurly_Resource
   var $subUuid;
   var $addOnCode;
 
-  protected static $_writeableAttributes;
-
-  public static function init()
-  {
-    Recurly_Usage::$_writeableAttributes = array(
-      'amount','merchant_tag','usage_type','unit_amount_in_cents',
-      'billed_at','recording_timestamp','usage_timestamp','measured_unit'
-    );
-  }
-
   public static function build($subUuid, $addOnCode, $client = null) {
     $usage = new self(null, $client);
     $usage->subUuid = $subUuid;
@@ -50,8 +40,9 @@ class Recurly_Usage extends Recurly_Resource
     return 'usage';
   }
   protected function getWriteableAttributes() {
-    return Recurly_Usage::$_writeableAttributes;
+    return array(
+      'amount', 'merchant_tag', 'usage_type', 'unit_amount_in_cents',
+      'billed_at', 'recording_timestamp', 'usage_timestamp', 'measured_unit'
+    );
   }
 }
-
-Recurly_Usage::init();


### PR DESCRIPTION
Right now we've got a lot of overhead setting up static `$_writeableAttributes` and `$_requiredAttributes` variable that are only used by accessor functions. We can remove a lot of boilerplate code by just having the accessors return the arrays directly.