### PR TITLE
Add support for updating a subscription at next bill date

### DIFF
--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -124,6 +124,15 @@ class Recurly_Subscription extends Recurly_Resource
     $this->_save(Recurly_Client::PUT, $this->uri());
   }
 
+  /**
+   * Make an update that applies at the next bill date of the subscription.
+   *
+   * @throws Recurly_Error
+   */
+  public function updateAtNextBillDate() {
+    $this->timeframe = 'bill_date';
+    $this->_save(Recurly_Client::PUT, $this->uri());
+  }
 
   /**
    * Terminate the subscription immediately and issue a full refund of the last renewal


### PR DESCRIPTION
This adds support for updating the subscription at next bill date rather than just immediately or at renewal.

```php
<?php

$uuid = '4c2a90c55cfe520e7f33744dc09ae922';
$sub = Recurly_Subscription::get($uuid);

$sub->plan_code = "silver";

$sub->updateAtNextBillDate();
```