### PR TITLE
Remove X-Records header

### DIFF
--- a/Tests/Recurly/Account_List_Test.php
+++ b/Tests/Recurly/Account_List_Test.php
@@ -14,7 +14,6 @@ class Recurly_AccountListTest extends Recurly_TestCase
 
     $this->assertInstanceOf('Recurly_AccountList', $accounts);
     $this->assertEquals('/accounts', $accounts->getHref());
-    $this->assertEquals(42, $accounts->count());
   }
 
   public function testGetActive() {

--- a/Tests/Recurly/Client_Test.php
+++ b/Tests/Recurly/Client_Test.php
@@ -8,7 +8,7 @@ class Recurly_ClientTest extends Recurly_TestCase
     $this->client->addResponse('GET', '/accounts', 'client/deprecated-200.xml');
 
     // This should print an error but not raise.
-    $accounts = Recurly_AccountList::get(null, $this->client)->count();
+    $accounts = Recurly_AccountList::get(null, $this->client)->get();
   }
 
   public function testUnauthorizedError() {

--- a/Tests/Recurly/Coupon_Test.php
+++ b/Tests/Recurly/Coupon_Test.php
@@ -42,7 +42,7 @@ class Recurly_CouponTest extends Recurly_TestCase
     $redemptions = $coupon->redemptions->get();
 
     $this->assertInstanceOf('Recurly_CouponRedemptionList', $redemptions);
-    $this->assertEquals(2, $redemptions->count());
+    $this->assertEquals('https://api.recurly.com/v2/coupons/special/redemptions', $redemptions->getHref());
   }
 
   public function testRedeemCouponExpired() {

--- a/Tests/Recurly/GiftCard_List_Test.php
+++ b/Tests/Recurly/GiftCard_List_Test.php
@@ -13,6 +13,5 @@ class RecurlyGiftCardListTest extends Recurly_TestCase
 
     $this->assertInstanceOf('Recurly_GiftCardList', $gift_cards);
     $this->assertEquals('/gift_cards', $gift_cards->getHref());
-    $this->assertEquals(42, $gift_cards->count());
   }
 }

--- a/Tests/Recurly/MeasuredUnit_List_Test.php
+++ b/Tests/Recurly/MeasuredUnit_List_Test.php
@@ -9,6 +9,6 @@ class Recurly_MeasuredUnitListTest extends Recurly_TestCase
     $measured_units = Recurly_MeasuredUnitList::get(null, $this->client);
 
     $this->assertInstanceOf('Recurly_MeasuredUnitList', $measured_units);
-    $this->assertEquals(2, $measured_units->count());
+    $this->assertEquals('/measured_units', $measured_units->getHref());
   }
 }

--- a/Tests/Recurly/Note_List_Test.php
+++ b/Tests/Recurly/Note_List_Test.php
@@ -8,10 +8,9 @@ class Recurly_NoteListTest extends Recurly_TestCase
 
     $notes = Recurly_NoteList::get('abcdef1234567890', array(), $this->client);
     $this->assertInstanceOf('Recurly_NoteList', $notes);
-    $this->assertEquals($notes->count(), 2);
+    $this->assertEquals('/accounts/abcdef1234567890/notes?', $notes->getHref());
 
     $note = $notes->current();
-
     $this->assertInstanceOf('Recurly_Note', $note);
     $this->assertEquals($note->message, 'this account needs an account manager');
     $this->assertEquals($note->created_at->format(DateTime::ISO8601), '2013-03-12T18:35:00+0000');

