### PR TITLE
Add all_transactions link to Invoice

### DIFF
--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -17,6 +17,7 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Invoice', $invoice);
     $this->assertInstanceOf('Recurly_Stub', $invoice->account);
     $this->assertInstanceOf('Recurly_Stub', $invoice->subscription);
+    $this->assertInstanceOf('Recurly_Stub', $invoice->all_transactions);
     $this->assertEquals($invoice->state, 'paid');
     $this->assertEquals($invoice->total_in_cents, 2995);
     $this->assertEquals($invoice->getHref(),'https://api.recurly.com/v2/invoices/1001');

--- a/Tests/fixtures/invoices/show-200.xml
+++ b/Tests/fixtures/invoices/show-200.xml
@@ -5,6 +5,7 @@ Content-Type: application/xml; charset=utf-8
 <invoice href="https://api.recurly.com/v2/invoices/1001">
   <account href="https://api.recurly.com/v2/accounts/1"/>
   <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
+  <all_transactions href="https://api.recurly.com/v2/invoices/1001/transactions"/>
   <uuid>012345678901234567890123456789aa</uuid>
   <state>paid</state>
   <invoice_number type="integer">1001</invoice_number>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -4,6 +4,7 @@
  * @property Recurly_Stub $account
  * @property Recurly_Address $address
  * @property Recurly_Stub $subscriptions
+ * @property Recurly_String $all_transactions A link to all transactions on the invoice. Only present if there are more than 500 transactions
  * @property string $uuid
  * @property string $state
  * @property int $invoice_number


### PR DESCRIPTION
This is part of API version 2.13. It adds the documentation for the `all_transactions` link. This link appears if there are more than 500 transactions on the invoice.