### PR TITLE
Adds a getType method to all Resources

### DIFF
--- a/Tests/Recurly/Adjustment_Test.php
+++ b/Tests/Recurly/Adjustment_Test.php
@@ -16,6 +16,7 @@ class Recurly_AdjustmentTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Stub', $adjustment->account);
     $this->assertInstanceOf('Recurly_Stub', $adjustment->invoice);
     $this->assertInstanceOf('Recurly_Stub', $adjustment->subscription);
+    $this->assertEquals('charge', $adjustment->getType());
     $this->assertEquals('abcdef1234567890', $adjustment->uuid);
     $this->assertEquals('invoiced', $adjustment->state);
     $this->assertEquals('$12 Annual Subscription', $adjustment->description);

--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -27,6 +27,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertEquals($billing_info->year, 2015);
     $this->assertEquals($billing_info->month, 1);
     $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info');
+    $this->assertEquals($billing_info->getType(), 'credit_card');
   }
 
   public function testGetPayPalBillingInfo() {

--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -35,6 +35,7 @@ class Recurly_TransactionTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_FraudInfo', $transaction->fraud);
     $this->assertEquals($transaction->fraud->score, 99);
     $this->assertEquals($transaction->fraud->decision, 'DECLINE');
+    $this->assertEquals($transaction->getType(), 'credit_card');
   }
 
   public function testCreateTransactionFailed() {

--- a/Tests/fixtures/billing_info/show-200.xml
+++ b/Tests/fixtures/billing_info/show-200.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info">
+<billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info" type="credit_card">
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
   <first_name>Larry</first_name>
   <last_name>David</last_name>

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -3,6 +3,7 @@
 abstract class Recurly_Base
 {
   protected $_href;
+  protected $_type;
   protected $_client;
   protected $_links;
 
@@ -147,6 +148,11 @@ abstract class Recurly_Base
   }
   public function setHref($href) {
     $this->_href = $href;
+  }
+
+  /** Refers to the `type` root xml attribute **/
+  public function getType() {
+    return $this->_type;
   }
 
   private function addLink($name, $href, $method){
@@ -402,6 +408,12 @@ abstract class Recurly_Base
         $new_obj = new $node_class($nodeName);
       } else
         $new_obj = new $node_class();
+
+      // It may have a type attribute we wish to capture
+      $typeAttribute = $node->getAttribute('type');
+      if (!empty($typeAttribute)) {
+        $new_obj->_type = $typeAttribute;
+      }
 
       $href = $node->getAttribute('href');
       if (!empty($href)) {


### PR DESCRIPTION
Resolves #210
Resolves #245

This adds a method `getType` on every resource object which returns the xml attribute `type`. This can currently be found on Adjustments, Transactions, and BillingInfos.