### PR TITLE
Release version 2.11.0 / API version 2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Recurly PHP Client Library CHANGELOG
 
-## Unreleased
-* Remove Recurly.js v2 code
+## Version 2.11.0 (December 11th, 2018)
+
+This release will upgrade us to API version 2.17.
+
+* Add `gateway_code` to Subscription and Invoice objects [PR](https://github.com/recurly/recurly-client-php/pull/380)
+* Add `exemption_certificate` to Account object [PR](https://github.com/recurly/recurly-client-php/pull/381)
+* Remove deprecated JS module [PR](https://github.com/recurly/recurly-client-php/pull/382)
+* Add `getHeaders()` method [PR](https://github.com/recurly/recurly-client-php/pull/383)
+* Add OpenSSL version to user agent [PR](https://github.com/recurly/recurly-client-php/pull/384)
 
 ### Upgrade Notes
-
-This release contains the following breaking changes:
-- Older Recurly.js token signing is not longer supported. You should upgrade to version 4 of Recurly.js: https://dev.recurly.com/docs/recurlyjs
+This release contains one breaking change. Older Recurly.js token signing is not longer supported. You should upgrade to version 4 of Recurly.js: https://dev.recurly.com/docs/recurlyjs
 
 ## Version 2.10.6 (October 30th, 2018)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ section, there's a line that says something like:
 libcurl/7.19.5 OpenSSL/1.0.1g zlib/1.2.3.3 libidn/1.15
 ```
 
-Please ensure that your OpenSSL version supports TLS v1.1 or higher. At a minimum use v1.0.1g, however we recommend v1.1.0 and up.
+Please ensure that your OpenSSL version supports TLS v1.2 or higher.
 
 ### Timezone
 You will need to specify your server's timezone before using the Recurly PHP client. This is necessary for the library to properly handle datetime conversions. You can do this in your `php.ini` file:
@@ -43,12 +43,12 @@ date_default_timezone_set('America/Los_Angeles');
 
 If you're using [Composer](http://getcomposer.org/), you can simply add a
 dependency on `recurly/recurly-client` to your project's `composer.json` file.
-Here's an example of a dependency on 2.10:
+Here's an example of a dependency on 2.11:
 
 ```json
 {
     "require": {
-        "recurly/recurly-client": "2.10.*"
+        "recurly/recurly-client": "2.11.*"
     }
 }
 ```

--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -27,6 +27,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $this->assertEquals($account->created_at->getTimestamp(), 1304164800);
     $this->assertEquals($account->getHref(),'https://api.recurly.com/v2/accounts/abcdef1234567890');
     $this->assertTrue($account->tax_exempt);
+    $this->assertEquals($account->exemption_certificate, 'Some Certificate');
     $this->assertEquals($account->entity_use_code, 'I');
     $this->assertEquals($account->vat_location_valid, true);
     $this->assertEquals($account->cc_emails, 'cheryl.hines@example.com,richard.lewis@example.com');
@@ -99,6 +100,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->first_name = 'Verena';
     $account->address->address1 = "123 Main St.";
     $account->tax_exempt = false;
+    $account->exemption_certificate = 'Some Certificate';
     $account->entity_use_code = 'I';
     $account->preferred_locale = 'en-US';
 
@@ -143,7 +145,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->custom_fields[] = new Recurly_CustomField("serial_number", "4567-8900-1234");
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt><entity_use_code>I</entity_use_code><shipping_addresses><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Home</nickname><first_name>Verena</first_name><last_name>Example</last_name></shipping_address></shipping_addresses><preferred_locale>en-US</preferred_locale><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields><account_acquisition><cost_in_cents>599</cost_in_cents><currency>USD</currency><channel>marketing_content</channel><subchannel>pickle sticks blog post</subchannel><campaign>mailchimp67a904de95.0914d8f4b4</campaign></account_acquisition></account>\n",
+      "<?xml version=\"1.0\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt><entity_use_code>I</entity_use_code><shipping_addresses><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Home</nickname><first_name>Verena</first_name><last_name>Example</last_name></shipping_address></shipping_addresses><preferred_locale>en-US</preferred_locale><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields><account_acquisition><cost_in_cents>599</cost_in_cents><currency>USD</currency><channel>marketing_content</channel><subchannel>pickle sticks blog post</subchannel><campaign>mailchimp67a904de95.0914d8f4b4</campaign></account_acquisition><exemption_certificate>Some Certificate</exemption_certificate></account>\n",
       $account->xml()
     );
   }

--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -189,9 +189,10 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $invoice->terms_and_conditions = 'Never disclose the location of the Krabby Patty secret formula.';
     $invoice->vat_reverse_charge_notes = "can't be changed when invoice was not a reverse charge";
     $invoice->net_terms = '60';
+    $invoice->gateway_code = 'A new gateway code';
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<invoice><address><first_name>Spongebob</first_name><last_name>Squarepants</last_name><name_on_account>Patrick Star</name_on_account><company>Krusty Krab</company><address1>124 Conch Street</address1><address2>Pineapple</address2><city>Bikini Bottom</city><state>Dead Eye Gulch</state><zip>96970</zip><country>Pacific Ocean</country><phone>509-990-3551</phone></address><terms_and_conditions>Never disclose the location of the Krabby Patty secret formula.</terms_and_conditions><customer_notes>Is this the Krusty Krab?</customer_notes><vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes><net_terms>60</net_terms><po_number>3699</po_number></invoice>\n",
+      "<?xml version=\"1.0\"?>\n<invoice><address><first_name>Spongebob</first_name><last_name>Squarepants</last_name><name_on_account>Patrick Star</name_on_account><company>Krusty Krab</company><address1>124 Conch Street</address1><address2>Pineapple</address2><city>Bikini Bottom</city><state>Dead Eye Gulch</state><zip>96970</zip><country>Pacific Ocean</country><phone>509-990-3551</phone></address><terms_and_conditions>Never disclose the location of the Krabby Patty secret formula.</terms_and_conditions><customer_notes>Is this the Krusty Krab?</customer_notes><vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes><net_terms>60</net_terms><po_number>3699</po_number><gateway_code>A new gateway code</gateway_code></invoice>\n",
       $invoice->xml()
     );
     $invoice->update();

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -238,7 +238,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
 
     $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
 
-    $notes = array("customer_notes" => "New Customer Notes", "terms_and_condititions" => "New Terms", "vat_reverse_charge_notes" => "New VAT Notes");
+    $notes = array("customer_notes" => "New Customer Notes", "terms_and_condititions" => "New Terms", "vat_reverse_charge_notes" => "New VAT Notes", "gateway_code" => "A new gateway code");
 
     // You can also update custom fields through this endpoint
     $cf = $subscription->custom_fields["shasta"];

--- a/Tests/fixtures/accounts/show-200.xml
+++ b/Tests/fixtures/accounts/show-200.xml
@@ -18,6 +18,7 @@ Content-Type: application/xml; charset=utf-8
   <vat_number>ST-1937</vat_number>
   <entity_use_code>I</entity_use_code>
   <tax_exempt type="boolean">true</tax_exempt>
+  <exemption_certificate>Some Certificate</exemption_certificate>
   <preferred_locale>en-US</preferred_locale>
   <address>
     <address1>123 Main St.</address1>

--- a/Tests/fixtures/subscriptions/show-200-changed-notes.xml
+++ b/Tests/fixtures/subscriptions/show-200-changed-notes.xml
@@ -27,6 +27,7 @@ Content-Type: application/xml; charset=utf-8
   <terms_and_conditions>New Terms</terms_and_conditions>
   <customer_notes>New Customer Notes</customer_notes>
   <vat_reverse_charge_notes>New VAT Notes</vat_reverse_charge_notes>
+  <gateway_code>A new gateway code</gateway_code>
   <subscription_add_ons type="array">
     <subscription_add_on>
       <name>IP Addresses</name>

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -19,6 +19,7 @@
  * @property string $company_name The company name of the account.
  * @property string $vat_number The VAT number of the account (to avoid having the VAT applied).
  * @property boolean $tax_exempt The tax status of the account. true exempts tax on the account, false applies tax on the account.
+ * @property string $exemption_certificate Optional field for merchants taxing through Vertex. A string representing the exemption certificate. 1-30 characters in length.
  * @property Recurly_Address $address The nested address information of the account: address1, address2, city, state, zip, country, phone.
  * @property string $accept_language The ISO 639-1 language code from the user's browser, indicating their preferred language and locale.
  * @property string $hosted_login_token The unique token for automatically logging the account in to the hosted management pages. You may automatically log the user into their hosted management pages by directing the user to: https://:subdomain.recurly.com/account/:hosted_login_token.
@@ -105,7 +106,7 @@ class Recurly_Account extends Recurly_Resource
       'account_code', 'username', 'first_name', 'last_name', 'vat_number',
       'email', 'company_name', 'accept_language', 'billing_info', 'address',
       'tax_exempt', 'entity_use_code', 'cc_emails', 'shipping_addresses',
-      'preferred_locale', 'custom_fields', 'account_acquisition'
+      'preferred_locale', 'custom_fields', 'account_acquisition', 'exemption_certificate'
     );
   }
   protected function getRequiredAttributes() {

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.16';
+  public static $apiVersion = '2.17';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.10.6';
+  const API_CLIENT_VERSION = '2.11.0';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -29,6 +29,7 @@
  * @property string $terms_and_conditions
  * @property string $vat_reverse_charge_notes
  * @property string $customer_notes
+ * @property string $gateway_code The unique identifier of a payment gateway used to specify which payment gateway you wish to process this invoices’ payments
  * @property string $tax_type
  * @property string $tax_region
  * @property float $tax_rate
@@ -226,7 +227,8 @@ class Recurly_Invoice extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'address', 'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
-      'collection_method', 'net_terms', 'po_number', 'currency', 'credit_customer_notes'
+      'collection_method', 'net_terms', 'po_number', 'currency', 'credit_customer_notes',
+      'gateway_code'
     );
   }
 

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -42,6 +42,7 @@
  * @property Recurly_CustomFieldList $custom_fields Optional custom fields for the subscription.
  * @property string $uuid Subscription's unique identifier.
  * @property string $timeframe now for immediate, renewal to perform when the subscription renews. Defaults to now.
+ * @property string $gateway_code The unique identifier of a payment gateway used to specify which payment gateway you wish to process this subscriptions’ payments
  */
 class Recurly_Subscription extends Recurly_Resource
 {
@@ -266,7 +267,7 @@ class Recurly_Subscription extends Recurly_Resource
       'bank_account_authorized_at', 'revenue_schedule_type', 'gift_card',
       'shipping_address', 'shipping_address_id', 'imported_trial',
       'remaining_pause_cycles', 'custom_fields', 'auto_renew',
-      'renewal_billing_cycles'
+      'renewal_billing_cycles', 'gateway_code'
     );
   }
 }


### PR DESCRIPTION
## Version 2.11.0 (December 11th, 2018)

This release will upgrade us to API version 2.17.

* Add `gateway_code` to Subscription and Invoice objects [PR](https://github.com/recurly/recurly-client-php/pull/380)
* Add `exemption_certificate` to Account object [PR](https://github.com/recurly/recurly-client-php/pull/381)
* Remove deprecated JS module [PR](https://github.com/recurly/recurly-client-php/pull/382)
* Add `getHeaders()` method [PR](https://github.com/recurly/recurly-client-php/pull/383)
* Add OpenSSL version to user agent [PR](https://github.com/recurly/recurly-client-php/pull/384)

### Upgrade Notes
This release contains one breaking change. Older Recurly.js token signing is not longer supported. You should upgrade to version 4 of Recurly.js: https://dev.recurly.com/docs/recurlyjs
