### PR TITLE
[TPE-2561] Support for custom fields

### DIFF
--- a/Tests/Recurly/CustomFieldList_Test.php
+++ b/Tests/Recurly/CustomFieldList_Test.php
@@ -1,0 +1,108 @@
+<?php
+
+class Recurly_CustomFieldListTest extends Recurly_TestCase
+{
+  function asXml($list) {
+    $doc = new DOMDocument("1.0");
+    $list->populateXmlDoc($doc, $doc);
+    return $doc->saveXML(null, LIBXML_NOEMPTYTAG);
+  }
+
+  public function testEmptyListXml() {
+    $list = new Recurly_CustomFieldList();
+    $this->assertEquals("<?xml version=\"1.0\"?>\n", $this->asXml($list));
+  }
+
+  public function testRejectsOtherObjects() {
+    $list = new Recurly_CustomFieldList();
+    try {
+      $list[] = 'foo';
+      $this->fail('Should have thrown an exception');
+    } catch (Exception $e) {
+      $this->assertEquals('value must be an instance of Recurly_CustomField', $e->getMessage());
+    }
+  }
+
+  public function testRejectsUnmatchedName() {
+    $list = new Recurly_CustomFieldList();
+    try {
+      $list['food'] = new Recurly_CustomField('foo', 'bar');
+      $this->fail('Should have thrown an exception');
+    } catch (Exception $e) {
+      $this->assertEquals("key: 'food' does not match fields's name: 'foo'", $e->getMessage());
+    }
+  }
+
+  public function testAssignField() {
+    $field = new Recurly_CustomField();
+    $field->name = 'food';
+    $field->value = 'salsa';
+    $this->assertTrue($field->has_changed());
+    $list = new Recurly_CustomFieldList();
+    $list[] = $field;
+
+    $this->assertEquals('salsa', $list['food']->value);
+    $this->assertEquals("<?xml version=\"1.0\"?>\n<custom_fields><custom_field><name>food</name><value>salsa</value></custom_field></custom_fields>\n", $this->asXml($list));
+  }
+
+  public function testAssignStringValue() {
+    $list = new Recurly_CustomFieldList();
+    $list[] = new Recurly_CustomField('foo', 'bar');
+
+    $this->assertEquals('bar', $list['foo']->value);
+    $this->assertTrue($list['foo']->has_changed());
+    $this->assertEquals("<?xml version=\"1.0\"?>\n<custom_fields><custom_field><name>foo</name><value>bar</value></custom_field></custom_fields>\n", $this->asXml($list));
+  }
+
+  public function testAssignEmptyValue() {
+    $list = new Recurly_CustomFieldList();
+    $list[] = new Recurly_CustomField('empty_value', '');
+
+    $this->assertEquals('', $list['empty_value']->value);
+    $this->assertEquals("<?xml version=\"1.0\"?>\n<custom_fields><custom_field><name>empty_value</name><value></value></custom_field></custom_fields>\n", $this->asXml($list));
+  }
+
+  public function testAssignNilValue() {
+    $list = new Recurly_CustomFieldList();
+    $list[] = new Recurly_CustomField('nil_value', null);
+
+    $this->assertEquals('', $list['nil_value']->value);
+    $this->assertEquals("<?xml version=\"1.0\"?>\n<custom_fields><custom_field><name>nil_value</name><value nil=\"nil\"></value></custom_field></custom_fields>\n", $this->asXml($list));
+  }
+
+  public function testUnset() {
+    $list = new Recurly_CustomFieldList();
+    unset($list['foo']);
+
+    $this->assertTrue(isset($list['foo']));
+    $this->assertEquals(null, $list['foo']->value);
+    $this->assertEquals("<?xml version=\"1.0\"?>\n<custom_fields><custom_field><name>foo</name><value nil=\"nil\"></value></custom_field></custom_fields>\n", $this->asXml($list));
+  }
+
+  public function testIteration() {
+    $list = new Recurly_CustomFieldList();
+    foreach ($list as $field) {
+      $this->fail('Should not have anything to iterate over.');
+    }
+
+    $list[] = new Recurly_CustomField('foo', 'something');
+    $list[] = new Recurly_CustomField('bar', 0);
+
+    $actual = array();
+    foreach ($list as $field) {
+      $this->assertInstanceOf('Recurly_CustomField', $field);
+      $actual[$field->name] = $field->value;
+    }
+    $this->assertEquals(array('foo' => 'something', 'bar' => 0), $actual);
+
+    $list[] = new Recurly_CustomField('foo', null);
+    $list[] = new Recurly_CustomField('baz', '');
+
+    $actual = array();
+    foreach ($list as $field) {
+      $this->assertInstanceOf('Recurly_CustomField', $field);
+      $actual[$field->name] = $field->value;
+    }
+    $this->assertEquals(array('foo' => null, 'bar' => 0, 'baz' => ''), $actual);
+  }
+}

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -31,6 +31,14 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $this->assertEquals('Some VAT Notes', $subscription->vat_reverse_charge_notes);
     $this->assertEquals('plan_free_trial', $subscription->no_billing_info_reason);
 
