### PR TITLE
Fix pager->current() breaking when no data

### DIFF
--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -115,4 +115,24 @@ class Recurly_PagerTest extends Recurly_TestCase
     $this->assertIteratesCorrectly($pager, 4);
     $this->assertEquals(4, count($pager), 'Count is unchanged after iterating');
   }
+
+  public function testFromEmpty() {
+    $relative_url = '/mocks';
+    $this->client->addResponse('GET', $relative_url, 'pager/index-empty-200.xml');
+
+    $pager = new Mock_Pager($relative_url, $this->client);
+    $pager->_loadFrom($relative_url);
+
+    $this->assertEquals($pager->current(), null);
+  }
+
+  public function testFromEmptyNested() {
+    $relative_url = '/mocks';
+    $this->client->addResponse('GET', $relative_url, 'pager/show-empty-200.xml');
+
+    $pager = new Mock_Pager($relative_url, $this->client);
+    $pager->_loadFrom($relative_url);
+
+    $this->assertEquals($pager->current(), null);
+  }
 }

--- a/Tests/fixtures/pager/index-empty-200.xml
+++ b/Tests/fixtures/pager/index-empty-200.xml
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<mocks type="array">
+</mocks>

--- a/Tests/fixtures/pager/show-empty-200.xml
+++ b/Tests/fixtures/pager/show-empty-200.xml
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <mocks type="array">
+  </mocks>
+</account>

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -59,6 +59,9 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
         $this->_loadFrom($this->_links['next']);
         $this->_position = 0;
       }
+      else if (empty($this->_objects) && ($this->_position == 0)) {
+        return null;
+      }
       else {
         throw new Recurly_Error("Pager is not in a valid state");
       }


### PR DESCRIPTION
Fixes #354 

Script:
```php
  // 'account' should be a valid account with canceled subscriptions but no live subscriptions
  $subscriptions = Recurly_SubscriptionList::getForAccount('account', ['state' => 'live']);
  print $subscriptions->count() . "\n";
  $sub = $subscriptions->current();
  var_dump($sub);
```
Before this commit, this script would throw an exception. Now it prints
```
0
NULL
```