### PR TITLE
Restore libxml state when changed

### DIFF
--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -287,7 +287,7 @@ abstract class Recurly_Base
     $dom = new DOMDocument();
 
     // Attempt to prevent XXE that could be exploited through loadXML()
-    $xmlLoader = libxml_disable_entity_loader(true);
+    libxml_disable_entity_loader(true);
 
     if (empty($response->body) || !$dom->loadXML($response->body, LIBXML_NOBLANKS)) {
       return null;
@@ -301,9 +301,6 @@ abstract class Recurly_Base
       $obj->_afterParseResponse($response, $uri);
       $obj->setHeaders($response->headers);
     }
-
-    libxml_disable_entity_loader($xmlLoader);
-
     return $obj;
   }
 
@@ -316,7 +313,7 @@ abstract class Recurly_Base
     $dom = new DOMDocument();
 
     // Attempt to prevent XXE that could be exploited through loadXML()
-    $xmlLoader = libxml_disable_entity_loader(true);
+    libxml_disable_entity_loader(true);
 
     if (empty($xml) || !$dom->loadXML($xml, LIBXML_NOBLANKS)) return null;
 
@@ -330,8 +327,6 @@ abstract class Recurly_Base
       Recurly_Resource::__parseXmlToObject($rootNode->firstChild, $this->_errors, $this->_client);
     }
     $this->updateErrorAttributes();
-
-    libxml_disable_entity_loader($xmlLoader);
   }
 
   protected static function __parseXmlToObject($node, &$object, $client)

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -287,7 +287,7 @@ abstract class Recurly_Base
     $dom = new DOMDocument();
 
     // Attempt to prevent XXE that could be exploited through loadXML()
-    libxml_disable_entity_loader(true);
+    $xmlLoader = libxml_disable_entity_loader(true);
 
     if (empty($response->body) || !$dom->loadXML($response->body, LIBXML_NOBLANKS)) {
       return null;
@@ -301,6 +301,9 @@ abstract class Recurly_Base
       $obj->_afterParseResponse($response, $uri);
       $obj->setHeaders($response->headers);
     }
+
+    libxml_disable_entity_loader($xmlLoader);
+
     return $obj;
   }
 
@@ -313,7 +316,7 @@ abstract class Recurly_Base
     $dom = new DOMDocument();
 
     // Attempt to prevent XXE that could be exploited through loadXML()
-    libxml_disable_entity_loader(true);
+    $xmlLoader = libxml_disable_entity_loader(true);
 
     if (empty($xml) || !$dom->loadXML($xml, LIBXML_NOBLANKS)) return null;
 
@@ -327,6 +330,8 @@ abstract class Recurly_Base
       Recurly_Resource::__parseXmlToObject($rootNode->firstChild, $this->_errors, $this->_client);
     }
     $this->updateErrorAttributes();
