### PR TITLE
Document that you can't call preview() then save()

### DIFF
--- a/lib/recurly/gift_card.php
+++ b/lib/recurly/gift_card.php
@@ -25,6 +25,12 @@ class Recurly_GiftCard extends Recurly_Resource
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_GIFT_CARDS);
   }
 
+  /**
+   * Preview the creation and check for errors.
+   *
+   * Note: once preview() has been called you will not be able to call create()
+   * without reassiging all the attributes.
+   */
   public function preview() {
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_GIFT_CARDS . '/preview');
   }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -15,6 +15,12 @@ class Recurly_Subscription extends Recurly_Resource
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_SUBSCRIPTIONS);
   }
 
+  /**
+   * Preview the creation and check for errors.
+   *
+   * Note: once preview() has been called you will not be able to call create()
+   * or save() without reassiging all the attributes.
+   */
   public function preview() {
     if ($this->uuid) {
       $this->_save(Recurly_Client::POST, $this->uri() . '/preview');


### PR DESCRIPTION
`preview()` indirectly calls `__parseXmlToObject()` which resets the `_unsavedKeys` property. So when `save()` is called it appears there is nothing to do. There's not an easy fix for this so I think we can just document the behavior.