### PR TITLE
Handle HTTP headers in a more case insensitive way

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -77,8 +77,10 @@ class Recurly_MockClient {
         break;
       }
       preg_match('/([^:]+): (.*)/', $fixture[$i], $matches);
-      if (sizeof($matches) > 2)
-        $headers[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $headers[$headerKey] = $matches[2];
+      }
     }
 
     if ($bodyLineNumber < sizeof($fixture))

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -201,8 +201,10 @@ class Recurly_Client
     $returnHeaders = array();
     foreach ($headers as &$header) {
       preg_match('/([^:]+): (.*)/', $header, $matches);
-      if (sizeof($matches) > 2)
-        $returnHeaders[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $returnHeaders[$headerKey] = $matches[2];
+      }
     }
     return $returnHeaders;
   }

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -141,7 +141,7 @@ class Recurly_Coupon extends Recurly_Resource
     $response->assertValidResponse();
 
     $coupons = array();
-    foreach (new Recurly_UniqueCouponCodeList($response->headers['Location'], $this->_client) as $coupon) {
+    foreach (new Recurly_UniqueCouponCodeList($response->headers['location'], $this->_client) as $coupon) {
       $coupons[] = $coupon;
       if (count($coupons) == $number) break;
     }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -21,8 +21,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   public function count() {
     if (isset($this->_href)) {
       $headers = Recurly_Base::_head($this->_href, $this->_client);
-      if (isset($headers['X-Records'])) {
-        return intval($headers['X-Records']);
+      if (isset($headers['x-records'])) {
+        return intval($headers['x-records']);
       }
     } elseif (isset($this->_objects) && is_array($this->_objects)) {
       return count($this->_objects);
@@ -132,8 +132,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   private function _loadLinks($response) {
     $this->_links = array();
 
-    if (isset($response->headers['Link'])) {
-      $links = $response->headers['Link'];
+    if (isset($response->headers['link'])) {
+      $links = $response->headers['link'];
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -48,8 +48,8 @@ class Recurly_ClientResponse
    */
   public function assertValidResponse()
   {
-    if (!empty($this->headers['Recurly-Deprecated'])) {
-      error_log("WARNING: API version {$this->headers['X-Api-Version']} is deprecated and will only be available until {$this->headers['Recurly-Sunset-Date']}. Please upgrade the Recurly PHP client.");
+    if (!empty($this->headers['recurly-deprecated'])) {
+      error_log("WARNING: API version {$this->headers['x-api-version']} is deprecated and will only be available until {$this->headers['recurly-sunset-date']}. Please upgrade the Recurly PHP client.");
     }
 
     // Successful response code


### PR DESCRIPTION
Changes Recurly_Client to always force HTTP header keys in to lowercase before storing in Recurly_Response.