+
+    libxml_disable_entity_loader($xmlLoader);
   }
 
   protected static function __parseXmlToObject($node, &$object, $client)

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -286,8 +286,7 @@ abstract class Recurly_Base
   protected static function __parseResponseToNewObject($response, $uri, $client) {
     $dom = new DOMDocument();
 
-    // Attempt to prevent XXE that could be exploited through loadXML()
-    libxml_disable_entity_loader(true);
+    Recurly_Client::disableXmlEntityLoading();
 
     if (empty($response->body) || !$dom->loadXML($response->body, LIBXML_NOBLANKS)) {
       return null;
@@ -312,8 +311,7 @@ abstract class Recurly_Base
   {
     $dom = new DOMDocument();
 
-    // Attempt to prevent XXE that could be exploited through loadXML()
-    libxml_disable_entity_loader(true);
+    Recurly_Client::disableXmlEntityLoading();
 
     if (empty($xml) || !$dom->loadXML($xml, LIBXML_NOBLANKS)) return null;
 

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -120,7 +120,7 @@ class Recurly_Client
    */
   public static function disableXmlEntityLoading()
   {
-    $disable = getenv('RECURLY_DISABLE_ENTITY_LOADING', true);
+    $disable = getenv('RECURLY_DISABLE_ENTITY_LOADING');
     if ($disable === false) {
         $disable = true;
     } else {

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -115,6 +115,22 @@ class Recurly_Client
   }
 
   /**
+   * Attempt to prevent XXE that could be exploited through loadXML()
+   * unless requested not to
+   */
+  public static function disableXmlEntityLoading()
+  {
+    $disable = getenv('RECURLY_DISABLE_ENTITY_LOADING', true);
+    if ($disable === false) {
+        $disable = true;
+    } else {
+        $disable = (bool)$disable;
+    }
+
+    libxml_disable_entity_loader($disable);
+  }
+
+  /**
    * Current API key
    * @return string API key
    */

--- a/lib/recurly/push_notification.php
+++ b/lib/recurly/push_notification.php
@@ -98,11 +98,11 @@ class Recurly_PushNotification
 
   function parseXml($post_xml)
   {
-
     // Attempt to prevent XXE that could be exploited through simplexml_load_string()
-    libxml_disable_entity_loader(true);
+    $xmlLoader = libxml_disable_entity_loader(true);
 
     if (!@simplexml_load_string ($post_xml)) {
+      libxml_disable_entity_loader($xmlLoader);
       return;
     }
     $xml = new SimpleXMLElement ($post_xml);
@@ -139,5 +139,7 @@ class Recurly_PushNotification
           break;
       }
     }
+
+    libxml_disable_entity_loader($xmlLoader);
   }
 }

--- a/lib/recurly/push_notification.php
+++ b/lib/recurly/push_notification.php
@@ -99,8 +99,7 @@ class Recurly_PushNotification
   function parseXml($post_xml)
   {
 
-    // Attempt to prevent XXE that could be exploited through simplexml_load_string()
-    libxml_disable_entity_loader(true);
+    Recurly_Client::disableXmlEntityLoading();
 
     if (!@simplexml_load_string ($post_xml)) {
       return;

--- a/lib/recurly/push_notification.php
+++ b/lib/recurly/push_notification.php
@@ -98,11 +98,11 @@ class Recurly_PushNotification
 
   function parseXml($post_xml)
   {
+
     // Attempt to prevent XXE that could be exploited through simplexml_load_string()
-    $xmlLoader = libxml_disable_entity_loader(true);
+    libxml_disable_entity_loader(true);
 
     if (!@simplexml_load_string ($post_xml)) {
-      libxml_disable_entity_loader($xmlLoader);
       return;
     }
     $xml = new SimpleXMLElement ($post_xml);
@@ -139,7 +139,5 @@ class Recurly_PushNotification
           break;
       }
     }
-
-    libxml_disable_entity_loader($xmlLoader);
   }
 }

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -104,16 +104,11 @@ class Recurly_ClientResponse
     $dom = new DOMDocument();
 
     // Attempt to prevent XXE that could be exploited through loadXML()
-    $xmlLoader = libxml_disable_entity_loader(true);
+    libxml_disable_entity_loader(true);
 
-    if (empty($xml) || !$dom->loadXML($xml)) {
-        libxml_disable_entity_loader($xmlLoader);
-        return null;
-    }
+    if (empty($xml) || !$dom->loadXML($xml)) return null;
 
     $rootNode = $dom->documentElement;
-
-    libxml_disable_entity_loader($xmlLoader);
     if ($rootNode->nodeName == 'error')
       return Recurly_ClientResponse::parseErrorNode($rootNode);
     else

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -104,11 +104,16 @@ class Recurly_ClientResponse
     $dom = new DOMDocument();
 
     // Attempt to prevent XXE that could be exploited through loadXML()
-    libxml_disable_entity_loader(true);
+    $xmlLoader = libxml_disable_entity_loader(true);
 
-    if (empty($xml) || !$dom->loadXML($xml)) return null;
+    if (empty($xml) || !$dom->loadXML($xml)) {
+        libxml_disable_entity_loader($xmlLoader);
+        return null;
+    }
 
     $rootNode = $dom->documentElement;
+
+    libxml_disable_entity_loader($xmlLoader);
     if ($rootNode->nodeName == 'error')
       return Recurly_ClientResponse::parseErrorNode($rootNode);
     else

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -103,8 +103,7 @@ class Recurly_ClientResponse
   private function parseErrorXml($xml) {
     $dom = new DOMDocument();
 
-    // Attempt to prevent XXE that could be exploited through loadXML()
-    libxml_disable_entity_loader(true);
+    Recurly_Client::disableXmlEntityLoading();
 
     if (empty($xml) || !$dom->loadXML($xml)) return null;
 


### PR DESCRIPTION
Disabling the Entity Loader was a great idea
https://github.com/recurly/recurly-client-php/commit/a7e08334

However, this wreaked havoc for me for other code on the site that tries to load xml files.

This patch may be a bit ham-fisted, but it corrects the problem on my sites and I hope you'll consider including it or a similar fix in future versions.