### PR TITLE
Bump 2.9.0, API version 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This release will upgrade us to API version 2.8.
 
 ### Upgrade Notes
 
-There is one breaking changes in this API version you must consider. All `country` fields must now contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html).  If your code fails validation, you will receive a validation error. This affects any endpoint where an address is collected.
+There is one breaking changes in this API version you must consider. All `country` fields must now contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html).  If your country code fails validation, you will receive a validation error. This affects any endpoint where an address is collected.
 
 ## Version 2.8.2 (July 21th, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ This release will upgrade us to API version 2.8.
 
 ### Upgrade Notes
 
-There is one breaking changes in this API version you must consider. All `country` fields must now
-contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html).
-If your code fails validation, you will receive a validation error.
-This affects any endpoint where an address is collected.
+There is one breaking changes in this API version you must consider. All `country` fields must now contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html).  If your code fails validation, you will receive a validation error. This affects any endpoint where an address is collected.
 
 ## Version 2.8.2 (July 21th, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.9.0 (October 6th, 2017)
+
+This release will upgrade us to API version 2.8.
+
+- Added custom invoice notes to `Purchase` [#332](https://github.com/recurly/recurly-client-php/pull/332)
+- Added `imported_trial` boolean field to `Subscription` [#331](https://github.com/recurly/recurly-client-php/pull/331)
+
+### Upgrade Notes
+
+There is one breaking changes in this API version you must consider. All `country` fields must now
+contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html).
+If your code fails validation, you will receive a validation error.
+This affects any endpoint where an address is collected.
+
 ## Version 2.8.2 (July 21th, 2017)
 
 * Fixes a bug creating subscriptions for existing accounts (thanks to @g30rg) [#326](https://github.com/recurly/recurly-client-php/pull/326)

--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -13,6 +13,9 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = new Recurly_Purchase();
     $purchase->currency = 'USD';
     $purchase->collection_method = 'automatic';
+    $purchase->customer_notes = 'Customer Notes';
+    $purchase->terms_and_conditions = 'Terms and Conditions';
+    $purchase->vat_reverse_charge_notes = 'VAT Reverse Charge Notes';
     $purchase->account = new Recurly_Account();
     $purchase->account->account_code = 'aba9209a-aa61-4790-8e61-0a2692435fee';
     $purchase->account->address->phone = "555-555-5555";
@@ -39,7 +42,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = $this->mockPurchase();
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency></purchase>\n",
+      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes></purchase>\n",
       $purchase->xml()
     );
   }

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -41,6 +41,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->net_terms = 10;
     $subscription->collection_method = 'manual';
     $subscription->po_number = '1000';
+    $subscription->imported_trial = true;
 
     $account = new Recurly_Account();
     $account->account_code = '123';
@@ -48,7 +49,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->account = $account;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code><address></address></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons></subscription_add_ons><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code><address></address></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons></subscription_add_ons><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method><imported_trial>true</imported_trial></subscription>\n",
       $subscription->xml()
   );
   }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.8.2';
+  const API_CLIENT_VERSION = '2.9.0';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.7';
+  public static $apiVersion = '2.8';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/purchase.php
+++ b/lib/recurly/purchase.php
@@ -10,6 +10,9 @@
  * @property string[] $coupon_codes An array of coupon codes to apply to the purchase
  * @property Recurly_Subscription[] $subscriptions An array of subscriptions to apply to the purchase
  * @property Recurly_GiftCard $gift_card A gift card to apply to the purchase
+ * @property string $customer_notes Optional notes field. This will default to the Customer Notes text specified on the Invoice Settings page in your Recurly admin. Custom notes made on an invoice for a one time charge will not carry over to subsequent invoices.
+ * @property string $terms_and_conditions Optional Terms and Conditions field. This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Custom notes will stay with a subscription on all renewals.
+ * @property string $vat_reverse_charge_notes Optional VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription. Custom notes will stay with a subscription on all renewals.
  */
 class Recurly_Purchase extends Recurly_Resource
 {
@@ -45,7 +48,8 @@ class Recurly_Purchase extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'account', 'adjustments', 'collection_method', 'currency', 'po_number',
-      'net_terms', 'subscriptions', 'gift_card', 'coupon_codes'
+      'net_terms', 'subscriptions', 'gift_card', 'coupon_codes', 'customer_notes',
+      'terms_and_conditions', 'vat_reverse_charge_notes'
     );
   }
 }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -26,6 +26,7 @@
  * @property string $add_on_code The code for the Add-On.
  * @property string $usage_percentage If add_on_type = usage and usage_type = percentage, you can set a custom usage_percentage for the subscription add-on. Must be between 0.0000 and 100.0000.
  * @property string $revenue_schedule_type Optional field for setting a revenue schedule type. This will determine how revenue for the associated Subscription Add-On should be recognized. When creating a Subscription Add-On, available schedule types are never, evenly, at_range_start, or at_range_end. If no revenue_schedule_type is set, the Subscription Add-On will inherit the revenue_schedule_type from its Plan Add-On.
+ * @property boolean $imported_trial Optionally set true to denote that this subscription was imported from a trial.
  */
 class Recurly_Subscription extends Recurly_Resource
 {
@@ -168,7 +169,7 @@ class Recurly_Subscription extends Recurly_Resource
       'collection_method', 'cost_in_cents', 'remaining_billing_cycles', 'bulk',
       'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
       'bank_account_authorized_at', 'revenue_schedule_type', 'gift_card',
-      'shipping_address', 'shipping_address_id'
+      'shipping_address', 'shipping_address_id', 'imported_trial'
     );
   }
 }


### PR DESCRIPTION
This release will upgrade us to API version 2.8.

- Added custom invoice notes to `Purchase` [#332](https://github.com/recurly/recurly-client-php/pull/332)
- Added `imported_trial` boolean field to `Subscription` [#331](https://github.com/recurly/recurly-client-php/pull/331)

### Upgrade Notes

There is one breaking changes in this API version you must consider. All `country` fields must now
contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html). If your country code fails validation, you will receive a validation error. This affects any endpoint where an address is collected.
