### PR TITLE
Specify which versions of HHVM we should test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - hhvm
+  - hhvm-4.0.0
+  - hhvm-3.30
+  - hhvm-3.27
+  - hhvm-3.24
 sudo: false
 dist: trusty
 install:
@@ -14,5 +17,9 @@ install:
 script: vendor/phpunit/phpunit/phpunit Tests
 matrix:
   allow_failures:
-    - php: 5.4
+    - php: hhvm-4.0.0
+    - php: hhvm-3.24
+    - php: 7.0
+    - php: 5.6
     - php: 5.5
+    - php: 5.4

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ $ vendor/bin/phpunit
 - [https://support.recurly.com](https://support.recurly.com)
 - [stackoverflow](http://stackoverflow.com/questions/tagged/recurly)
 
+## Supported Versions
+
+We support all ["currently supported versions" of PHP](http://php.net/supported-versions.php).
+We also support the LTS versions of [HHVM](https://docs.hhvm.com/hhvm/installation/release-schedule), but only those which support PHP and Composer.
+
 ## Contributing Guidelines
 
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
HHVM no longer supports Composer or PHP as of version 4.0.0. More information can be found in their blog. https://hhvm.com/blog/2019/02/11/hhvm-4.0.0.html