### PR TITLE
Remove 5.3 Support and upgrade Travis to support HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.3
   - hhvm
 sudo: false
+dist: trusty
 install:
   - composer install --dev
 script: vendor/phpunit/phpunit/phpunit Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
   - hhvm
 sudo: false
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ be careful when upgrading.
 
 ###cURL and OpenSSL
 
-The PHP library depends on PHP 5.3.0 (or higher) and libcurl compiled with
+The PHP library depends on PHP 5.4.0 (or higher) and libcurl compiled with
 OpenSSL support. Open up a `phpinfo();` page and verify that under the curl
 section, there's a line that says something like:
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": ">= 5.3.0",
+        "php": ">= 5.4.0",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
HHVM is no longer supported on Ubuntu Precise. This is needed to get the tests to run again.