### PR TITLE
Bump to version 2.10.5 / API version 2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.10.5 (September 25th, 2018)
+
+This release will upgrade us to API version 2.15. There are no breaking changes.
+
+* Added `scripts` folder [364](https://github.com/recurly/recurly-client-php/pull/364)
+* Provide a correct recurly code when responding with a 404 [366](https://github.com/recurly/recurly-client-php/pull/366)
+* Add support for more webhooks [368](https://github.com/recurly/recurly-client-php/pull/368)
+
 ## Version 2.10.4 (August 21st, 2018)
 
 This release will upgrade us to API version 2.14. There are no breaking changes.

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.10.4';
+  const API_CLIENT_VERSION = '2.10.5';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.14';
+  public static $apiVersion = '2.15';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).


### PR DESCRIPTION
## Version 2.10.5 (September 25th, 2018)

This release will upgrade us to API version 2.15. There are no breaking changes.

* Added `scripts` folder [364](https://github.com/recurly/recurly-client-php/pull/364)
* Provide a correct recurly code when responding with a 404 [366](https://github.com/recurly/recurly-client-php/pull/366)
* Add support for more webhooks [368](https://github.com/recurly/recurly-client-php/pull/368)