--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -22,15 +22,6 @@ Recurly_Resource::$class_map['mock'] = 'Mock_Item';
 
 class Recurly_PagerTest extends Recurly_TestCase
 {
-  function defaultResponses() {
-    return array(
-      array('GET', '/mocks', 'pager/index-1-200.xml'),
-      array('GET', 'http://example.com/mocks?cursor=1', 'pager/index-1-200.xml'),
-      array('GET', 'http://example.com/mocks?cursor=2', 'pager/index-2-200.xml'),
-      array('GET', 'http://example.com/mocks?cursor=3', 'pager/index-3-200.xml'),
-    );
-  }
-
   private function assertIteratesCorrectly($pager, $count) {
     // Initialization and enumeration
     $pager->rewind();
@@ -64,26 +55,51 @@ class Recurly_PagerTest extends Recurly_TestCase
   }
 
   public function testFromHref() {
-    $url = '/mocks';
-    $pager = new Mock_Pager($url, $this->client);
-    $pager->_loadFrom($url);
+    $relative_url = '/mocks';
+    $this->client->addResponse('GET', $relative_url, 'pager/index-1-200.xml');
 
-    $this->assertEquals($url, $pager->getHref());
-    $this->assertEquals(6, $pager->count(), 'Returns correct count');
-    $this->assertEquals(6, count($pager), 'Returns correct count');
+    $pager = new Mock_Pager($relative_url, $this->client);
+    $pager->_loadFrom($relative_url);
+
+    // Until we've fetched a second page with a next link we'll keep using the
+    // initial relative URL.
+    $this->assertEquals($relative_url, $pager->getHref());
+    $this->client->addResponse('HEAD', $relative_url, 'pager/head-200.xml');
+    $this->assertEquals(count($pager), 6);
+
+    $this->client->addResponse('GET', 'http://example.com/mocks?cursor=1', 'pager/index-1-200.xml');
+    $this->client->addResponse('GET', 'http://example.com/mocks?cursor=2', 'pager/index-2-200.xml');
+    $this->client->addResponse('GET', 'http://example.com/mocks?cursor=3', 'pager/index-3-200.xml');
     $this->assertIteratesCorrectly($pager, 6);
+
+    // After rewinding we'll be using the start link
+    $this->assertEquals('http://example.com/mocks?cursor=1', $pager->getHref());
+    $this->client->addResponse('HEAD', 'http://example.com/mocks?cursor=1', 'pager/head-200.xml');
+    $this->assertEquals(count($pager), 6);
   }
 
   public function testFromStub() {
-    $url = '/mocks';
-    $stub = new Recurly_Stub('mocks', $url, $this->client);
-    $pager = $stub->get();
+    $relative_url = '/mocks';
+    $this->client->addResponse('GET', $relative_url, 'pager/index-1-200.xml');
+
+    $pager = (new Recurly_Stub('mocks', $relative_url, $this->client))->get();
     $this->assertInstanceOf('Mock_Pager', $pager);
 
-    $this->assertEquals($url, $pager->getHref());
-    $this->assertEquals($pager->count(), 6, 'Returns correct count');
-    $this->assertEquals(count($pager), 6, 'Returns correct count');
+    // Until we've fetched a second page with a next link we'll keep using the
+    // initial relative URL.
+    $this->assertEquals($relative_url, $pager->getHref());
+    $this->client->addResponse('HEAD', $relative_url, 'pager/head-200.xml');
+    $this->assertEquals(count($pager), 6);
+
+    $this->client->addResponse('GET', 'http://example.com/mocks?cursor=1', 'pager/index-1-200.xml');
+    $this->client->addResponse('GET', 'http://example.com/mocks?cursor=2', 'pager/index-2-200.xml');
+    $this->client->addResponse('GET', 'http://example.com/mocks?cursor=3', 'pager/index-3-200.xml');
     $this->assertIteratesCorrectly($pager, 6);
+
+    // After rewinding we'll be using the start link
+    $this->assertEquals('http://example.com/mocks?cursor=1', $pager->getHref());
+    $this->client->addResponse('HEAD', 'http://example.com/mocks?cursor=1', 'pager/head-200.xml');
+    $this->assertEquals(count($pager), 6, 'Count works after iterating');
   }
 
   public function testFromNested() {
@@ -95,8 +111,8 @@ class Recurly_PagerTest extends Recurly_TestCase
     $this->assertInstanceOf('Mock_Pager', $pager);
 
     $this->assertNull($pager->getHref(), "Nested records shouldn't have a URL");
-    $this->assertEquals(4, $pager->count(), 'Returns correct count');
-    $this->assertEquals(4, count($pager), 'Returns correct count');
+    $this->assertEquals(4, count($pager));
     $this->assertIteratesCorrectly($pager, 4);
+    $this->assertEquals(4, count($pager), 'Count is unchanged after iterating');
   }
 }

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -239,8 +239,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
 
     $redemptions = $subscription->redemptions->get();
