### PR TITLE
API Version 2.9

### DIFF
--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -105,4 +105,16 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $billing_info->create();
   }
 
+  public function testForExternalHppType() {
+    $billing_info = new Recurly_BillingInfo(null, $this->client);
+    $billing_info->token_id = 'abc123';
+    $billing_info->external_hpp_type = 'adyen';
+
+    $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
+    $this->assertEquals(
+      $billing_info->xml(),
+      "<?xml version=\"1.0\"?>\n<billing_info><token_id>abc123</token_id><external_hpp_type>adyen</external_hpp_type></billing_info>\n"
+    );
+  }
+
 }

--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -6,6 +6,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     return array(
       array('POST', '/purchases', 'purchases/create-201.xml'),
       array('POST', '/purchases/preview', 'purchases/preview-200.xml'),
+      array('POST', '/purchases/authorize', 'purchases/authorize-200.xml'),
     );
   }
 
@@ -25,6 +26,8 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase->account->address->state = "CA";
     $purchase->account->address->zip = "94110";
     $purchase->account->address->country = "US";
+    $purchase->account->billing_info = new Recurly_BillingInfo();
+    $purchase->account->billing_info->token_id = '7z6furn4jvb9';
 
     $adjustment = new Recurly_Adjustment();
     $adjustment->product_code = "abcd123";
@@ -42,7 +45,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = $this->mockPurchase();
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes></purchase>\n",
+      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><billing_info><token_id>7z6furn4jvb9</token_id></billing_info><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes></purchase>\n",
       $purchase->xml()
     );
   }
@@ -62,6 +65,17 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Invoice', $invoice);
     $this->assertNull($invoice->uuid);
   }
+
+  public function testAuthorizePurchase() {
+    $purchase = $this->mockPurchase();
+    $purchase->account->email = 'benjamin.dumonde@example.com';
+    $purchase->account->billing_info->external_hpp_type = 'adyen';
+    $invoice = Recurly_Purchase::authorize($purchase, $this->client);
+
+    $this->assertInstanceOf('Recurly_Invoice', $invoice);
+    $this->assertNull($invoice->uuid);
+  }
+
 
   public function testTransactionError() {
     $this->client->addResponse('POST', '/purchases', 'purchases/create-422.xml');

--- a/Tests/fixtures/purchases/authorize-200.xml
+++ b/Tests/fixtures/purchases/authorize-200.xml
@@ -1,0 +1,64 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="">
+  <account href="https://api.recurly.com/v2/accounts/c442b36c-c64f-41d7-b8e1-9c04e7a6ff82"/>
+  <address>
+    <address1>400 Alabama St</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94110</zip>
+    <country>US</country>
+    <phone nil="nil"></phone>
+  </address>
+  <uuid nil="nil"></uuid>
+  <state>open</state>
+  <invoice_number_prefix></invoice_number_prefix>
+  <invoice_number nil="nil"></invoice_number>
+  <po_number nil="nil"></po_number>
+  <vat_number nil="nil"></vat_number>
+  <subtotal_in_cents type="integer">1000</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">1000</total_in_cents>
+  <subtotal_after_discount_in_cents type="integer">1000</subtotal_after_discount_in_cents>
+  <currency>USD</currency>
+  <created_at nil="nil"></created_at>
+  <updated_at nil="nil"></updated_at>
+  <attempt_next_collection_at type="datetime">2017-05-17T16:36:56Z</attempt_next_collection_at>
+  <closed_at nil="nil"></closed_at>
+  <terms_and_conditions nil="nil"></terms_and_conditions>
+  <customer_notes nil="nil"></customer_notes>
+  <recovery_reason nil="nil"></recovery_reason>
+  <net_terms type="integer">0</net_terms>
+  <collection_method>automatic</collection_method>
+  <line_items type="array">
+    <adjustment href="" type="charge">
+      <account href="https://api.recurly.com/v2/accounts/c442b36c-c64f-41d7-b8e1-9c04e7a6ff82"/>
+      <uuid>3d86103d63f614d7aeee8341c98b2655</uuid>
+      <state>pending</state>
+      <description nil="nil"></description>
+      <accounting_code nil="nil"></accounting_code>
+      <product_code>4549449c-5870-4845-b672-1d07f15e87dd</product_code>
+      <origin>debit</origin>
+      <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <discount_in_cents type="integer">0</discount_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">1000</total_in_cents>
+      <currency>USD</currency>
+      <taxable type="boolean">false</taxable>
+      <tax_exempt type="boolean">false</tax_exempt>
+      <tax_code nil="nil"></tax_code>
+      <start_date type="datetime">2017-05-17T16:36:56Z</start_date>
+      <end_date nil="nil"></end_date>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <revenue_schedule_type>at_invoice</revenue_schedule_type>
+    </adjustment>
+  </line_items>
+  <transactions type="array">
+  </transactions>
+</invoice>

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -22,6 +22,7 @@
  * @property string $currency Currency in which invoices will be posted. Only applicable if this account is enrolled in a plan has a different currency than your site's default.
  * @property string $verification_value Security code or CVV, 3-4 digits STRONGLY RECOMMENDED
  * @property string $ip_address Customer's IP address when updating their Billing Information STRONGLY RECOMMENDED
+ * @property string $external_hpp_type Used to indicate payment made out of band via an external service (e.g. Adyen HPP).
  */
 class Recurly_BillingInfo extends Recurly_Resource
 {
@@ -65,7 +66,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       'vat_number', 'number', 'month', 'year', 'verification_value',
       'account_number', 'routing_number', 'account_type',
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
-      'token_id'
+      'token_id', 'external_hpp_type'
     );
   }
 }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.8';
