### PR TITLE
Change PUT to POST for creating billing info

### DIFF
--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -33,7 +33,7 @@ class Recurly_BillingInfo extends Recurly_Resource
   }
 
   public function create() {
-    $this->update();
+    $this->_save(Recurly_Client::POST, $this->uri());
   }
   public function update() {
     $this->_save(Recurly_Client::PUT, $this->uri());


### PR DESCRIPTION
It is impossible to create billing info via a POST call without this change.

Playground script:

```php
<?php
include './scripts/php/stub.php';

// Assumes account "x" exists on this site
// Assumes gateway_code "jhpqd551excn" is the code for vantiv on this site

try {
  $billing_info = new Recurly_BillingInfo();
  $billing_info->account_code       = 'x';
  $billing_info->first_name         = 'John';
  $billing_info->last_name          = 'Du Monde';
  $billing_info->address1           = '123 Paper Street';
  $billing_info->city               = 'Los Angeles';
  $billing_info->state              = 'CA';
  $billing_info->zip                = '95312';
  $billing_info->country            = 'US';
  $billing_info->phone              = '213-555-5555';
  $billing_info->vat_number         = '54321';
  $billing_info->gateway_token      = '4111115851581111';
  $billing_info->gateway_code       = 'jhpqd551excn';
  $billing_info->card_type          = 'visa';
  $billing_info->month              = '10';
  $billing_info->year               = '2020';
  $billing_info->create();

  print "Billing Info: $billing_info";
} catch (Recurly_ValidationError $e) {
  // The paypal billing agreement provided is invalid
  print "Invalid paypal billing agreement: $e";
} catch (Recurly_NotFoundError $e) {
  // Could not find account
  print "Not Found: $e";
}
catch (Recurly_Error $e) {
    // Could not find account
    print "Bad request: $e";
}
```