### PR TITLE
Adds external paymnets to invoices

### DIFF
--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -142,4 +142,18 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $refund_invoice = $invoice->refund($adjustments);
     $this->assertEquals($refund_invoice->subtotal_in_cents, -1000);
   }
+
+  public function testEnterOfflinePayment() {
+    $invoice = Recurly_Invoice::get('1001', $this->client);
+    $this->client->addResponse('POST', 'https://api.recurly.com/v2/invoices/1001/transactions', 'transactions/create-200.xml');
+    $transactionAttrs = new Recurly_Transaction();
+    $transactionAttrs->payment_method = 'check';
+    $transactionAttrs->collected_at = date('c', strtotime('2012-12-31Z'));
+    $transactionAttrs->amount_in_cents = 1000;
+    $transactionAttrs->description = "check #12345";
+    $transaction = $invoice->enterOfflinePayment($transactionAttrs, $this->client);
+
+    $this->assertInstanceOf('Recurly_Transaction', $transaction);
+    $this->assertEquals($transaction->status, 'success');
+  }
 }

--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -6,6 +6,7 @@ class Recurly_TransactionTest extends Recurly_TestCase
   function defaultResponses() {
     return array(
       array('GET', '/transactions/012345678901234567890123456789ab', 'transactions/show-200.xml'),
+      array('GET', '/invoices/1001', 'invoices/show-200.xml'),
     );
   }
 

--- a/Tests/fixtures/transactions/create-200.xml
+++ b/Tests/fixtures/transactions/create-200.xml
@@ -1,0 +1,45 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890">
+  <account href="https://api.recurly.com/v2/accounts/verena"/>
+  <invoice href="https://api.recurly.com/v2/invoices/abcdef1234567890"/>
+  <uuid>a13acd8fe4294916b79aec87b7ea441f</uuid>
+  <action>purchase</action>
+  <amount_in_cents type="integer">100</amount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <currency>USD</currency>
+  <status>success</status>
+  <payment_method>check</payment_method>
+  <reference nil="nil"></reference>
+  <source>transaction</source>
+  <recurring type="boolean">false</recurring>
+  <test type="boolean">true</test>
+  <voidable type="boolean">true</voidable>
+  <refundable type="boolean">false</refundable>
+  <created_at type="datetime">2011-08-25T12:00:00Z</created_at>
+  <details>
+    <account>
+      <account_code>1</account_code>
+      <state>active</state>
+      <username nil="nil"></username>
+      <email>verena@example.com</email>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <company_name></company_name>
+      <vat_number nil="nil"></vat_number>
+      <tax_exempt type="boolean">false</tax_exempt>
+      <address>
+        <address1>123 Main St.</address1>
+        <address2 nil="nil"></address2>
+        <city>San Francisco</city>
+        <state>CA</state>
+        <zip>94105</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+      </address>
+    </account>
+  </details>
+  <a name="refund" href="https://api.recurly.com/v2/transactions/abcdef1234567890" method="delete"/>
+</transaction>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -66,6 +66,16 @@ class Recurly_Invoice extends Recurly_Resource
   }
 
   /**
+   * Enters an offline payment for an invoice
+   * @param Recurly_Transaction additional transaction attributes. The attributes available to set are (payment_method, collected_at, amount_in_cents, description)
+   * @return Recurly_Transaction transaction on success
+   */
+  public function enterOfflinePayment($transaction) {
+    $uri = $this->uri() . '/transactions';
+    return Recurly_Transaction::_post($uri, $transaction->xml(), $this->_client);
+  }
+
+  /**
    * Refunds an open amount from the invoice and returns a new refund invoice
    * @param Integer amount in cents to refund from this invoice
    * @param String indicates the refund order to apply, valid options: {'credit','transaction'}, defaults to 'credit'

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -31,6 +31,8 @@
  * @property string $merchant_message For declined transactions, the message displayed to the merchant (if applicable).
  * @property string $customer_message For declined transactions, the message displayed to the customer (if applicable).
  * @property string $gateway_error_code For declined transactions, this field lists the gateway error code sent to us from the gateway (if applicable).
+ * @property string $payment_method The method of payment: The method of payment: (credit_card, paypal, eft, wire_transfer, money_order, check, or other).
+ * @property DateTime $collected_at Date payment was collected
  */
 class Recurly_Transaction extends Recurly_Resource
 {
@@ -86,7 +88,7 @@ class Recurly_Transaction extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'account', 'amount_in_cents', 'currency', 'description', 'accounting_code',
-      'tax_exempt', 'tax_code'
+      'tax_exempt', 'tax_code', 'payment_method', 'collected_at'
     );
   }
 }


### PR DESCRIPTION
Resolves #141 

Adds the ability to ["Enter an offline payment for a manual invoice"](https://dev.recurly.com/docs/enter-an-offline-payment-for-a-manual-invoice-beta). If this is merged, then the code example on that page will have to be updated. This picks up on the work of @cgerrior in PR #154 