### PR TITLE
Release version 2.11.2 / API version 2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.11.2 (February 19th, 2019)
+
+* Adds support for Amazon Region [PR](https://github.com/recurly/recurly-client-php/pull/394)
+* Add note about HHVM support [PR](https://github.com/recurly/recurly-client-php/pull/399)
+* Adds X-API-Version header to getPdf() and getFile() in the client [PR](https://github.com/recurly/recurly-client-php/pull/398)
+
 ## Version 2.11.1 (January 17th, 2019)
 
 * Adds missing properties to BillingInfo [PR](https://github.com/recurly/recurly-client-php/pull/395)

--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -38,6 +38,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertEquals($billing_info->year, null);
     $this->assertEquals($billing_info->month, null);
     $this->assertEquals($billing_info->amazon_billing_agreement_id, null);
+    $this->assertEquals($billing_info->amazon_region, null);
     $this->assertEquals($billing_info->paypal_billing_agreement_id, 'abc123');
     $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/paypal1234567890/billing_info');
   }
@@ -51,6 +52,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertEquals($billing_info->month, null);
     $this->assertEquals($billing_info->paypal_billing_agreement_id, null);
     $this->assertEquals($billing_info->amazon_billing_agreement_id, 'C01-1234567-8901234');
+    $this->assertEquals($billing_info->amazon_region, 'us');
     $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/amazon1234567890/billing_info');
   }
 

--- a/Tests/fixtures/billing_info/show-amazon-200.xml
+++ b/Tests/fixtures/billing_info/show-amazon-200.xml
@@ -18,4 +18,5 @@ Content-Type: application/xml; charset=utf-8
   <ip_address>127.0.0.1</ip_address>
   <ip_address_country nil="nil"></ip_address_country>
   <amazon_billing_agreement_id>C01-1234567-8901234</amazon_billing_agreement_id>
+  <amazon_region>us</amazon_region>
 </billing_info>

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -282,6 +282,10 @@ abstract class Recurly_Base
   // Use a valid Recurly_Response to populate a new object.
   protected static function __parseResponseToNewObject($response, $uri, $client) {
     $dom = new DOMDocument();
+
+    // Attempt to prevent XXE that could be exploited through loadXML()
+    libxml_disable_entity_loader(true);
+
     if (empty($response->body) || !$dom->loadXML($response->body, LIBXML_NOBLANKS)) {
       return null;
     }
@@ -305,6 +309,10 @@ abstract class Recurly_Base
   protected function __parseXmlToUpdateObject($xml)
   {
     $dom = new DOMDocument();
+
+    // Attempt to prevent XXE that could be exploited through loadXML()
+    libxml_disable_entity_loader(true);
+
     if (empty($xml) || !$dom->loadXML($xml, LIBXML_NOBLANKS)) return null;
 
     $rootNode = $dom->documentElement;

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.11.1';
+  const API_CLIENT_VERSION = '2.11.2';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.17';
+  public static $apiVersion = '2.18';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/push_notification.php
+++ b/lib/recurly/push_notification.php
@@ -98,6 +98,10 @@ class Recurly_PushNotification
 
   function parseXml($post_xml)
   {
+
+    // Attempt to prevent XXE that could be exploited through simplexml_load_string()
+    libxml_disable_entity_loader(true);
+
     if (!@simplexml_load_string ($post_xml)) {
       return;
     }

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -102,6 +102,10 @@ class Recurly_ClientResponse
 
   private function parseErrorXml($xml) {
     $dom = new DOMDocument();
+
+    // Attempt to prevent XXE that could be exploited through loadXML()
+    libxml_disable_entity_loader(true);
+
     if (empty($xml) || !$dom->loadXML($xml)) return null;
 
     $rootNode = $dom->documentElement;


### PR DESCRIPTION
## Version 2.11.2 (February 19th, 2019)

* Adds support for Amazon Region [PR](https://github.com/recurly/recurly-client-php/pull/394)
* Add note about HHVM support [PR](https://github.com/recurly/recurly-client-php/pull/399)
* Adds X-API-Version header to getPdf() and getFile() in the client [PR](https://github.com/recurly/recurly-client-php/pull/398)