### PR TITLE
Bump to 2.10.4 / API version 2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.10.4 (August 21st, 2018)
+
+This release will upgrade us to API version 2.14. There are no breaking changes.
+
+* Update php version info [#355](https://github.com/recurly/recurly-client-php/pull/355)
+* Support updating an invoice [#360](https://github.com/recurly/recurly-client-php/pull/360)
+* Fix custom field serialization [#361](https://github.com/recurly/recurly-client-php/pull/361)
+* Support updating custom fields through Subscription#updateNotes [#362](https://github.com/recurly/recurly-client-php/pull/362)
+* Update README [#359](https://github.com/recurly/recurly-client-php/pull/359)
+
 ## Version 2.10.3 (June 26th, 2018)
 
 This release will upgrade us to API version 2.13. There are no breaking changes.

--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -165,4 +165,35 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Transaction', $transaction);
     $this->assertEquals($transaction->status, 'success');
   }
+
+  public function testUpdateInvoice() {
+    $this->client->addResponse('PUT', 'https://api.recurly.com/v2/invoices/1001', 'invoices/show-200-updated-invoice.xml');
+
+    $invoice = Recurly_Invoice::get('1001', $this->client);
+
+    $invoice->address = new Recurly_Address();
+    $invoice->address->first_name = "Spongebob";
+    $invoice->address->last_name = "Squarepants";
+    $invoice->address->name_on_account = 'Patrick Star';
+    $invoice->address->company = 'Krusty Krab';
+    $invoice->address->address1 = '124 Conch Street';
+    $invoice->address->address2 = 'Pineapple';
+    $invoice->address->city = 'Bikini Bottom';
+    $invoice->address->state = 'Dead Eye Gulch';
+    $invoice->address->zip = '96970';
+    $invoice->address->country = 'Pacific Ocean';
+    $invoice->address->phone = '509-990-3551';
+
+    $invoice->po_number = '3699';
+    $invoice->customer_notes = 'Is this the Krusty Krab?';
+    $invoice->terms_and_conditions = 'Never disclose the location of the Krabby Patty secret formula.';
+    $invoice->vat_reverse_charge_notes = "can't be changed when invoice was not a reverse charge";
+    $invoice->net_terms = '60';
+
+    $this->assertEquals(
+      "<?xml version=\"1.0\"?>\n<invoice><address><first_name>Spongebob</first_name><last_name>Squarepants</last_name><name_on_account>Patrick Star</name_on_account><company>Krusty Krab</company><address1>124 Conch Street</address1><address2>Pineapple</address2><city>Bikini Bottom</city><state>Dead Eye Gulch</state><zip>96970</zip><country>Pacific Ocean</country><phone>509-990-3551</phone></address><terms_and_conditions>Never disclose the location of the Krabby Patty secret formula.</terms_and_conditions><customer_notes>Is this the Krusty Krab?</customer_notes><vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes><net_terms>60</net_terms><po_number>3699</po_number></invoice>\n",
+      $invoice->xml()
+    );
+    $invoice->update();
+  }
 }

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -240,6 +240,11 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
 
     $notes = array("customer_notes" => "New Customer Notes", "terms_and_condititions" => "New Terms", "vat_reverse_charge_notes" => "New VAT Notes");
 
+    // You can also update custom fields through this endpoint
+    $cf = $subscription->custom_fields->offsetGet("shasta");
+    $cf->name = "shasta";
+    $cf->value = "did not eat my tacos";
+
     $subscription->updateNotes($notes);
 
     foreach($notes as $key => $value) {

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -241,7 +241,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $notes = array("customer_notes" => "New Customer Notes", "terms_and_condititions" => "New Terms", "vat_reverse_charge_notes" => "New VAT Notes");
 
     // You can also update custom fields through this endpoint
-    $cf = $subscription->custom_fields->offsetGet("shasta");
+    $cf = $subscription->custom_fields["shasta"];
     $cf->name = "shasta";
     $cf->value = "did not eat my tacos";
 

--- a/Tests/fixtures/invoices/show-200-updated-invoice.xml
+++ b/Tests/fixtures/invoices/show-200-updated-invoice.xml
@@ -1,0 +1,119 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="https://api.recurly.com/v2/invoices/1001">
+  <account href="https://api.recurly.com/v2/accounts/1"/>
+  <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
+  <all_transactions href="https://api.recurly.com/v2/invoices/1001/transactions"/>
+  <address>
+    <first_name>Spongebob</first_name>
+    <last_name>Squarepants</last_name>
+    <name_on_account>Patrick Star</name_on_account>
+    <company>Krusty Krab</company>
+    <address1>124 Conch Street</address1>
+    <address2>Pineapple</address2>
+    <city>Bikini Bottom</city>
+    <state>Dead Eye Gulch</state>
+    <zip>96970</zip>
+    <country>Pacific Ocean</country>
+    <phone>509-990-3551</phone>
+  </address>
+  <uuid>012345678901234567890123456789aa</uuid>
+  <state>paid</state>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
+  <po_number>3699</po_number>
+  <vat_number></vat_number>
+  <subtotal_in_cents type="integer">2995</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">2995</total_in_cents>
+  <currency>USD</currency>
+  <created_at type="datetime">2012-05-28T17:44:13Z</created_at>
+  <closed_at type="datetime">2012-05-28T17:44:13Z</closed_at>
+  <net_terms type="integer">60</net_terms>
+  <collection_method>automatic</collection_method>
+  <tax_type>usst</tax_type>
+  <terms_and_conditions>Never disclose the location of the Krabby Patty secret formula.</terms_and_conditions>
+  <customer_notes>Is this the Krusty Krab?</customer_notes>
+  <vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes>
+  <subtotal_after_discount_in_cents type="integer">300</subtotal_after_discount_in_cents>
+  <attempt_next_collection_at nil="nil"></attempt_next_collection_at>
+  <recovery_reason nil="nil"></recovery_reason>
+  <tax_types nil="nil"></tax_types>
+  <line_items type="array">
+    <adjustment href="https://api.recurly.com/v2/adjustments/012345678901234567890123456789ab" type="charge">
+      <account href="https://api.recurly.com/v2/accounts/1"/>
+      <invoice href="https://api.recurly.com/v2/invoices/1001"/>
+      <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
+      <uuid>012345678901234567890123456789ab</uuid>
+      <state>invoiced</state>
+      <description>Silver Plan</description>
+      <accounting_code></accounting_code>
+      <product_code nil="nil"></product_code>
+      <origin>plan</origin>
+      <unit_amount_in_cents type="integer">2995</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <discount_in_cents type="integer">0</discount_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">2995</total_in_cents>
+      <currency>USD</currency>
+      <taxable type="boolean">false</taxable>
+      <start_date type="datetime">2012-05-28T17:44:13Z</start_date>
+      <end_date type="datetime">2013-05-28T17:44:13Z</end_date>
+      <created_at type="datetime">2012-05-28T17:44:13Z</created_at>
+    </adjustment>
+  </line_items>
+  <transactions type="array">
+    <transaction href="https://api.recurly.com/v2/transactions/012345678901234567890123456789ab" type="credit_card">
+      <account href="https://api.recurly.com/v2/accounts/1"/>
+      <invoice href="https://api.recurly.com/v2/invoices/1001"/>
+      <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
+      <uuid>012345678901234567890123456789ab</uuid>
+      <action>purchase</action>
+      <amount_in_cents type="integer">2995</amount_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <currency>USD</currency>
+      <status>success</status>
+      <payment_method>credit_card</payment_method>
+      <reference>12345</reference>
+      <source>subscription</source>
+      <recurring type="boolean">false</recurring>
+      <test type="boolean">true</test>
+      <voidable type="boolean">true</voidable>
+      <refundable type="boolean">true</refundable>
+      <cvv_result code="M">Match</cvv_result>
+      <avs_result code="D">Street address and postal code match.</avs_result>
+      <avs_result_street>Y</avs_result_street>
+      <avs_result_postal>Y</avs_result_postal>
+      <created_at type="datetime">2012-05-28T17:44:13Z</created_at>
+      <details>
+        <account>
+          <account_code>1</account_code>
+          <first_name>John</first_name>
+          <last_name>Doe</last_name>
+          <company nil="nil"></company>
+          <email>john@example.com</email>
+          <billing_info type="credit_card">
+            <first_name nil="nil"></first_name>
+            <last_name nil="nil"></last_name>
+            <address1 nil="nil"></address1>
+            <address2 nil="nil"></address2>
+            <city nil="nil"></city>
+            <state nil="nil"></state>
+            <zip nil="nil"></zip>
+            <country nil="nil"></country>
+            <phone nil="nil"></phone>
+            <vat_number nil="nil"></vat_number>
+            <card_type>Visa</card_type>
+            <year type="integer">2013</year>
+            <month type="integer">1</month>
+            <first_six>411111</first_six>
+            <last_four>1111</last_four>
+          </billing_info>
+        </account>
+      </details>
+      <a name="refund" href="https://api.recurly.com/v2/transactions/012345678901234567890123456789ab" method="delete"/>
+    </transaction>
+  </transactions>
+</invoice>

--- a/Tests/fixtures/subscriptions/show-200-changed-notes.xml
+++ b/Tests/fixtures/subscriptions/show-200-changed-notes.xml
@@ -35,6 +35,16 @@ Content-Type: application/xml; charset=utf-8
       <quantity type="integer">2</quantity>
     </subscription_add_on>
   </subscription_add_ons>
+  <custom_fields type="array">
+    <custom_field>
+      <name>shasta</name>
+      <value>didn't eat my tacos</value>
+    </custom_field>
+    <custom_field>
+      <name>license-number</name>
+      <value>0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz</value>
+    </custom_field>
+  </custom_fields>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/terminate" method="put"/>
 </subscription>

--- a/lib/recurly/address.php
+++ b/lib/recurly/address.php
@@ -2,6 +2,10 @@
 
 /**
  * Class Recurly_Address
+ * @property string $first_name The first name.
+ * @property string $last_name The last name.
+ * @property string $name_on_account The first and last name.
+ * @property string $company The company.
  * @property string $address1 The first street address line.
  * @property string $address2 The second street address line.
  * @property string $city The city.
@@ -16,6 +20,7 @@ class Recurly_Address extends Recurly_Resource {
   }
   protected function getWriteableAttributes() {
     return array(
+      'first_name', 'last_name', 'name_on_account', 'company',
       'address1', 'address2', 'city', 'state',
       'zip', 'country', 'phone'
     );

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.13';
+  public static $apiVersion = '2.14';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.10.3';
+  const API_CLIENT_VERSION = '2.10.4';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -2,28 +2,44 @@
 /**
  * class Recurly_Invoice
  * @property Recurly_Stub $account
- * @property Recurly_Address $address
  * @property Recurly_Stub $subscriptions
- * @property Recurly_String $all_transactions A link to all transactions on the invoice. Only present if there are more than 500 transactions
+ * @property Recurly_Address $address
+ * @property Recurly_ShippingAddress $shipping_address
  * @property string $uuid
  * @property string $state
+ * @property int $invoice_number_prefix
  * @property int $invoice_number
- * @property int $tax_in_cents
- * @property int $total_in_cents
- * @property DateTime $created_at
- * @property DateTime $closed_at
- * @property int $net_terms
- * @property string $collection_method
- * @property int $subtotal_before_discount_in_cents The total of all adjustments on the invoice before discounts or taxes are applied.
+ * @property string $po_number
+ * @property string $vat_number
  * @property int $subtotal_in_cents The total of all adjustments on the invoice after discounts are applied, but before taxes.
  * @property int $discount_in_cents The total of all discounts applied to adjustments on the invoice.
- * @property int $balance_in_cents The total_in_cents minus all successful transactions and credit payments for the invoice.
  * @property DateTime $due_on If type = charge, will have a value that is the created_at plus the terms. If type = credit, will be null.
+ * @property int $balance_in_cents The total_in_cents minus all successful transactions and credit payments for the invoice.
  * @property int $type Whether the invoice is a credit invoice or charge invoice.
  * @property int $origin The event that created the invoice.
- * @property int $credit_customer_notes Allows merchant to set customer notes on a credit invoice. Will only be rejected if type is set to "charge", otherwise will be ignored if no credit invoice is created.
+ * @property Recurly_Stub $credit_invoices
+ * @property int $refundable_total_in_cents
+ * @property array $credit_payments
+ * @property int $tax_in_cents
+ * @property int $total_in_cents
+ * @property string $currency
+ * @property DateTime $created_at
+ * @property DateTime $updated_at
+ * @property DateTime $closed_at
+ * @property string $terms_and_conditions
+ * @property string $vat_reverse_charge_notes
+ * @property string $customer_notes
+ * @property string $tax_type
+ * @property string $tax_region
+ * @property float $tax_rate
+ * @property int $net_terms
+ * @property string $collection_method
+ * @property Recurly_Stub $redemptions
  * @property Recurly_Adjustment[] $line_items
  * @property Recurly_TransactionList $transactions
+ * @property Recurly_String $all_transactions A link to all transactions on the invoice. Only present if there are more than 500 transactions
+ * @property int $subtotal_before_discount_in_cents The total of all adjustments on the invoice before discounts or taxes are applied.
+ * @property int $credit_customer_notes Allows merchant to set customer notes on a credit invoice. Will only be rejected if type is set to "charge", otherwise will be ignored if no credit invoice is created.
  */
 class Recurly_Invoice extends Recurly_Resource
 {
@@ -150,6 +166,13 @@ class Recurly_Invoice extends Recurly_Resource
     return $this->createRefundInvoice($this->renderXML($doc));
   }
 
+  /**
+   * Attempts to update an invoice
+   */
+  public function update() {
+    $this->_save(Recurly_Client::PUT, $this->uri());
+  }
+
   protected function createRefundInvoice($xml_string) {
     return Recurly_Invoice::_post($this->uri() . '/refund', $xml_string, $this->_client);
   }
@@ -159,7 +182,7 @@ class Recurly_Invoice extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return array(
-      'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
+      'address', 'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
       'collection_method', 'net_terms', 'po_number', 'currency', 'credit_customer_notes'
     );
   }


### PR DESCRIPTION
This release will upgrade us to API version 2.14. There are no breaking changes.

* Update php version info [#355](https://github.com/recurly/recurly-client-php/pull/355)
* Support updating an invoice [#360](https://github.com/recurly/recurly-client-php/pull/360)
* Fix custom field serialization [#361](https://github.com/recurly/recurly-client-php/pull/361)
* Support updating custom fields through Subscription#updateNotes [#362](https://github.com/recurly/recurly-client-php/pull/362)
* Update README [#359](https://github.com/recurly/recurly-client-php/pull/359)