+  public static $apiVersion = '2.9';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/purchase.php
+++ b/lib/recurly/purchase.php
@@ -27,7 +27,7 @@ class Recurly_Purchase extends Recurly_Resource
   }
 
   /**
-   * Send the purchase data to the server and creates a preview invoice. This runs
+   * Send the purchase data to the server and create a preview invoice. This runs
    * the validations but not the transactions.
    *
    * @param Recurly_Purchase Our purchase data.
@@ -35,6 +35,20 @@ class Recurly_Purchase extends Recurly_Resource
    */
   public static function preview($purchase, $client = null) {
     return Recurly_Base::_post('/purchases/preview', $purchase->xml(), $client);
+  }
+
+  /**
+   * Send the purchase data to the server and create an authorized purchase. This runs
+   * the validations but not the transactions. This endpoint will create a
+   * pending purchase that can be activated at a later time once payment
+   * has been completed on an external source (e.g. Adyen's Hosted
+   * Payment Pages).
+   *
+   * @param Recurly_Purchase Our purchase data.
+   * @param RecurlyClient Optional client for the request, useful for mocking the client
+   */
+  public static function authorize($purchase, $client = null) {
+    return Recurly_Base::_post('/purchases/authorize', $purchase->xml(), $client);
   }
 
   public function __construct($href = null, $client = null) {


### PR DESCRIPTION
This PR contains the changes needed to bump to API version 2.9.

1. Adding the `authorize` endpoint for Purchases. You can read about authorize in [the dev docs](https://dev.recurly.com/docs/authorize-purchase). Example:

```php
$purchase = new Recurly_Purchase();
$purchase->currency = 'USD';
$purchase->collection_method = 'automatic';
$purchase->account = new Recurly_Account();
// In this case, email is required
$purchase->account->email = 'benjamin.dumonde@example.com';
$purchase->account->account_code = 'aa61-4790-8e61-0a2692435fee';
$purchase->account->first_name = "Benjamin";
$purchase->account->last_name = "Du Monde";
$purchase->account->address->phone = "555-555-5555";
$purchase->account->address->email = "verena@example.com";
$purchase->account->address->address1 = "123 Main St.";
$purchase->account->address->city = "San Francisco";
$purchase->account->address->state = "CA";
$purchase->account->address->zip = "94110";
$purchase->account->address->country = "US";

$billing_info = new Recurly_BillingInfo();
$billing_info->number = '4111-1111-1111-1111';
$billing_info->month = 12;
$billing_info->year = 2019;
$billing_info->verification_value = '123';
$billing_info->address1 = '400 Alabama St';
$billing_info->city = 'San Francisco';
$billing_info->state = 'CA';
$billing_info->country = 'US';
$billing_info->zip = '94110';
// Tells Recurly that an external payment collection method will be used.
// In this case, Adyen HPP.
$billing_info->external_hpp_type = 'adyen';

$purchase->account->billing_info = $billing_info;

$adjustment = new Recurly_Adjustment();
$adjustment->unit_amount_in_cents = 1000;
$adjustment->quantity = 1;

$purchase->adjustments = array($adjustment);

$subscription = new Recurly_Subscription();
$subscription->plan_code = 'gold1';

try {
  $authorized_invoice = Recurly_Purchase::authorize($purchase);
  print($authorized_invoice);
} catch (Recurly_ValidationError $e) {
  print($e);
} catch (Recurly_Error $e) {
  print($e);
}
```

2. Not a code change, but the `subscription` link on an instance of `Recurly_Adjustment` is now only created if adjustment is originating from a subscription plan charge, setup fee, add on, trial or proration credit. It is no longer created for other adjustments.

3. Also not a code change, but instances of `Recurly_Transaction` and `Recurly_Invoice` no longer have a `subscription` link and you must now use the `subscriptions` link.