### PR TITLE
Added missing account_acquisition to writable attributes

### DIFF
--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -102,6 +102,15 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->entity_use_code = 'I';
     $account->preferred_locale = 'en-US';
 
+    $account_acquisition = new Recurly_AccountAcquisition();
+    $account_acquisition->cost_in_cents = 599;
+    $account_acquisition->currency = 'USD';
+    $account_acquisition->channel = 'marketing_content';
+    $account_acquisition->subchannel = 'pickle sticks blog post';
+    $account_acquisition->campaign = 'mailchimp67a904de95.0914d8f4b4';
+
+    $account->account_acquisition = $account_acquisition;
+
     // work shipping address
     $shad1 = new Recurly_ShippingAddress();
     $shad1->nickname = "Work";
@@ -134,7 +143,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->custom_fields[] = new Recurly_CustomField("serial_number", "4567-8900-1234");
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt><entity_use_code>I</entity_use_code><shipping_addresses><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Home</nickname><first_name>Verena</first_name><last_name>Example</last_name></shipping_address></shipping_addresses><preferred_locale>en-US</preferred_locale><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields></account>\n",
+      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt><entity_use_code>I</entity_use_code><shipping_addresses><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Home</nickname><first_name>Verena</first_name><last_name>Example</last_name></shipping_address></shipping_addresses><preferred_locale>en-US</preferred_locale><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields><account_acquisition><cost_in_cents>599</cost_in_cents><currency>USD</currency><channel>marketing_content</channel><subchannel>pickle sticks blog post</subchannel><campaign>mailchimp67a904de95.0914d8f4b4</campaign></account_acquisition></account>\n",
       $account->xml()
     );
   }

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -104,7 +104,7 @@ class Recurly_Account extends Recurly_Resource
       'account_code', 'username', 'first_name', 'last_name', 'vat_number',
       'email', 'company_name', 'accept_language', 'billing_info', 'address',
       'tax_exempt', 'entity_use_code', 'cc_emails', 'shipping_addresses',
-      'preferred_locale', 'custom_fields'
+      'preferred_locale', 'custom_fields', 'account_acquisition'
     );
   }
   protected function getRequiredAttributes() {

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -32,6 +32,7 @@
  * @property DateTime $created_at The date and time the account was created in Recurly.
  * @property DateTime $updated_at The date and time the account or its billing info was last updated.
  * @property DateTime $closed_at For closed accounts, the date and time it was closed.
+ * @property Recurly_AccountAcquisition $account_acquisition The nested account acquisition information: cost_in_cents, currency, channel, subchannel, campaign.
  */
 class Recurly_Account extends Recurly_Resource
 {


### PR DESCRIPTION
As per documentation in https://dev.recurly.com/docs/create-an-account `account_acquisition` parameter is missing in writeable attribute array.

Additional note: there seems to be a mismatch between the client and the documentation concerning `shipping_address` attribute, not sure which is correct.