### PR TITLE
Ensure compatibility between Recurly_Resource constructors

### DIFF
--- a/Tests/Recurly/AccountBalance_Test.php
+++ b/Tests/Recurly/AccountBalance_Test.php
@@ -8,6 +8,16 @@ class Recurly_AccountBalanceTest extends Recurly_TestCase
     );
   }
 
+  public function testConstructor() {
+    $client = new Recurly_Client;
+    $plan = new Recurly_AccountBalance(null, $client);
+
+    $prop = new ReflectionProperty($plan, '_client');
+    $prop->setAccessible(true);
+
+    $this->assertSame($client, $prop->getValue($plan));
+  }
+
   public function testGet() {
     $balance = Recurly_AccountBalance::get('abcdef1234567890', $this->client);
 

--- a/Tests/Recurly/Addon_Test.php
+++ b/Tests/Recurly/Addon_Test.php
@@ -9,6 +9,16 @@ class Recurly_AddonTest extends Recurly_TestCase
     );
   }
 
+  public function testConstructor() {
+    $client = new Recurly_Client;
+    $plan = new Recurly_Addon(null, $client);
+
+    $prop = new ReflectionProperty($plan, '_client');
+    $prop->setAccessible(true);
+
+    $this->assertSame($client, $prop->getValue($plan));
+  }
+
   public function testDelete() {
     $this->client->addResponse(
       'DELETE',

--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -9,6 +9,16 @@ class Recurly_PlanTest extends Recurly_TestCase
     );
   }
 
+  public function testConstructor() {
+    $client = new Recurly_Client;
+    $plan = new Recurly_Plan(null, $client);
+
+    $prop = new ReflectionProperty($plan, '_client');
+    $prop->setAccessible(true);
+
+    $this->assertSame($client, $prop->getValue($plan));
+  }
+
   public function testGetPlan() {
     $plan = Recurly_Plan::get('silver', $this->client);
 

--- a/lib/recurly/account_balance.php
+++ b/lib/recurly/account_balance.php
@@ -12,8 +12,8 @@ class Recurly_AccountBalance extends Recurly_Resource
     return Recurly_Base::_get(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_BALANCE, $client);
   }
 
-  function __construct() {
-    parent::__construct();
+  function __construct($href = null, $client = null) {
+    parent::__construct($href, $client);
     $this->balance_in_cents = new Recurly_CurrencyList('balance_in_cents');
   }
 

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -21,8 +21,8 @@
  */
 class Recurly_Addon extends Recurly_Resource
 {
-  function __construct() {
-    parent::__construct();
+  function __construct($href = null, $client = null) {
+    parent::__construct($href, $client);
     $this->unit_amount_in_cents = new Recurly_CurrencyList('unit_amount_in_cents');
   }
 

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -37,8 +37,8 @@
  */
 class Recurly_Plan extends Recurly_Resource
 {
-  function __construct() {
-    parent::__construct();
+  function __construct($href = null, $client = null) {
+    parent::__construct($href, $client);
     $this->setup_fee_in_cents = new Recurly_CurrencyList('setup_fee_in_cents');
     $this->unit_amount_in_cents = new Recurly_CurrencyList('unit_amount_in_cents');
   }


### PR DESCRIPTION
Three sub-classes of `Recurly_Resource` (`Recurly_Plan`, `Recurly_Addon`, and `Recurly_AccountBalance`) use overload their parents' `__construct()` methods, but do not accept arguments. This makes it impossible to use mocked `Recurly_Client` objects during testing when working with these three resources, meaning tests can't run without actually calling the Recurly API.

This PR ensures that these resources can accept `$href` and `$client` arguments, passing them through to the parent constructor.