### PR TITLE
per recurly support, docs are wrong and canceling should give a state…

### DIFF
--- a/Tests/fixtures/purchases/cancel-200.xml
+++ b/Tests/fixtures/purchases/cancel-200.xml
@@ -16,7 +16,7 @@ Location: https://api.recurly.com/v2/invoices
       <phone nil="nil"></phone>
     </address>
     <uuid nil="nil"></uuid>
-    <state>closed</state>
+    <state>failed</state>
     <invoice_number_prefix></invoice_number_prefix>
     <invoice_number nil="nil"></invoice_number>
     <po_number nil="nil"></po_number>


### PR DESCRIPTION
… of failed

Hi Aaron, 

I'm glad you were able to get the purchase endpoint working with that transaction id.  I apologize for the delay following up.  I'd be more than happy to help further.  I was testing this on my end and I believe what you were seeing in the response is correct. It appears that the invoice is being marked as 'failed'. I'd be more than happy to speak with our team to see if we can get the docs updated to reflect the correct response that is returned by the cancel authorization endpoint.  I appreciate you bringing this to our attention.  Please let me know if you have any further questions. 

Thanks, 
Justin
Recurly Support