+    $this->assertInstanceOf('Recurly_CustomFieldList', $subscription->custom_fields);
+    $this->assertCount(2, $subscription->custom_fields);
+    $this->assertEquals(array('shasta', 'license-number'), array_keys((array)$subscription->custom_fields));
+    $this->assertInstanceOf('Recurly_CustomField', $subscription->custom_fields['license-number']);
+    $this->assertEquals($subscription->custom_fields['license-number']->value, '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz');
+    $this->assertInstanceOf('Recurly_CustomField', $subscription->custom_fields['shasta']);
+    $this->assertEquals($subscription->custom_fields['shasta']->value, 'ate my tacos');
+
     # TODO: Should test the rest of the parsing.
   }
 
@@ -97,8 +105,10 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->account = $account;
     $account->billing_info = $billing_info;
 
+    $subscription->custom_fields[] = new Recurly_CustomField("serial_number", "4567-8900-1234");
+
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons><bulk>true</bulk><terms_and_conditions>Some Terms and Conditions</terms_and_conditions><customer_notes>Some Customer Notes</customer_notes><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons><bulk>true</bulk><terms_and_conditions>Some Terms and Conditions</terms_and_conditions><customer_notes>Some Customer Notes</customer_notes><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields></subscription>\n",
       $subscription->xml()
     );
   }

--- a/Tests/fixtures/accounts/show-200.xml
+++ b/Tests/fixtures/accounts/show-200.xml
@@ -18,12 +18,6 @@ Content-Type: application/xml; charset=utf-8
   <vat_number>ST-1937</vat_number>
   <entity_use_code>I</entity_use_code>
   <tax_exempt type="boolean">true</tax_exempt>
-  <has_live_subscription type="boolean">true</has_live_subscription>
-  <has_active_subscription type="boolean">true</has_active_subscription>
-  <has_future_subscription type="boolean">false</has_future_subscription>
-  <has_canceled_subscription type="boolean">false</has_canceled_subscription>
-  <has_past_due_invoice type="boolean">false</has_past_due_invoice>
-  <has_paused_subscription type="boolean">false</has_paused_subscription>
   <preferred_locale>en-US</preferred_locale>
   <address>
     <address1>123 Main St.</address1>
@@ -36,6 +30,23 @@ Content-Type: application/xml; charset=utf-8
   </address>
   <accept_language>en-US</accept_language>
   <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
-  <closed_at nil="nil"></closed_at>
+  <updated_at type="datetime">2018-05-30T17:14:16Z</updated_at>
+  <closed_at nil="nil"/>
+  <custom_fields type="array">
+    <custom_field>
+      <name>cat_name</name>
+      <value>mittens</value>
+    </custom_field>
+    <custom_field>
+      <name>shasta</name>
+      <value>ate my hamburger</value>
+    </custom_field>
+  </custom_fields>
+  <has_live_subscription type="boolean">true</has_live_subscription>
+  <has_active_subscription type="boolean">true</has_active_subscription>
+  <has_future_subscription type="boolean">false</has_future_subscription>
+  <has_canceled_subscription type="boolean">false</has_canceled_subscription>
+  <has_past_due_invoice type="boolean">false</has_past_due_invoice>
+  <has_paused_subscription type="boolean">false</has_paused_subscription>
   <vat_location_valid type="boolean">true</vat_location_valid>
 </account>