-
-    $this->assertEquals(2, $redemptions->count());
+    $this->assertEquals('https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/redemptions', $redemptions->getHref());
 
     foreach($redemptions as $r) {
       $this->assertInstanceOf('Recurly_CouponRedemption', $r);

--- a/Tests/fixtures/accounts/index-200.xml
+++ b/Tests/fixtures/accounts/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 42
 Link: <https://api.recurly.com/v2/accounts?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/export_dates/index-200.xml
+++ b/Tests/fixtures/export_dates/index-200.xml
@@ -1,7 +1,6 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 X-Api-Version: 2.4
-X-Records: 1
 
 <export_dates type="array">
   <export_date>

--- a/Tests/fixtures/export_files/index-200.xml
+++ b/Tests/fixtures/export_files/index-200.xml
@@ -1,7 +1,6 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
 X-Api-Version: 2.4
-X-Records: 1
 
 <export_files href="https://api.recurly.com/v2/export_dates/2016-08-01/export_files">
   <export_file href="https://api.recurly.com/v2/export_dates/2016-08-01/export_files/revenue_schedules_full.csv">

--- a/Tests/fixtures/gift_cards/index-200.xml
+++ b/Tests/fixtures/gift_cards/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 42
 Link: <https://api.recurly.com/v2/gift_cards?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/gift_cards?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/invoices/index-200.xml
+++ b/Tests/fixtures/invoices/index-200.xml
@@ -1,5 +1,4 @@
 HTTP/1.1 200 OK
-X-Records: 3
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/measured_units/index-200.xml
+++ b/Tests/fixtures/measured_units/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 2
 
 <?xml version="1.0" encoding="UTF-8"?>
 <measured_units>

--- a/Tests/fixtures/notes/index-200.xml
+++ b/Tests/fixtures/notes/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 2
 Link: <https://api.recurly.com/v2/accounts/abcdef1234567890/notes?cursor=1234567890&per_page=20>; rel="start", <https://api.recurly.com/v2/accounts/abcdef1234567890/notes?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/pager/head-200.xml
+++ b/Tests/fixtures/pager/head-200.xml
@@ -1,4 +1,3 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 33
-
+X-Records: 6

--- a/Tests/fixtures/pager/index-1-200.xml
+++ b/Tests/fixtures/pager/index-1-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 6
 Link: <http://example.com/mocks?cursor=2>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/pager/index-2-200.xml
+++ b/Tests/fixtures/pager/index-2-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 6
 Link: <http://example.com/mocks?cursor=1>; rel="start", <http://example.com/mocks?cursor=1>; rel="prev", <http://example.com/mocks?cursor=3>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/pager/index-3-200.xml
+++ b/Tests/fixtures/pager/index-3-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 6
 Link: <http://example.com/mocks?cursor=1>; rel="start", <http://example.com/mocks?cursor=2>; rel="prev"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/subscriptions/index-200.xml
+++ b/Tests/fixtures/subscriptions/index-200.xml
@@ -1,5 +1,4 @@
 HTTP/1.1 200 OK
-X-Records: 5
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/transactions/index-200.xml
+++ b/Tests/fixtures/transactions/index-200.xml
@@ -1,5 +1,4 @@
 HTTP/1.1 200 OK
-X-Records: 5
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/fixtures/unique_coupons/generate-201.xml
+++ b/Tests/fixtures/unique_coupons/generate-201.xml
@@ -1,5 +1,4 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 2
 Link: <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="start", <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="next"
 Location: https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20

--- a/Tests/fixtures/unique_coupons/index-200.xml
+++ b/Tests/fixtures/unique_coupons/index-200.xml
@@ -1,6 +1,5 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-Records: 2
 Link: <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="start", <https://api.recurly.com/v2/coupons/fifteen-off/unique_coupon_codes?cursor=1234566890&per_page=20>; rel="next"
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -16,7 +16,7 @@ abstract class Recurly_Base
 
   /**
    * Request the URI, validate the response and return the object.
-   * @param string Resource URI, if not fully qualified, the base URL will be appended
+   * @param string Resource URI, if not fully qualified, the base URL will be prepended
    * @param string Optional client for the request, useful for mocking the client
    */
   public static function _get($uri, $client = null)
@@ -30,8 +30,23 @@ abstract class Recurly_Base
   }
 
   /**
+   * Send a HEAD request to the URI, validate the response and return the headers.
+   * @param string Resource URI, if not fully qualified, the base URL will be prepended
+   * @param string Optional client for the request, useful for mocking the client
+   */
+  public static function _head($uri, $client = null)
+  {
+    if (is_null($client)) {
+      $client = new Recurly_Client();
+    }
+    $response = $client->request(Recurly_Client::HEAD, $uri);
+    $response->assertValidResponse();
+    return $response->headers;
+  }
+
+  /**
    * Post to the URI, validate the response and return the object.
-   * @param string Resource URI, if not fully qualified, the base URL will be appended
+   * @param string Resource URI, if not fully qualified, the base URL will be prepended
    * @param string Data to post to the URI
    * @param string Optional client for the request, useful for mocking the client
    */
