### PR TITLE
Add trial requires billing info field and no billing info reason field

### DIFF
--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -22,6 +22,7 @@ class Recurly_PlanTest extends Recurly_TestCase
     $this->assertEquals('days', $plan->trial_interval_unit);
     $this->assertEquals(6, $plan->total_billing_cycles);
     $this->assertEquals("Setup Fee AC", $plan->setup_fee_accounting_code);
+    $this->assertEquals(false, $plan->trial_requires_billing_info);
 
     $this->assertInstanceOf('Recurly_CurrencyList', $plan->unit_amount_in_cents);
     $this->assertEquals(1000, $plan->unit_amount_in_cents['USD']->amount_in_cents);
@@ -46,10 +47,11 @@ class Recurly_PlanTest extends Recurly_TestCase
     $plan->unit_amount_in_cents->addCurrency('USD', 1500);
     $plan->unit_amount_in_cents->addCurrency('EUR', 1200);
     $plan->setup_fee_in_cents->addCurrency('EUR', 500);
+    $plan->trial_requires_billing_info = false;
     $plan->total_billing_cycles = 6;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum &amp; Gold Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles>6</total_billing_cycles></plan>\n",
+      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum &amp; Gold Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles>6</total_billing_cycles><trial_requires_billing_info>false</trial_requires_billing_info></plan>\n",
       $plan->xml()
     );
   }
@@ -63,10 +65,11 @@ class Recurly_PlanTest extends Recurly_TestCase
     $plan->setup_fee_in_cents->addCurrency('EUR', 500);
     $plan->total_billing_cycles = NULL;
     $plan->tax_exempt = false;
+    $plan->trial_requires_billing_info = false;
     $plan->tax_code = 'fake-tax-code';
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><USD>500</USD><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles nil=\"nil\"></total_billing_cycles><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code></plan>\n",
+      "<?xml version=\"1.0\"?>\n<plan><plan_code>platinum</plan_code><name>Platinum Plan</name><unit_amount_in_cents><USD>1500</USD><EUR>1200</EUR></unit_amount_in_cents><setup_fee_in_cents><USD>500</USD><EUR>500</EUR></setup_fee_in_cents><total_billing_cycles nil=\"nil\"></total_billing_cycles><tax_exempt>false</tax_exempt><tax_code>fake-tax-code</tax_code><trial_requires_billing_info>false</trial_requires_billing_info></plan>\n",
       $plan->xml()
     );
   }

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -29,6 +29,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $this->assertEquals('Some Terms and Conditions', $subscription->terms_and_conditions);
     $this->assertEquals('Some Customer Notes', $subscription->customer_notes);
     $this->assertEquals('Some VAT Notes', $subscription->vat_reverse_charge_notes);
+    $this->assertEquals('plan_free_trial', $subscription->no_billing_info_reason);
 
     # TODO: Should test the rest of the parsing.
   }

--- a/Tests/fixtures/plans/show-200.xml
+++ b/Tests/fixtures/plans/show-200.xml
@@ -19,6 +19,7 @@ Content-Type: application/xml; charset=utf-8
   <plan_interval_unit>months</plan_interval_unit>
   <trial_interval_length type="integer">15</trial_interval_length>
   <trial_interval_unit>days</trial_interval_unit>
+  <trial_requires_billing_info type="boolean">false</trial_requires_billing_info>
   <total_billing_cycles type="integer">6</total_billing_cycles>
   <accounting_code nil="nil"></accounting_code>
   <setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>

--- a/Tests/fixtures/subscriptions/show-200.xml
+++ b/Tests/fixtures/subscriptions/show-200.xml
@@ -29,6 +29,7 @@ Content-Type: application/xml; charset=utf-8
   <customer_notes>Some Customer Notes</customer_notes>
   <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
   <started_with_gift type="boolean">false</started_with_gift>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
   <converted_at nil="nil"></converted_at>
   <subscription_add_ons type="array">
     <subscription_add_on>

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -32,6 +32,7 @@
  * @property string $measured_unit_id The id of the measured unit on your site associated with the add-on.
  * @property string $usage_type If add_on_type = usage, you must set a usage_type, which can be price or percentage. If price, the price is defined in unit_amount_in_cents. If percentage, the percentage is defined in usage_percentage.
  * @property string $usage_percentage If add_on_type = usage and usage_type = percentage, you must set a usage_percentage. Must be between 0.0000 and 100.0000.
+ * @property boolean $trial_requires_billing_info Setting to determine if subscriptions to this plan will always require billing info or will only require it when either not in a trial or when money is due, defaults to true.
  */
 class Recurly_Plan extends Recurly_Resource
 {
@@ -81,7 +82,7 @@ class Recurly_Plan extends Recurly_Resource
       'trial_interval_unit', 'unit_amount_in_cents', 'setup_fee_in_cents',
       'total_billing_cycles', 'accounting_code', 'setup_fee_accounting_code',
       'revenue_schedule_type', 'setup_fee_revenue_schedule_type',
-      'tax_exempt', 'tax_code'
+      'tax_exempt', 'tax_code', 'trial_requires_billing_info'
     );
   }
 }


### PR DESCRIPTION
This adds the new read/write boolean field to plan `trial_requires_billing_info` and a new read only string field to subscription: `no_billing_info_reason`