--- a/Tests/fixtures/subscriptions/show-200.xml
+++ b/Tests/fixtures/subscriptions/show-200.xml
@@ -46,6 +46,16 @@ Content-Type: application/xml; charset=utf-8
       <usage_percentage nil="nil"/>
     </subscription_add_on>
   </subscription_add_ons>
+  <custom_fields type="array">
+    <custom_field>
+      <name>shasta</name>
+      <value>ate my tacos</value>
+    </custom_field>
+    <custom_field>
+      <name>license-number</name>
+      <value>0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz</value>
+    </custom_field>
+  </custom_fields>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/terminate" method="put"/>
 </subscription>

--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -28,6 +28,8 @@ require_once(dirname(__FILE__) . '/recurly/coupon.php');
 require_once(dirname(__FILE__) . '/recurly/coupon_list.php');
 require_once(dirname(__FILE__) . '/recurly/credit_payment.php');
 require_once(dirname(__FILE__) . '/recurly/credit_payment_list.php');
+require_once(dirname(__FILE__) . '/recurly/custom_field.php');
+require_once(dirname(__FILE__) . '/recurly/custom_field_list.php');
 require_once(dirname(__FILE__) . '/recurly/unique_coupon_code_list.php');
 require_once(dirname(__FILE__) . '/recurly/export_date.php');
 require_once(dirname(__FILE__) . '/recurly/export_date_list.php');

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -40,6 +40,7 @@ class Recurly_Account extends Recurly_Resource
     if (!is_null($accountCode))
       $this->account_code = $accountCode;
     $this->address = new Recurly_Address();
+    $this->custom_fields = new Recurly_CustomFieldList();
   }
 
   public function &__get($key)
@@ -103,7 +104,7 @@ class Recurly_Account extends Recurly_Resource
       'account_code', 'username', 'first_name', 'last_name', 'vat_number',
       'email', 'company_name', 'accept_language', 'billing_info', 'address',
       'tax_exempt', 'entity_use_code', 'cc_emails', 'shipping_addresses',
-      'preferred_locale'
+      'preferred_locale', 'custom_fields'
     );
   }
   protected function getRequiredAttributes() {

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -201,6 +201,8 @@ abstract class Recurly_Base
     'charge_invoice' => 'Recurly_Invoice',
     'credit_invoice' => 'Recurly_Invoice',
     'currency' => 'Recurly_Currency',
+    'custom_fields' => 'Recurly_CustomFieldList',
+    'custom_field' => 'Recurly_CustomField',
     'credit_invoices' => 'array',
     'credit_payment' => 'Recurly_CreditPayment',
     'credit_payments' => 'Recurly_CreditPaymentList',
@@ -318,7 +320,9 @@ abstract class Recurly_Base
             $node = $node->nextSibling;
             continue;
           }
