### PR TITLE
Add 3DS tokens to transaction error and billing info

### DIFF
--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -98,7 +98,8 @@ class Recurly_BillingInfo extends Recurly_Resource
       'account_number', 'routing_number', 'account_type',
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id', 'external_hpp_type', 'gateway_token', 'gateway_code',
-      'braintree_payment_nonce', 'roku_billing_agreement_id'
+      'braintree_payment_nonce', 'roku_billing_agreement_id',
+      'three_d_secure_action_result_token_id'
     );
   }
 }


### PR DESCRIPTION
This allows the client to use the new 3DSecure features of the API. This involves a 2 step flow with RecurlyJS, see https://github.com/recurly/recurly-js/pull/527 for technical details on that side of this process.

Script 1: Attempt to update a billing info with a credit card that requires 3DS authentication:
```php
try {
  $billing_info = new Recurly_BillingInfo();
  $billing_info->account_code       = 'x';
  $billing_info->first_name         = 'John';
  $billing_info->last_name          = 'Du Monde';
  $billing_info->address1           = '123 Paper Street';
  $billing_info->city               = 'Los Angeles';
  $billing_info->state              = 'CA';
  $billing_info->zip                = '95312';
  $billing_info->country            = 'US';
  $billing_info->phone              = '213-555-5555';
  $billing_info->number             = '4000000000003220';
  $billing_info->month              = '10';
  $billing_info->year               = '2020';
  $billing_info->create();

  print "Billing Info: $billing_info" . "\n";
} catch (Recurly_ValidationError $e) {
  // Requires 3DS authentication. Get the token id to pass into RJS:
  print $e->errors[0]->three_d_secure_action_token_id . "\n";
}
```

The `ValidationError`'s `TransactionError` (the first element of the `errors` array) will contain a `three_d_secure_action_token_id`, which needs to be passed to RJS for authentication. Upon successful authentication, RJS will return a result token, which can then be passed with the billing info.

Script 2: Update the billing info using 3DS:
```php
try {
  $billing_info = new Recurly_BillingInfo();
  $billing_info->account_code       = 'x';
  $billing_info->first_name         = 'John';
  $billing_info->last_name          = 'Du Monde';
  $billing_info->address1           = '123 Paper Street';
  $billing_info->city               = 'Los Angeles';
  $billing_info->state              = 'CA';
  $billing_info->zip                = '95312';
  $billing_info->country            = 'US';
  $billing_info->phone              = '213-555-5555';
  $billing_info->number             = '4000000000003220';
  $billing_info->month              = '10';
  $billing_info->year               = '2020';
  $billing_info->three_d_secure_action_result_token_id = '4jkL_3RCvKGaJ3wwphf_9A';
  $billing_info->create();

  print "Billing Info: $billing_info" . "\n";
} catch (Recurly_Error $e) {
  var_dump($e);
}
```

This flow still applies when passing a `billing_info` object to the `/accounts`, `/subscriptions`, and `/purchases` endpoints.