### PR TITLE
Bump 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.8.1 (July 14th, 2017)
+
+This bumps us to API v2.7 but does not contain any breaking changes.
+
+* Bump API v2.7 (purchase endpoint updates) [#319](https://github.com/recurly/recurly-client-php/pull/319)
+* Enhancement: Enable IntelliSense (IDE friendly) for class properties (Part 2) Invoice and Subscription (thanks to @phpdave) [#279](https://github.com/recurly/recurly-client-php/pull/279)
+
 ## Version 2.8.0 (June 7th, 2017)
 
 No changes from 2.8.0.rc1

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's an example of a dependency on 2.7:
 ```json
 {
     "require": {
-        "recurly/recurly-client": "2.7.*"
+        "recurly/recurly-client": "2.8.*"
     }
 }
 ```

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.8.0';
+  const API_CLIENT_VERSION = '2.8.1';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
This bumps us to API v2.7 but does not contain any breaking changes.

* Bump API v2.7 (purchase endpoint updates) [#319](https://github.com/recurly/recurly-client-php/pull/319)
* Enhancement: Enable IntelliSense (IDE friendly) for class properties (Part 2) Invoice and Subscription (thanks to @phpdave) [#279](https://github.com/recurly/recurly-client-php/pull/279)