### PR TITLE
Release version 2.12.0 / API version 2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.0 (March 12th, 2019)
+
+This brings us up to API version 2.19
+
+* Adds support for Account Hierarchy [PR](https://github.com/recurly/recurly-client-php/pull/393)
+* Ensure that the client can only connect to recurly domains to improve security [878e844](https://github.com/recurly/recurly-client-php/pull/401/commits/878e8444ad7aa675fed956d610e8c44158787047)
+
+### Upgrade Notes
+If you are using the `Recurly_ExportFile` class, you must now use `getDownloadUrl()` to get the download url rather than accessing this property directly.
+```php
+# if you are accessing the download url directly
+$url = $export_file->download_url;
+# you'll now need to use a getter
+$url = $export_file->getDownloadUrl();
+```
+If you are using `$export_file->download($fp)` and not accessing the url directly, you should not be affected.
+
 ## Version 2.11.2 (February 19th, 2019)
 
 * Adds support for Amazon Region [PR](https://github.com/recurly/recurly-client-php/pull/394)

--- a/Tests/Recurly/ExportFile_Test.php
+++ b/Tests/Recurly/ExportFile_Test.php
@@ -13,6 +13,6 @@ class Recurly_ExportFile_Test extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_ExportFile', $file);
     $this->assertEquals('https://api.recurly.com/v2/export_dates/2016-08-01/export_files/revenue_schedules_full.csv', $file->getHref());
     $this->assertEquals('1471631526', $file->expires_at->getTimestamp());
-    $this->assertEquals('https://example.com/download/1424738224870632110/dates/2016-08-01/revenue_schedules_full.csv', $file->download_url);
+    $this->assertEquals('https://example.com/download/1424738224870632110/dates/2016-08-01/revenue_schedules_full.csv', $file->getDownloadUrl());
   }
 }

--- a/Tests/fixtures/accounts/hierarchy/create-201.xml
+++ b/Tests/fixtures/accounts/hierarchy/create-201.xml
@@ -1,0 +1,35 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <parent_account href="https://api.recurly.com/v2/accounts/1234567890"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <parent_account_code>1234567890</parent_account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/Tests/fixtures/accounts/hierarchy/show-child-200.xml
+++ b/Tests/fixtures/accounts/hierarchy/show-child-200.xml
@@ -1,0 +1,34 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <parent_account href="https://api.recurly.com/v2/accounts/1234567890"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <parent_account_code>1234567890</parent_account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/Tests/fixtures/accounts/hierarchy/show-parent-200.xml
+++ b/Tests/fixtures/accounts/hierarchy/show-parent-200.xml
@@ -1,0 +1,47 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/1234567890">
+  <child_accounts href="https://api.recurly.com/v2/accounts/1234567890/child_accounts"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/1234567890/adjustments"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/1234567890/balance"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/1234567890/invoices"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/1234567890/shipping_addresses"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/1234567890/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/1234567890/transactions"/>
+  <notes href="https://api.recurly.com/v2/accounts/1234567890/notes"/>
+  <account_code>1234567890</account_code>
+  <state>active</state>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <cc_emails nil="nil"></cc_emails>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <vat_number nil="nil"></vat_number>
+  <preferred_locale nil="nil"></preferred_locale>
+  <address>
+    <address1 nil="nil"></address1>
+    <address2 nil="nil"></address2>
+    <city nil="nil"></city>
+    <state nil="nil"></state>
+    <zip nil="nil"></zip>
+    <country nil="nil"></country>
+    <phone nil="nil"></phone>
+  </address>
+  <accept_language nil="nil"></accept_language>
+  <created_at type="datetime">2018-09-26T15:23:12Z</created_at>
+  <updated_at type="datetime">2018-12-26T15:25:20Z</updated_at>
+  <closed_at nil="nil"></closed_at>
+  <custom_fields type="array">
+  </custom_fields>
+  <has_live_subscription type="boolean">true</has_live_subscription>
+  <has_active_subscription type="boolean">true</has_active_subscription>
+  <has_future_subscription type="boolean">false</has_future_subscription>
+  <has_canceled_subscription type="boolean">false</has_canceled_subscription>
+  <has_past_due_invoice type="boolean">false</has_past_due_invoice>
+  <has_paused_subscription type="boolean">false</has_paused_subscription>
+  <bill_to>self</bill_to>
+</account>

--- a/Tests/fixtures/accounts/hierarchy/update-200.xml
+++ b/Tests/fixtures/accounts/hierarchy/update-200.xml
@@ -1,0 +1,35 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <parent_account href="https://api.recurly.com/v2/accounts/1234567890"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <parent_account_code>1234567890</parent_account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/Tests/fixtures/accounts/hierarchy/update-no-parent-200.xml
+++ b/Tests/fixtures/accounts/hierarchy/update-no-parent-200.xml
@@ -1,0 +1,33 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/abcdef1234567890.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/abcdef1234567890">
+  <adjustments href="https://api.recurly.com/v2/accounts/abcdef1234567890/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/abcdef1234567890/invoices"/>
+  <redemptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/redemptions"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/abcdef1234567890/subscriptions"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses"/>
+  <transactions href="https://api.recurly.com/v2/accounts/abcdef1234567890/transactions"/>
+  <account_code>abcdef1234567890</account_code>
+  <username>shmohawk58</username>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <company_name>Home Box Office</company_name>
+  <accept_language>en-US</accept_language>
+  <hosted_login_token>18d935f06b0547ddad8cdf2490ac802e</hosted_login_token>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <vat_number>12345-67</vat_number>
+  <address>
+    <address1>123 Main St.</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015551234</phone>
+  </address>
+</account>

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -63,6 +63,8 @@ class Recurly_Account extends Recurly_Resource
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_ACCOUNTS);
   }
   public function update() {
+    # Manually clear the `parent_account` because the attribute name is `parent_account_code`
+    $this->parent_account = null;
     $this->_save(Recurly_Client::PUT, $this->uri());
   }
 
