### PR TITLE
Add writeable imported_trial bool to subscription

### DIFF
--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -41,6 +41,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->net_terms = 10;
     $subscription->collection_method = 'manual';
     $subscription->po_number = '1000';
+    $subscription->imported_trial = true;
 
     $account = new Recurly_Account();
     $account->account_code = '123';
@@ -48,7 +49,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->account = $account;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code><address></address></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons></subscription_add_ons><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code><address></address></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons></subscription_add_ons><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method><imported_trial>true</imported_trial></subscription>\n",
       $subscription->xml()
   );
   }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -26,6 +26,7 @@
  * @property string $add_on_code The code for the Add-On.
  * @property string $usage_percentage If add_on_type = usage and usage_type = percentage, you can set a custom usage_percentage for the subscription add-on. Must be between 0.0000 and 100.0000.
  * @property string $revenue_schedule_type Optional field for setting a revenue schedule type. This will determine how revenue for the associated Subscription Add-On should be recognized. When creating a Subscription Add-On, available schedule types are never, evenly, at_range_start, or at_range_end. If no revenue_schedule_type is set, the Subscription Add-On will inherit the revenue_schedule_type from its Plan Add-On.
+ * @property boolean $imported_trial Optionally set true to denote that this subscription was imported from a trial.
  */
 class Recurly_Subscription extends Recurly_Resource
 {
@@ -168,7 +169,7 @@ class Recurly_Subscription extends Recurly_Resource
       'collection_method', 'cost_in_cents', 'remaining_billing_cycles', 'bulk',
       'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
       'bank_account_authorized_at', 'revenue_schedule_type', 'gift_card',
-      'shipping_address', 'shipping_address_id'
+      'shipping_address', 'shipping_address_id', 'imported_trial'
     );
   }
 }


### PR DESCRIPTION
This is an API v2.8 change and is thus going into the `api_version_2_8` branch.

This allows the merchant to tag a subscription being imported as a trial to ensure Recurly's trial conversion report does not include it as a true trial and instead as an active subscription.