### PR TITLE
Moto transactions

### DIFF
--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -151,6 +151,18 @@ class Recurly_AccountTest extends Recurly_TestCase
   }
 
   /**
+   * Test that transaction_type is rendered
+   */
+  public function testTransactionType() {
+    $account = Recurly_Account::get('abcdef1234567890', $this->client);
+    $account->transaction_type = 'moto';
+    $this->assertEquals(
+      "<?xml version=\"1.0\"?>\n<account><transaction_type>moto</transaction_type></account>\n",
+      $account->xml()
+    );
+  }
+
+  /**
    * Test that updates to nested account addresses are detected when generating
    * XML to send.
    */

--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -107,6 +107,17 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $billing_info->create();
   }
 
+  public function testTransactionType() {
+    $billing_info = new Recurly_BillingInfo(null, $this->client);
+    $billing_info->transaction_type = 'moto';
+
+    $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
+    $this->assertEquals(
+      $billing_info->xml(),
+      "<?xml version=\"1.0\"?>\n<billing_info><transaction_type>moto</transaction_type></billing_info>\n"
+    );
+  }
+
   public function testForExternalHppType() {
     $billing_info = new Recurly_BillingInfo(null, $this->client);
     $billing_info->token_id = 'abc123';

--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -112,7 +112,7 @@ class Recurly_InvoiceTest extends Recurly_TestCase
     $this->client->addResponse('PUT', 'https://api.recurly.com/v2/invoices/1001/collect', 'invoices/force_collect-200.xml');
 
     $invoice = Recurly_Invoice::get('1001', $this->client);
-    $invoice->forceCollect();
+    $invoice->forceCollect('moto');
     $this->assertEquals($invoice->state, 'paid');
   }
 

--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -16,6 +16,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
 
   public function mockPurchase() {
     $purchase = new Recurly_Purchase();
+    $purchase->transaction_type = 'moto';
     $purchase->currency = 'USD';
     $purchase->gateway_code = 'aBcD1234';
     $purchase->collection_method = 'automatic';
@@ -61,7 +62,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = $this->mockPurchase();
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><billing_info><token_id>7z6furn4jvb9</token_id></billing_info><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address><shipping_addresses><shipping_address><address1>400 Dolores St</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><nickname>Home</nickname><first_name>Dolores</first_name><last_name>Du Monde</last_name></shipping_address></shipping_addresses></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes><gateway_code>aBcD1234</gateway_code></purchase>\n",
+      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><billing_info><token_id>7z6furn4jvb9</token_id></billing_info><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address><shipping_addresses><shipping_address><address1>400 Dolores St</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><nickname>Home</nickname><first_name>Dolores</first_name><last_name>Du Monde</last_name></shipping_address></shipping_addresses></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes><gateway_code>aBcD1234</gateway_code><transaction_type>moto</transaction_type></purchase>\n",
       $purchase->xml()
     );
   }

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -34,6 +34,7 @@
  * @property DateTime $updated_at The date and time the account or its billing info was last updated.
  * @property DateTime $closed_at For closed accounts, the date and time it was closed.
  * @property Recurly_AccountAcquisition $account_acquisition The nested account acquisition information: cost_in_cents, currency, channel, subchannel, campaign.
+ * @property string $transaction_type Indicates type of resulting transaction. accepted_values: "moto".
  */
 class Recurly_Account extends Recurly_Resource
 {
@@ -109,7 +110,7 @@ class Recurly_Account extends Recurly_Resource
       'email', 'company_name', 'accept_language', 'billing_info', 'address',
       'tax_exempt', 'entity_use_code', 'cc_emails', 'shipping_addresses',
       'preferred_locale', 'custom_fields', 'account_acquisition', 'exemption_certificate',
-      'parent_account_code'
+      'parent_account_code', 'transaction_type'
     );
   }
   protected function getRequiredAttributes() {

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -31,6 +31,7 @@
  * @property string $amazon_billing_agreement_id Amazon's billing agreement
  * @property string $braintree_payment_nonce Braintree's payment method nonce representing the Paypal billing agreement id. This is required when processing Paypal transactions through Braintree.
  * @property string $roku_billing_agreement_id Roku's CIB if billing through Roku
+ * @property string $transaction_type Indicates type of resulting transaction. accepted_values: "moto".
  */
 class Recurly_BillingInfo extends Recurly_Resource
 {
@@ -99,7 +100,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id', 'external_hpp_type', 'gateway_token', 'gateway_code',
       'braintree_payment_nonce', 'roku_billing_agreement_id',
-      'three_d_secure_action_result_token_id'
+      'three_d_secure_action_result_token_id', 'transaction_type'
     );
   }
 }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -22,7 +22,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.21';
