### PR TITLE
Fix broken _verifyUri method

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -219,6 +219,11 @@ class Recurly_Client
   private function _verifyUri($uri) {
     $host = parse_url($uri, PHP_URL_HOST);
 
+    // remove the subdomain from $host
+    if (count(explode('.', $host)) > 2) {
+      $host = substr($host, strpos($host, ".") + 1);
+    }
+
     if (!in_array($host, Recurly_Client::$valid_domains))
       throw new Recurly_Error("$host is not a valid Recurly domain!");
   }


### PR DESCRIPTION
The new method to verify the domain that a request is being made to breaks when there is a subdomain (which is most of the time). This PR removes the subdomain so that it is just verifying the domain is whitelisted.