@@ -49,7 +64,7 @@ abstract class Recurly_Base
 
   /**
    * Put to the URI, validate the response and return the object.
-   * @param string Resource URI, if not fully qualified, the base URL will be appended
+   * @param string Resource URI, if not fully qualified, the base URL will be prepended
    * @param string Optional client for the request, useful for mocking the client
    */
   protected static function _put($uri, $client = null)

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -150,6 +150,10 @@ class Recurly_Client
       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
       curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
     }
+    else if ('HEAD' == $method)
+    {
+      curl_setopt($ch, CURLOPT_NOBODY, TRUE);
+    }
     else if('GET' != $method)
     {
       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -9,25 +9,25 @@
 abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
 {
   private $_position = 0;    // position within the current page
-  protected $_count = null;  // total number of records
   protected $_objects;       // current page of records
 
   /**
-   * Number of records in this list.
+   * If the pager has a URL this will send a HEAD request to get the count of
+   * all records. Otherwise it'll return the count of the cached _objects.
+   *
    * @return integer number of records in list
    */
   public function count() {
-    if (!isset($this->_count)) {
-      if (isset($this->_objects)) {
-        $this->_count = count($this->_objects);
-      } elseif (isset($this->_href)) {
-        // Don't bother with the HEAD request the server takes the same amount
-        // of time to generate them so, might as well just get the results at
-        // the same time.
-        $this->_loadFrom($this->_href);
+    if (isset($this->_href)) {
+      $headers = Recurly_Base::_head($this->_href, $this->_client);
+      if (isset($headers['X-Records'])) {
+        return intval($headers['X-Records']);
       }
+    } elseif (isset($this->_objects) && is_array($this->_objects)) {
+      return count($this->_objects);
     }
-    return $this->_count;
+
+    return null;
   }
 
   /**
@@ -45,8 +45,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   public function current()
   {
     // Work around pre-PHP 5.5 issue that prevents `empty($this->count())`:
-    if ($this->count() == 0) {
-      return null;
+    if (!isset($this->_objects)) {
+      $this->_loadFrom($this->_href);
     }
 
     if ($this->_position >= sizeof($this->_objects)) {
@@ -100,7 +100,6 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   }
 
   protected function _afterParseResponse($response, $uri) {
-    $this->_loadRecordCount($response);
     $this->_loadLinks($response);
     $this->_href = isset($this->_links['start']) ? $this->_links['start'] : $uri;
   }
@@ -131,24 +130,11 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
     }
   }
 
-  /**
-   * Find the total number of results in the collection from the 'X-Records' header.
-   */
-  private function _loadRecordCount($response)
-  {
-    if (isset($response->headers['X-Records'])) {
-      $this->_count = intval($response->headers['X-Records']);
-    }
-  }
-
   protected function updateErrorAttributes() {}
-
 
   public function __toString()
   {
     $class = get_class($this);
-    $count = (!empty($this->_count) ? "count={$this->_count}" : '');
-
-    return "<{$class}[href={$this->getHref()}] $count>";
+    return "<{$class}[href={$this->getHref()}]>";
   }
 }


### PR DESCRIPTION
This is for API v2.6.

The X-Records header was removed on all GET index endpoints. You must
now call HEAD explicitly to get the header and thus the count.

For instance, say you want to get the count of all Accounts in your site:

```php
$accounts = Recurly_AccountList::get();
print $accounts->count() . "\n"; // 1033
```

This only works when the internal `_objects` array is empty. Calling `->current()` or any other method that loads the page into memory will change the behavior of this method to return the count of the page:

```php
$accounts = Recurly_AccountList::get();
print $accounts->count() . "\n"; // 1033
$accounts->current();
print $accounts->count() . "\n"; // 50
```