+  public static $apiVersion = '2.22';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -125,8 +125,15 @@ class Recurly_Invoice extends Recurly_Resource
   /**
    * @throws Recurly_Error
    */
-  public function forceCollect() {
-    $this->_save(Recurly_Client::PUT, $this->uri() . '/collect');
+  public function forceCollect($transaction_type = null) {
+    $body = null;
+    if ($transaction_type != null) {
+      $doc = $this->createDocument();
+      $root = $doc->appendChild($doc->createElement('invoice'));
+      $root->appendChild($doc->createElement('transaction_type', $transaction_type));
+      $body = $this->renderXML($doc);
+    }
+    $this->_save(Recurly_Client::PUT, $this->uri() . '/collect', $body, $this->_client);
   }
 
   /**

--- a/lib/recurly/purchase.php
+++ b/lib/recurly/purchase.php
@@ -16,6 +16,7 @@
  * @property integer $shipping_address_id Optional id of an existing ShippingAddress to be applied to all subscriptions and adjustments in purchase.
  * @property string $gateway_code Optional base36 encoded id for the gateway you wish to use for this transaction.
  * @property Recurly_ShippingFee[] $shipping_fees Optional array of shipping fees to apply to the purchase.
+ * @property string $transaction_type Indicates type of resulting transaction. accepted_values: "moto".
  */
 class Recurly_Purchase extends Recurly_Resource
 {
@@ -116,7 +117,7 @@ class Recurly_Purchase extends Recurly_Resource
       'account', 'adjustments', 'collection_method', 'currency', 'po_number',
       'net_terms', 'subscriptions', 'gift_card', 'coupon_codes', 'customer_notes',
       'terms_and_conditions', 'vat_reverse_charge_notes', 'shipping_address_id',
-      'gateway_code', 'shipping_fees'
+      'gateway_code', 'shipping_fees', 'transaction_type'
     );
   }
 }

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -45,6 +45,7 @@
  * @property string $gateway_code The unique identifier of a payment gateway used to specify which payment gateway you wish to process this subscriptions’ payments
  * @property string $shipping_method_code The unique identifier of the shipping method for this subscription.
  * @property integer $shipping_amount_in_cents The amount charged for shipping in cents.
+ * @property string $transaction_type Indicates type of resulting transaction. accepted_values: "moto".
  */
 class Recurly_Subscription extends Recurly_Resource
 {
@@ -279,7 +280,7 @@ class Recurly_Subscription extends Recurly_Resource
       'shipping_address', 'shipping_address_id', 'imported_trial',
       'remaining_pause_cycles', 'custom_fields', 'auto_renew',
       'renewal_billing_cycles', 'gateway_code', 'shipping_method_code',
-      'shipping_amount_in_cents'
+      'shipping_amount_in_cents', 'transaction_type'
     );
   }
 }


### PR DESCRIPTION
As a part of PSD2, there is an exemption to exclude MOTO transactions from SCA scope.
In order to pass this indicator to the gateways, merchants need a mechanism via API
to inform Recurly of these transactions. These transactions will be initiated from
within a merchants customer service / support admin portal UI, where the customer
is not authenticated to be able to complete an SCA flow.

This is exposed to the programmer as `transaction_type` on many of the resources. Set the value to `moto` to mark the transaction as MOTO. Ex use with purchases:

```php
$purchase = new Recurly_Purchase();
$purchase->currency = 'USD';
$purchase->transaction_type = 'moto';
$purchase->account = new Recurly_Account();
$purchase->account->account_code = 'aba9209a-aa61-4790-8e61-0a2692435fee';
$subscription = new Recurly_Subscription();
$subscription->plan_code = 'pp';
$purchase->subscriptions = array($subscription);
$collection = Recurly_Purchase::invoice($purchase);
```