### PR TITLE
Client Release 2.10.2 / API version 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.10.2 (May 16th, 2018)
+
+This release will upgrade us to API version 2.12. There are no breaking changes.
+
+* API Version 2.12 [#348](https://github.com/recurly/recurly-client-php/pull/348)
+
 ## Version 2.10.1 (April 4th, 2018)
 
 This release will upgrade us to API version 2.11. There are no breaking changes.

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.10.1';
+  const API_CLIENT_VERSION = '2.10.2';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
 This release will upgrade us to API version 2.12. There are no breaking changes.

* API Version 2.12 [#348](https://github.com/recurly/recurly-client-php/pull/348)
