### PR TITLE
Add amazon_region to Billing Info

### DIFF
--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -38,6 +38,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertEquals($billing_info->year, null);
     $this->assertEquals($billing_info->month, null);
     $this->assertEquals($billing_info->amazon_billing_agreement_id, null);
+    $this->assertEquals($billing_info->amazon_region, null);
     $this->assertEquals($billing_info->paypal_billing_agreement_id, 'abc123');
     $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/paypal1234567890/billing_info');
   }
@@ -51,6 +52,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertEquals($billing_info->month, null);
     $this->assertEquals($billing_info->paypal_billing_agreement_id, null);
     $this->assertEquals($billing_info->amazon_billing_agreement_id, 'C01-1234567-8901234');
+    $this->assertEquals($billing_info->amazon_region, 'us');
     $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/amazon1234567890/billing_info');
   }
 

--- a/Tests/fixtures/billing_info/show-amazon-200.xml
+++ b/Tests/fixtures/billing_info/show-amazon-200.xml
@@ -18,4 +18,5 @@ Content-Type: application/xml; charset=utf-8
   <ip_address>127.0.0.1</ip_address>
   <ip_address_country nil="nil"></ip_address_country>
   <amazon_billing_agreement_id>C01-1234567-8901234</amazon_billing_agreement_id>
+  <amazon_region>us</amazon_region>
 </billing_info>


### PR DESCRIPTION
Adds an assert to verify that the new `amazon_region` will work with Billing Info objects.

```php
<?php
try {
  $billing_info = new Recurly_BillingInfo();
  $billing_info->account_code       = 'x';
  $billing_info->first_name         = 'John';
  $billing_info->last_name          = 'Du Monde';
  $billing_info->address1           = '123 Paper Street';
  $billing_info->city               = 'Los Angeles';
  $billing_info->state              = 'CA';
  $billing_info->zip                = '95312';
  $billing_info->country            = 'US';
  $billing_info->phone              = '213-555-5555';
  $billing_info->amazon_billing_agreement_id = 'C01-1234567-8901234';
  $billing_info->amazon_region      = 'us';
  $billing_info->create();

  print "Billing Info: $billing_info";
} catch (Recurly_ValidationError $e) {
  // The amazon billing agreement provided is invalid
  print "Invalid amazon billing agreement: $e";
} catch (Recurly_NotFoundError $e) {
  // Could not find account
  print "Not Found: $e";
}
catch (Recurly_Error $e) {
  // Could not find account
  print "Bad request: $e";
}
```