### PR TITLE
Update php version info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.2
   - 7.1
   - 7.0
   - 5.6
@@ -11,3 +12,7 @@ dist: trusty
 install:
   - composer install --dev
 script: vendor/phpunit/phpunit/phpunit Tests
+matrix:
+  allow_failures:
+    - php: 5.4
+    - php: 5.5

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ be careful when upgrading.
 
 ### cURL and OpenSSL
 
-The PHP library depends on PHP 5.4.0 (or higher) and libcurl compiled with
+The PHP library depends on PHP 5.6 (or higher) and libcurl compiled with
 OpenSSL support. Open up a `phpinfo();` page and verify that under the curl
 section, there's a line that says something like:
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": ">= 5.4.0",
+        "php": ">= 5.6.0",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Bump the minimum version to 5.6. We will ignore failures in travis below
this version. We are also adding 7.2 to travis tests.