### PR TITLE
Bump to version 2.10.6 / API version 2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.10.6 (October 30th, 2018)
+
+This release will upgrade us to API version 2.16. There are no breaking changes.
+
+* Added `details` to error messages [372](https://github.com/recurly/recurly-client-php/pull/372)
+* Added `charge` parameter to subscription termination functions [374](https://github.com/recurly/recurly-client-php/pull/374)
+* Fixed errors reported by PHPStorm [375](https://github.com/recurly/recurly-client-php/pull/375)
+* Added `account_acquisition` attribute to `account` [377](https://github.com/recurly/recurly-client-php/pull/377)
+* Fixed pager so it does not break when there is no data [378](https://github.com/recurly/recurly-client-php/pull/378)
+
 ## Version 2.10.5 (September 25th, 2018)
 
 This release will upgrade us to API version 2.15. There are no breaking changes.

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.15';
+  public static $apiVersion = '2.16';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.10.5';
+  const API_CLIENT_VERSION = '2.10.6';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
## Version 2.10.6 (October 30th, 2018)

This release will upgrade us to API version 2.16. There are no breaking changes.

* Added `details` to error messages [372](https://github.com/recurly/recurly-client-php/pull/372)
* Added `charge` parameter to subscription termination functions [374](https://github.com/recurly/recurly-client-php/pull/374)
* Fixed errors reported by PHPStorm [375](https://github.com/recurly/recurly-client-php/pull/375)
* Added `account_acquisition` attribute to `account` [377](https://github.com/recurly/recurly-client-php/pull/377)
* Fixed pager so it does not break when there is no data [378](https://github.com/recurly/recurly-client-php/pull/378)