### PR TITLE
Adds documentation for subscriptions links

### DIFF
--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -4,6 +4,7 @@
  * @property Recurly_Stub $account
  * @property Recurly_Address $address
  * @property Recurly_Stub $subscription
+ * @property Recurly_Stub $subscriptions
  * @property string $uuid
  * @property string $state
  * @property int $invoice_number

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -5,6 +5,7 @@
  * @property Recurly_Stub $account The URL of the account associated with the transaction.  Run get() to pull back a Recurly_Account
  * @property Recurly_Stub $invoice The URL of the invoice associated with the transaction.  Run get() to pull back a Recurly_Invoice
  * @property Recurly_Stub $subscription The URL of the subscription associated with the transaction.  Run get() to pull back a Recurly_Subscription
+ * @property Recurly_Stub $subscriptions The URL of the subscriptions associated with the transaction.
  * @property string $original_transaction For refund transactions, the URL of the original transaction.  Run get() to pull back a Recurly_Transaction
  * @property string $action purchase, verify or refund.
  * @property integer $amount_in_cents Total transaction amount in cents.


### PR DESCRIPTION
This adds the documentation for the `subscriptions` links on the `Invoice` and `Transaction`. This was missed in the 2.8 release. Code is not required because links are dynamically created from xml.