@@ -106,7 +108,8 @@ class Recurly_Account extends Recurly_Resource
       'account_code', 'username', 'first_name', 'last_name', 'vat_number',
       'email', 'company_name', 'accept_language', 'billing_info', 'address',
       'tax_exempt', 'entity_use_code', 'cc_emails', 'shipping_addresses',
-      'preferred_locale', 'custom_fields', 'account_acquisition', 'exemption_certificate'
+      'preferred_locale', 'custom_fields', 'account_acquisition', 'exemption_certificate',
+      'parent_account_code'
     );
   }
   protected function getRequiredAttributes() {

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -174,7 +174,7 @@ abstract class Recurly_Base
   public function getHref() {
     return $this->_href;
   }
-  public function setHref($href) {
+  protected function setHref($href) {
     $this->_href = $href;
   }
 

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -27,7 +27,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.18';
+  public static $apiVersion = '2.19';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -49,7 +49,7 @@ class Recurly_Client
    */
   private static $valid_domains = ["recurly.com"];
 
-  const API_CLIENT_VERSION = '2.11.2';
+  const API_CLIENT_VERSION = '2.12.0';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,6 +44,11 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
+  /**
+   * Valid Recurly domains
+   */
+  private static $valid_domains = ["recurly.com"];
+
   const API_CLIENT_VERSION = '2.11.2';
   const DEFAULT_ENCODING = 'UTF-8';
 
@@ -125,6 +130,8 @@ class Recurly_Client
 
     if (substr($uri,0,4) != 'http')
       $uri = $this->baseUri() . $uri;
+
+    $this->_verifyUri($uri);
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $uri);
@@ -209,6 +216,13 @@ class Recurly_Client
     return $returnHeaders;
   }
 
+  private function _verifyUri($uri) {
+    $host = parse_url($uri, PHP_URL_HOST);
+
+    if (!in_array($host, Recurly_Client::$valid_domains))
+      throw new Recurly_Error("$host is not a valid Recurly domain!");
+  }
+
   /**
    * @param int $errorNumber The curl error number
    * @param string $message The error message
@@ -237,6 +251,8 @@ class Recurly_Client
    * @throws Recurly_Error
    */
   public function getFile($uri, $file_pointer) {
+    $this->_verifyUri($uri);
+
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $uri);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
@@ -276,6 +292,8 @@ class Recurly_Client
   {
     if (substr($uri,0,4) != 'http')
       $uri = $this->baseUri() . $uri;
+
+    $this->_verifyUri($uri);
 
     if (is_null($locale))
       $locale = $this->_acceptLanguage;

--- a/lib/recurly/export_file.php
+++ b/lib/recurly/export_file.php
@@ -2,6 +2,9 @@
 
 class Recurly_ExportFile extends Recurly_Resource
 {
+
+  protected $download_url;
+
   /**
    * Look up a file by date and name.
    * @param string date
@@ -12,6 +15,10 @@ class Recurly_ExportFile extends Recurly_Resource
    */
   public static function get($date, $name, $client = null) {
     return self::_get('/export_dates/' . rawurlencode($date) . '/export_files/' . rawurlencode($name), $client);
+  }
+
+  public function getDownloadUrl() {
+    return $this->download_url;
   }
 
   protected function getNodeName() {


### PR DESCRIPTION
## Version 2.12.0 (March 12th, 2019)

This brings us up to API version 2.19

* Adds support for Account Hierarchy [PR](https://github.com/recurly/recurly-client-php/pull/393)
* Ensure that the client can only connect to recurly domains to improve security [878e844](https://github.com/recurly/recurly-client-php/pull/401/commits/878e8444ad7aa675fed956d610e8c44158787047)

### Upgrade Notes
If you are using the `Recurly_ExportFile` class, you must now use `getDownloadUrl()` to get the download url rather than accessing this property directly.
```php
# if you are accessing the download url directly
$url = $export_file->download_url;
# you'll now need to use a getter
$url = $export_file->getDownloadUrl();
```
If you are using `$export_file->download($fp)` and not accessing the url directly, you should not be affected.