### PR TITLE
Release client 2.10.1 / API version 2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.10.1 (April 4th, 2018)
+
+This release will upgrade us to API version 2.11. There are no breaking changes.
+
+* API Version 2.11 [#342](https://github.com/recurly/recurly-client-php/pull/342)
+
 ## Version 2.10.0 (March 19th, 2018)
 
 This release will upgrade us to API version 2.10.

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.10.0';
+  const API_CLIENT_VERSION = '2.10.1';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
This release will upgrade us to API version 2.11. There are no breaking changes.

* API Version 2.11 [#342](https://github.com/recurly/recurly-client-php/pull/342)