### PR TITLE
Remove deprecated --dev flag to composer install command instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ PHPUnit, then run our existing tests:
 
 ```
 $ curl -s https://getcomposer.org/installer | php
-$ php composer.phar install --dev
+$ php composer.phar install
 $ vendor/phpunit/phpunit/phpunit Tests/
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can run our unit tests by using Composer to install PHPUnit:
 
 ```
 $ curl -s https://getcomposer.org/installer | php
-$ php composer.phar install --dev
+$ php composer.phar install
 $ vendor/bin/phpunit
 ```
 


### PR DESCRIPTION
Using the latest version of composer from https://getcomposer.org/installer yields this message:

```You are using the deprecated option "dev". Dev packages are installed by default now.```

This removes that flag from the instructions in README.md and CONTRIBUTING.md