### PR TITLE
GiftCard: deliver_at goes on the Delivery object

### DIFF
--- a/lib/recurly/delivery.php
+++ b/lib/recurly/delivery.php
@@ -8,7 +8,7 @@ class Recurly_Delivery extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'method','email_address','first_name','last_name',
-      'address','gifter_name','personal_message'
+      'address','gifter_name','personal_message','deliver_at'
     );
   }
 }

--- a/lib/recurly/gift_card.php
+++ b/lib/recurly/gift_card.php
@@ -55,7 +55,7 @@ class Recurly_GiftCard extends Recurly_Resource
     } else {
       return array(
         'product_code','unit_amount_in_cents','delivery',
-        'gifter_account','currency','delivery'
+        'gifter_account','currency'
       );
     }
   }


### PR DESCRIPTION
Looks like we added another `delivery` field when we meant to add `deliver_at`

\cc @elliottbernstein 