### PR TITLE
Parse incorrectly shaped validation errors

### DIFF
--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -26,8 +26,16 @@ class Recurly_ClientResponse
         if ($trans_error instanceof Recurly_TransactionError && $transaction instanceof Recurly_Transaction)
           throw new Recurly_ValidationError($trans_error->customer_message, $transaction, array($trans_error));
       }
-      else
+      else {
+        // Here we are making sure that this isn't a ValidationError in the shape of a FieldError
+        // If it is, we will reshape it into a ValidationError
+        $error = @$this->parseErrorXml($this->body);
+        if (isset($error)) {
+          throw new Recurly_ValidationError('Validation error', $object, array($error));
+        }
         throw new Recurly_ValidationError('Validation error', $object, $object->getErrors());
+      }
+
     }
   }
 


### PR DESCRIPTION
Resolves #284 
Resolves #281 

Some coupon validation errors are shaped like normal field errors, for instance:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<error>
  <symbol>subscription_must_change</symbol>
  <description>You must change the subscription in order to redeem a coupon.</description>
</error>
```

instead of what would be expected:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<errors>
  <error field="subscription.coupon_code" symbol="subscription_must_change">You must change the subscription in order to redeem a coupon.</error>
</error>
```

Example code:

```php
$active_subscription = '3b1c9a5c19f46a8e205abe409ebe3c01';

try {
  $subscription = Recurly_Subscription::get($active_subscription);
  $subscription->coupon_code = 'j32yaysm6g';

  $subscription->quantity = 2;
  $subscription->updateImmediately();

  print var_dump($subscription);
} catch (Recurly_ValidationError $e) {
  // prints all the error messages summed up
  print $e->getMessage() . "\n"; // You must change the subscription in order to redeem a coupon.

  // you can also dig through the individual errors, in this case there is only one
  foreach ($e->errors as $fieldErr) {
    print $fieldErr->symbol . "\n"; // subscription_must_change
    print $fieldErr->description . "\n"; // You must change the subscription in order to redeem a coupon.
  }
}
```
