### PR TITLE
Added new method getHeaders(), which will allow to get all response headers after each API call

### DIFF
--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -46,20 +46,21 @@ class Recurly_BaseTest extends Recurly_TestCase {
     $this->assertInstanceOf('Recurly_Stub', $invoice);
     $this->assertEquals(getProtectedProperty($invoice, '_client'), $this->client);
   }
-    public function testCheckIfResponseContainGetHeadersFunction() {
-        $this->client->addResponse('GET', 'accounts', 'accounts/index-200.xml');
-        $accounts = Recurly_Base::_get('accounts', $this->client);
-        $this->assertTrue(method_exists($accounts, 'getHeaders'),"Accounts Class does not have method getHeaders");
-        $this->assertInternalType('array',$accounts->getHeaders());
 
-        $this->client->addResponse('GET', 'subscriptions', 'subscriptions/index-200.xml');
-        $subscriptions = Recurly_Base::_get('subscriptions', $this->client);
-        $this->assertTrue(method_exists($subscriptions, 'getHeaders'),'Subscriptions Class does not have method getHeaders');
-        $this->assertInternalType('array',$subscriptions->getHeaders());
+  public function testCheckIfResponseContainGetHeadersFunction() {
+    $this->client->addResponse('GET', 'accounts', 'accounts/index-200.xml');
+    $accounts = Recurly_Base::_get('accounts', $this->client);
+    $this->assertTrue(method_exists($accounts, 'getHeaders'),"Accounts Class does not have method getHeaders");
+    $this->assertInternalType('array',$accounts->getHeaders());
 
-        $this->client->addResponse('GET', 'abcdef1234567890', 'adjustments/show-200.xml');
-        $adjustment = Recurly_Base::_get('abcdef1234567890', $this->client);
-        $this->assertTrue(method_exists($adjustment, 'getHeaders'),'Adjustments Class does not have method getHeaders');
-        $this->assertInternalType('array',$adjustment->getHeaders());
-    }
+    $this->client->addResponse('GET', 'subscriptions', 'subscriptions/index-200.xml');
+    $subscriptions = Recurly_Base::_get('subscriptions', $this->client);
+    $this->assertTrue(method_exists($subscriptions, 'getHeaders'),'Subscriptions Class does not have method getHeaders');
+    $this->assertInternalType('array',$subscriptions->getHeaders());
+
+    $this->client->addResponse('GET', 'abcdef1234567890', 'adjustments/show-200.xml');
+    $adjustment = Recurly_Base::_get('abcdef1234567890', $this->client);
+    $this->assertTrue(method_exists($adjustment, 'getHeaders'),'Adjustments Class does not have method getHeaders');
+    $this->assertInternalType('array',$adjustment->getHeaders());
+  }
 }

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -46,4 +46,20 @@ class Recurly_BaseTest extends Recurly_TestCase {
     $this->assertInstanceOf('Recurly_Stub', $invoice);
     $this->assertEquals(getProtectedProperty($invoice, '_client'), $this->client);
   }
+    public function testCheckIfResponseContainGetHeadersFunction() {
+        $this->client->addResponse('GET', 'accounts', 'accounts/index-200.xml');
+        $accounts = Recurly_Base::_get('accounts', $this->client);
+        $this->assertTrue(method_exists($accounts, 'getHeaders'),"Accounts Class does not have method getHeaders");
+        $this->assertInternalType('array',$accounts->getHeaders());
+
+        $this->client->addResponse('GET', 'subscriptions', 'subscriptions/index-200.xml');
+        $subscriptions = Recurly_Base::_get('subscriptions', $this->client);
+        $this->assertTrue(method_exists($subscriptions, 'getHeaders'),'Subscriptions Class does not have method getHeaders');
+        $this->assertInternalType('array',$subscriptions->getHeaders());
+
+        $this->client->addResponse('GET', 'abcdef1234567890', 'adjustments/show-200.xml');
+        $adjustment = Recurly_Base::_get('abcdef1234567890', $this->client);
+        $this->assertTrue(method_exists($adjustment, 'getHeaders'),'Adjustments Class does not have method getHeaders');
+        $this->assertInternalType('array',$adjustment->getHeaders());
+    }
 }

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -8,6 +8,7 @@ abstract class Recurly_Base
   protected $_links;
   protected $_values;
   protected $_errors;
+  protected $_headers;
 
   public function __construct($href = null, $client = null)
   {
@@ -177,6 +178,21 @@ abstract class Recurly_Base
     $this->_href = $href;
   }
 
+
+  /**
+   * @param array $headers
+   */
+  private function setHeaders($headers){
+        $this->_headers = $headers;
+  }
+
+  /**
+   * @return array|null
+   */
+  public function getHeaders(){
+      return $this->_headers;
+  }
+
   /** Refers to the `type` root xml attribute **/
   public function getType() {
     return $this->_type;
@@ -277,6 +293,7 @@ abstract class Recurly_Base
     Recurly_Resource::__parseXmlToObject($rootNode->firstChild, $obj);
     if ($obj instanceof self) {
       $obj->_afterParseResponse($response, $uri);
+      $obj->setHeaders($response->headers);
     }
     return $obj;
   }


### PR DESCRIPTION
Added new method getHeaders(), which will allow to get all response headers after each API call, without sending any extra request
fixed issue #276 