### PR TITLE
Custom Invoice notes on Purchase

### DIFF
--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -13,6 +13,9 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = new Recurly_Purchase();
     $purchase->currency = 'USD';
     $purchase->collection_method = 'automatic';
+    $purchase->customer_notes = 'Customer Notes';
+    $purchase->terms_and_conditions = 'Terms and Conditions';
+    $purchase->vat_reverse_charge_notes = 'VAT Reverse Charge Notes';
     $purchase->account = new Recurly_Account();
     $purchase->account->account_code = 'aba9209a-aa61-4790-8e61-0a2692435fee';
     $purchase->account->address->phone = "555-555-5555";
@@ -39,7 +42,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = $this->mockPurchase();
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency></purchase>\n",
+      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes></purchase>\n",
       $purchase->xml()
     );
   }

--- a/lib/recurly/purchase.php
+++ b/lib/recurly/purchase.php
@@ -10,6 +10,9 @@
  * @property string[] $coupon_codes An array of coupon codes to apply to the purchase
  * @property Recurly_Subscription[] $subscriptions An array of subscriptions to apply to the purchase
  * @property Recurly_GiftCard $gift_card A gift card to apply to the purchase
+ * @property string $customer_notes Optional notes field. This will default to the Customer Notes text specified on the Invoice Settings page in your Recurly admin. Custom notes made on an invoice for a one time charge will not carry over to subsequent invoices.
+ * @property string $terms_and_conditions Optional Terms and Conditions field. This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Custom notes will stay with a subscription on all renewals.
+ * @property string $vat_reverse_charge_notes Optional VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription. Custom notes will stay with a subscription on all renewals.
  */
 class Recurly_Purchase extends Recurly_Resource
 {
@@ -45,7 +48,8 @@ class Recurly_Purchase extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'account', 'adjustments', 'collection_method', 'currency', 'po_number',
-      'net_terms', 'subscriptions', 'gift_card', 'coupon_codes'
+      'net_terms', 'subscriptions', 'gift_card', 'coupon_codes', 'customer_notes',
+      'terms_and_conditions', 'vat_reverse_charge_notes'
     );
   }
 }


### PR DESCRIPTION
This is going into the API v2.8 branch. Adds 3 custom invoice notes to the `Purchase` resource.