-        } else if (is_array($object)) {
+        // Would prefer to do `$object instanceof ArrayAccess` but Recurly_CurrencyList
+        // implements that and expects to have its children assigned like `$list->USD = 123`.
+        } else if (is_array($object) || $object instanceof Recurly_CustomFieldList) {
           if ($nodeName == 'error') {
             $object[] = Recurly_Resource::parseErrorNode($node);
             $node = $node->nextSibling;
@@ -427,8 +431,9 @@ abstract class Recurly_Base
     else {
       if ($node_class == 'Recurly_CurrencyList') {
         $new_obj = new $node_class($nodeName);
-      } else
+      } else {
         $new_obj = new $node_class();
+      }
 
       // It may have a type attribute we wish to capture
       $typeAttribute = $node->getAttribute('type');

--- a/lib/recurly/custom_field.php
+++ b/lib/recurly/custom_field.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * An name/value pair.
+ */
+class Recurly_CustomField extends Recurly_Resource
+{
+  function __construct($name = null, $value = null, $client = null) {
+    parent::__construct(null, $client);
+    if (!is_null($name)) $this->name = $name;
+    $this->value = $value;
+  }
+
+  public function has_changed() {
+    return in_array('value', $this->_unsavedKeys);
+  }
+
+  // Need to make this public since Recurly_CustomFieldList doesn't inherit from
+  // Recurly_Resource.
+  public function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {
+    if ($this->has_changed()) {
+      $childNode = $node->appendChild($doc->createElement($this->getNodeName()));
+      parent::populateXmlDoc($doc, $childNode, $obj, $nested);
+    }
+  }
+
+  protected function getNodeName() {
+    return 'custom_field';
+  }
+
+  protected function getRequiredAttributes() {
+    return array('name');
+  }
+
+  protected function getWriteableAttributes() {
+    return array('name', 'value');
+  }
+}
+

--- a/lib/recurly/custom_field_list.php
+++ b/lib/recurly/custom_field_list.php
@@ -1,0 +1,47 @@
+<?php
+
+// Recurly only stores string values so if you have other data types you should
+// explicitly handle the casting/conversion yourself. Null or empty string
+// values are used to clear a value.
+class Recurly_CustomFieldList extends ArrayObject
+{
+  public function offsetSet($index, $value) {
+    if (!$value instanceof Recurly_CustomField) {
+      throw new Exception("value must be an instance of Recurly_CustomField");
+    }
+
+    if (is_null($index)) {
+      $index = $value->name;
+    }
+    else if ($index != $value->name) {
+      throw new Exception("key: '{$index}' does not match fields's name: '{$value->name}'");
+    }
+
+    parent::offsetSet($index, $value);
+  }
+
+  public function offsetUnset($index) {
+    parent::offsetSet($index, new Recurly_CustomField($index, null));
+  }
+
+  public function populateXmlDoc(&$doc, &$node) {
+    $customFieldsNode = $doc->createElement('custom_fields');
+
+    foreach($this->getIterator() as $field) {
+      $field->populateXmlDoc($doc, $customFieldsNode, $field);
+    }
+    // Don't emit anything if there are no children.
+    if ($customFieldsNode->hasChildNodes()) {
+      $node->appendChild($customFieldsNode);
+    }
+  }
+
+  public function __toString() {
+    $values = array();
+    foreach($this->getIterator() as $field) {
+      $values[] = "{$field->name}={$field->value}";
+    }
+    $values = implode($values, ', ');
+    return "<Recurly_CustomFieldList [$values]>";
+  }
+}

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -122,7 +122,9 @@ abstract class Recurly_Resource extends Recurly_Base
     $attributes = $obj->getChangedAttributes($nested);
 
     foreach ($attributes as $key => $val) {
-      if ($val instanceof Recurly_CurrencyList) {
+      // If we get another object that handles its own XML serialization but
+      // doesn't extend Recurly_Resource we should add an interface for this.
+      if ($val instanceof Recurly_CurrencyList || $val instanceof Recurly_CustomFieldList) {
         $val->populateXmlDoc($doc, $node);
       } else if ($val instanceof Recurly_Resource) {
         $attribute_node = $node->appendChild($doc->createElement($key));

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -36,6 +36,7 @@ class Recurly_Subscription extends Recurly_Resource
   public function __construct($href = null, $client = null) {
     parent::__construct($href, $client);
     $this->subscription_add_ons = array();
+    $this->custom_fields = new Recurly_CustomFieldList();
   }
 
   public static function get($uuid, $client = null) {
@@ -207,7 +208,7 @@ class Recurly_Subscription extends Recurly_Resource
       'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
       'bank_account_authorized_at', 'revenue_schedule_type', 'gift_card',
       'shipping_address', 'shipping_address_id', 'imported_trial',
-      'remaining_pause_cycles'
+      'remaining_pause_cycles', 'custom_fields'
     );
   }
 }


### PR DESCRIPTION
```php
// Get a field
$account->custom_fields['cat_name']->value;
// Get all fields
foreach ($account->custom_fields as $field) {
  print "{$field->name} {$field->value}\n";
}

// Set a value
$field = new Recurly_CustomField();
$field->name = 'food';
$field->value = 'salsa';
$account->custom_fields[] = $field;
// or
$account->custom_fields[] = new Recurly_CustomField('food', 'ate my hamburger');

// Clear a value
$account->custom_fields['cat_name']->value = null;
// or
unset($account->custom_fields['cat_name']);
```