### PR TITLE
Support billing_info on Subscription, Invoice & Gift card

### DIFF
--- a/lib/recurly/gift_card.php
+++ b/lib/recurly/gift_card.php
@@ -83,7 +83,8 @@ class Recurly_GiftCard extends Recurly_Resource
     } else {
       return array(
         'product_code','unit_amount_in_cents','delivery',
-        'gifter_account','currency'
+        'gifter_account','currency',
+        'billing_info'
       );
     }
   }

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -233,7 +233,7 @@ class Recurly_Invoice extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return array(
-      'address', 'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
+      'address', 'billing_info', 'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
       'collection_method', 'net_terms', 'po_number', 'currency', 'credit_customer_notes',
       'gateway_code'
     );

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -270,7 +270,7 @@ class Recurly_Subscription extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return array(
-      'account', 'plan_code', 'coupon_code', 'coupon_codes',
+      'account', 'billing_info', 'plan_code', 'coupon_code', 'coupon_codes',
       'unit_amount_in_cents', 'quantity', 'currency', 'starts_at',
       'trial_ends_at', 'total_billing_cycles', 'first_renewal_date',
       'timeframe', 'subscription_add_ons', 'net_terms', 'po_number',


### PR DESCRIPTION
Makes possible to resolve "three_d_secure_action_required" error triggered while:
- creating subscription
- updating subscription
- collecting invoice
- creating gift card

Support for this is mentioned in the [SCA integration guide](https://dev.recurly.com/page/recurly-3d-secure-2-integration-guide#section--step-106-submit-new-purchase-request) as well as documented on corresponding endpoints in API reference.