### PR TITLE
Add X-Api-Version header to getPdf and getFile

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -248,6 +248,7 @@ class Recurly_Client
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array(
       Recurly_Client::__userAgent(),
+      'X-Api-Version: ' . Recurly_Client::$apiVersion
     ));
     curl_setopt($ch, CURLOPT_FILE, $file_pointer);
 
@@ -292,7 +293,8 @@ class Recurly_Client
     curl_setopt($ch, CURLOPT_HTTPHEADER, array(
       'Accept: application/pdf',
       Recurly_Client::__userAgent(),
-      'Accept-Language: ' . $locale
+      'Accept-Language: ' . $locale,
+      'X-Api-Version: ' . Recurly_Client::$apiVersion
     ));
     curl_setopt($ch, CURLOPT_USERPWD, $this->apiKey());
 


### PR DESCRIPTION
The getPdf and getFile methods are not currently reporting which version they need. This adds the version header so when API versions are deprecated, these methods will still work.