### PR TITLE
Add details to error messages to make them more helpful

### DIFF
--- a/Tests/Recurly/Client_Test.php
+++ b/Tests/Recurly/Client_Test.php
@@ -40,4 +40,19 @@ class Recurly_ClientTest extends Recurly_TestCase
     }
     catch (Recurly_ConnectionError $e) {}
   }
+
+  // Test that the <details> tag from a 400 response is appended to the message
+  public function testBadRequestError() {
+    $this->client->addResponse('POST', '/purchases', 'client/bad-request-400.xml');
+
+    try {
+      $purchase = new Recurly_Purchase();
+      $purchase->address = 'something unacceptable';
+
+      $collection = Recurly_Purchase::invoice($purchase, $this->client);
+    }
+    catch(Recurly_Error $e) {
+      $this->assertEquals($e->getMessage(), "The provided XML was invalid. Details: Unacceptable tags <address>");
+    }
+  }
 }

--- a/Tests/fixtures/client/bad-request-400.xml
+++ b/Tests/fixtures/client/bad-request-400.xml
@@ -1,0 +1,9 @@
+HTTP/1.1 400 Bad Request
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+<symbol>invalid_xml</symbol>
+<description>The provided XML was invalid.</description>
+<details>Unacceptable tags &lt;address&gt;</details>
+</error>

--- a/lib/recurly/errors.php
+++ b/lib/recurly/errors.php
@@ -72,13 +72,16 @@ class Recurly_FieldError
   var $field;
   var $symbol;
   var $description;
+  var $details;
   
   public function __toString() {
     if (!empty($this->field) && ($this->__readableField() != 'base')) {
-      return $this->__readableField() . ' ' . $this->description;
+      $details = $this->details ? ' Details: ' . $this->details : '';
+      return $this->__readableField() . ' ' . $this->description . $details;
     }
     else {
-      return $this->description;
+      $details = $this->details ? ' Details: ' . $this->details : '';
+      return $this->description . $details;
     }
   }
   

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -57,7 +57,7 @@ class Recurly_ClientResponse
       case 0:
         throw new Recurly_ConnectionError('An error occurred while connecting to Recurly.');
       case 400:
-        $message = (is_null($error) ? 'Bad API Request' : $error->description);
+        $message = (is_null($error) ? 'Bad API Request' : (string) $error);
         throw new Recurly_Error($message, 0, null, $recurlyCode);
       case 401:
         throw new Recurly_UnauthorizedError('Your API Key is not authorized to connect to Recurly.');
@@ -116,6 +116,9 @@ class Recurly_ClientResponse
           break;
         case 'description':
           $error->description = $node->nodeValue;
+          break;
+        case 'details':
+          $error->details = $node->nodeValue;
           break;
       }
       $node = $node->nextSibling;


### PR DESCRIPTION
When an error comes back from the server, it has a details tag in the XML. For example:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<error>
<symbol>invalid_xml</symbol>
<description>The provided XML was invalid.</description>
<details>Unacceptable tags &lt;address&gt;</details>
</error>
```
Just stating that the provided XML was invalid is rather useless to a developer trying to fix their issues. Adding the detail of the unacceptable tag is much better.

This issue was originally highlighted by #344, which shows an example of where a developer would have been able to fix their issue more easily if they could see the details of the error.
