### PR TITLE
Removes links to singular subscription

### DIFF
--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -3,7 +3,6 @@
  * class Recurly_Invoice
  * @property Recurly_Stub $account
  * @property Recurly_Address $address
- * @property Recurly_Stub $subscription
  * @property Recurly_Stub $subscriptions
  * @property string $uuid
  * @property string $state

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -4,7 +4,6 @@
  * @property string $uuid Transaction's unique identifier.
  * @property Recurly_Stub $account The URL of the account associated with the transaction.  Run get() to pull back a Recurly_Account
  * @property Recurly_Stub $invoice The URL of the invoice associated with the transaction.  Run get() to pull back a Recurly_Invoice
- * @property Recurly_Stub $subscription The URL of the subscription associated with the transaction.  Run get() to pull back a Recurly_Subscription
  * @property Recurly_Stub $subscriptions The URL of the subscriptions associated with the transaction.
  * @property string $original_transaction For refund transactions, the URL of the original transaction.  Run get() to pull back a Recurly_Transaction
  * @property string $action purchase, verify or refund.


### PR DESCRIPTION
From the v2.9 Release Notes

- Removed deprecated singular <subscription> links. Now only plural
  <subscriptions> links are returned.