### PR TITLE
Add gateway_code to subscription and invoice

### DIFF
--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -189,9 +189,10 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $invoice->terms_and_conditions = 'Never disclose the location of the Krabby Patty secret formula.';
     $invoice->vat_reverse_charge_notes = "can't be changed when invoice was not a reverse charge";
     $invoice->net_terms = '60';
+    $invoice->gateway_code = 'A new gateway code';
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<invoice><address><first_name>Spongebob</first_name><last_name>Squarepants</last_name><name_on_account>Patrick Star</name_on_account><company>Krusty Krab</company><address1>124 Conch Street</address1><address2>Pineapple</address2><city>Bikini Bottom</city><state>Dead Eye Gulch</state><zip>96970</zip><country>Pacific Ocean</country><phone>509-990-3551</phone></address><terms_and_conditions>Never disclose the location of the Krabby Patty secret formula.</terms_and_conditions><customer_notes>Is this the Krusty Krab?</customer_notes><vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes><net_terms>60</net_terms><po_number>3699</po_number></invoice>\n",
+      "<?xml version=\"1.0\"?>\n<invoice><address><first_name>Spongebob</first_name><last_name>Squarepants</last_name><name_on_account>Patrick Star</name_on_account><company>Krusty Krab</company><address1>124 Conch Street</address1><address2>Pineapple</address2><city>Bikini Bottom</city><state>Dead Eye Gulch</state><zip>96970</zip><country>Pacific Ocean</country><phone>509-990-3551</phone></address><terms_and_conditions>Never disclose the location of the Krabby Patty secret formula.</terms_and_conditions><customer_notes>Is this the Krusty Krab?</customer_notes><vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes><net_terms>60</net_terms><po_number>3699</po_number><gateway_code>A new gateway code</gateway_code></invoice>\n",
       $invoice->xml()
     );
     $invoice->update();

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -238,7 +238,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
 
     $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
 
-    $notes = array("customer_notes" => "New Customer Notes", "terms_and_condititions" => "New Terms", "vat_reverse_charge_notes" => "New VAT Notes");
+    $notes = array("customer_notes" => "New Customer Notes", "terms_and_condititions" => "New Terms", "vat_reverse_charge_notes" => "New VAT Notes", "gateway_code" => "A new gateway code");
 
     // You can also update custom fields through this endpoint
     $cf = $subscription->custom_fields["shasta"];

--- a/Tests/fixtures/subscriptions/show-200-changed-notes.xml
+++ b/Tests/fixtures/subscriptions/show-200-changed-notes.xml
@@ -27,6 +27,7 @@ Content-Type: application/xml; charset=utf-8
   <terms_and_conditions>New Terms</terms_and_conditions>
   <customer_notes>New Customer Notes</customer_notes>
   <vat_reverse_charge_notes>New VAT Notes</vat_reverse_charge_notes>
+  <gateway_code>A new gateway code</gateway_code>
   <subscription_add_ons type="array">
     <subscription_add_on>
       <name>IP Addresses</name>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -29,6 +29,7 @@
  * @property string $terms_and_conditions
  * @property string $vat_reverse_charge_notes
  * @property string $customer_notes
+ * @property string $gateway_code The unique identifier of a payment gateway used to specify which payment gateway you wish to process this invoices’ payments
  * @property string $tax_type
  * @property string $tax_region
  * @property float $tax_rate
@@ -226,7 +227,8 @@ class Recurly_Invoice extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'address', 'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
-      'collection_method', 'net_terms', 'po_number', 'currency', 'credit_customer_notes'
+      'collection_method', 'net_terms', 'po_number', 'currency', 'credit_customer_notes',
+      'gateway_code'
     );
   }
 

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -42,6 +42,7 @@
  * @property Recurly_CustomFieldList $custom_fields Optional custom fields for the subscription.
  * @property string $uuid Subscription's unique identifier.
  * @property string $timeframe now for immediate, renewal to perform when the subscription renews. Defaults to now.
+ * @property string $gateway_code The unique identifier of a payment gateway used to specify which payment gateway you wish to process this subscriptions’ payments
  */
 class Recurly_Subscription extends Recurly_Resource
 {
@@ -266,7 +267,7 @@ class Recurly_Subscription extends Recurly_Resource
       'bank_account_authorized_at', 'revenue_schedule_type', 'gift_card',
       'shipping_address', 'shipping_address_id', 'imported_trial',
       'remaining_pause_cycles', 'custom_fields', 'auto_renew',
-      'renewal_billing_cycles'
+      'renewal_billing_cycles', 'gateway_code'
     );
   }
 }


### PR DESCRIPTION
Allows `gateway_code` to be updated via the `subscription/notes` endpoint and the `PUT invoice` endpoint

Scripts:
```php
<?php
// Assumes subscription uuid "46c7ddb06e35530669baa445e3926e34" exists
include './scripts/php/stub.php';

$uuid = '46c7ddb06e35530669baa445e3926e34';
$sub = Recurly_Subscription::get($uuid);
$sub->updateNotes(array("gateway_code" => "jvkvq2er456m");
print("\n");
```

```php
$invoice = Recurly_Invoice::get('1001');
$invoice->gateway_code = 'jvm7ol289raz';
$invoice->update();
```