### PR TITLE
Allow programmer to set gateway code in purchase

### DIFF
--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -14,6 +14,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
   public function mockPurchase() {
     $purchase = new Recurly_Purchase();
     $purchase->currency = 'USD';
+    $purchase->gateway_code = 'aBcD1234';
     $purchase->collection_method = 'automatic';
     $purchase->customer_notes = 'Customer Notes';
     $purchase->terms_and_conditions = 'Terms and Conditions';
@@ -57,7 +58,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = $this->mockPurchase();
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><billing_info><token_id>7z6furn4jvb9</token_id></billing_info><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address><shipping_addresses><shipping_address><address1>400 Dolores St</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><nickname>Home</nickname><first_name>Dolores</first_name><last_name>Du Monde</last_name></shipping_address></shipping_addresses></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes></purchase>\n",
+      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><billing_info><token_id>7z6furn4jvb9</token_id></billing_info><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address><shipping_addresses><shipping_address><address1>400 Dolores St</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><nickname>Home</nickname><first_name>Dolores</first_name><last_name>Du Monde</last_name></shipping_address></shipping_addresses></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes><gateway_code>aBcD1234</gateway_code></purchase>\n",
       $purchase->xml()
     );
   }

--- a/lib/recurly/purchase.php
+++ b/lib/recurly/purchase.php
@@ -14,6 +14,7 @@
  * @property string $terms_and_conditions Optional Terms and Conditions field. This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Custom notes will stay with a subscription on all renewals.
  * @property string $vat_reverse_charge_notes Optional VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription. Custom notes will stay with a subscription on all renewals.
  * @property integer $shipping_address_id Optional id of an existing ShippingAddress to be applied to all subscriptions and adjustments in purchase.
+ * @property string $gateway_code Optional base36 encoded id for the gateway you wish to use for this transaction.
  */
 class Recurly_Purchase extends Recurly_Resource
 {
@@ -79,7 +80,8 @@ class Recurly_Purchase extends Recurly_Resource
     return array(
       'account', 'adjustments', 'collection_method', 'currency', 'po_number',
       'net_terms', 'subscriptions', 'gift_card', 'coupon_codes', 'customer_notes',
-      'terms_and_conditions', 'vat_reverse_charge_notes', 'shipping_address_id'
+      'terms_and_conditions', 'vat_reverse_charge_notes', 'shipping_address_id',
+      'gateway_code'
     );
   }
 }


### PR DESCRIPTION
For API version 2.13. Allows programmer to set the gateway for a purchase. If this changes, I will follow up with another PR on the `api_version_2_13` branch.