### PR TITLE
Release version 2.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.4 (June 27th, 2019)
+
+This brings us up to API version 2.21. There are no breaking changes
+
+* Add 3DS authentication [PR](https://github.com/recurly/recurly-client-php/pull/415)
+
 ## Version 2.12.3 (May 21st, 2019)
 
 This brings us up to API version 2.20. There are no breaking changes

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -98,7 +98,8 @@ class Recurly_BillingInfo extends Recurly_Resource
       'account_number', 'routing_number', 'account_type',
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id', 'external_hpp_type', 'gateway_token', 'gateway_code',
-      'braintree_payment_nonce', 'roku_billing_agreement_id'
+      'braintree_payment_nonce', 'roku_billing_agreement_id',
+      'three_d_secure_action_result_token_id'
     );
   }
 }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -22,7 +22,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.20';
+  public static $apiVersion = '2.21';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -50,7 +50,7 @@ class Recurly_Client
   private static $apiUrl = 'https://%s.recurly.com/v2';
 
 
-  const API_CLIENT_VERSION = '2.12.3';
+  const API_CLIENT_VERSION = '2.12.4';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
## Version 2.12.4 (June 27th, 2019)

This brings us up to API version 2.21. There are no breaking changes

* Add 3DS authentication [PR](https://github.com/recurly/recurly-client-php/pull/415)