### PR TITLE
adds company to writeable billing_info attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added property documentation to several classes (thanks to [phpdave](https://github.com/phpdave)) [#278](https://github.com/recurly/recurly-client-php/pull/278)
+* Added company attribute to billing info [#280](https://github.com/recurly/recurly-client-php/pull/280)
 
 ## Version 2.7.0 (September 15th, 2016)
 

--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -20,6 +20,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
 
     $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
     $this->assertEquals($billing_info->first_name, 'Larry');
+    $this->assertEquals($billing_info->company, 'Pretty Good Company');
     $this->assertEquals($billing_info->address1, '123 Pretty Pretty Good St.');
     $this->assertEquals($billing_info->country, 'US');
     $this->assertEquals($billing_info->card_type, 'Visa');

--- a/Tests/fixtures/billing_info/show-200.xml
+++ b/Tests/fixtures/billing_info/show-200.xml
@@ -6,7 +6,7 @@ Content-Type: application/xml; charset=utf-8
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
   <first_name>Larry</first_name>
   <last_name>David</last_name>
-  <company nil="nil"></company>
+  <company>Pretty Good Company</company>
   <address1>123 Pretty Pretty Good St.</address1>
   <address2 nil="nil"></address2>
   <city>Los Angeles</city>

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -16,6 +16,7 @@
  * @property string $country Country, 2-letter ISO code STRONGLY RECOMMENDED
  * @property string $zip Zip or postal code, recommended for address validation
  * @property string $phone Phone number
+ * @property string $company Customer's company
  * @property string $vat_number Customer's VAT Number
  * @property string $currency Currency in which invoices will be posted. Only applicable if this account is enrolled in a plan has a different currency than your site's default.
  * @property string $verification_value Security code or CVV, 3-4 digits STRONGLY RECOMMENDED
@@ -58,7 +59,7 @@ class Recurly_BillingInfo extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return array(
-      'first_name', 'last_name', 'name_on_account', 'ip_address',
+      'first_name', 'last_name', 'name_on_account', 'company', 'ip_address',
       'address1', 'address2', 'city', 'state', 'country', 'zip', 'phone',
       'vat_number', 'number', 'month', 'year', 'verification_value',
       'account_number', 'routing_number', 'account_type',


### PR DESCRIPTION
Description: Adds company attribute to billing_info

Testing the change:
create billing info on an account and include a company name in the billing info

```php
$billing_info->company = 'Company Name'
```