### PR TITLE
Add shipping address to Purchase

### DIFF
--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -44,7 +44,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $shipping_address->country = 'US';
     $shipping_address->zip = '94110';
     $shipping_address->nickname = 'Home';
-    $purchase->account->shipping_addresses = array($shipping_address);
+    $purchase->shipping_address = $shipping_address;
 
     $adjustment = new Recurly_Adjustment();
     $adjustment->product_code = "abcd123";
@@ -62,7 +62,7 @@ class Recurly_PurchaseTest extends Recurly_TestCase
     $purchase = $this->mockPurchase();
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><billing_info><token_id>7z6furn4jvb9</token_id></billing_info><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address><shipping_addresses><shipping_address><address1>400 Dolores St</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><nickname>Home</nickname><first_name>Dolores</first_name><last_name>Du Monde</last_name></shipping_address></shipping_addresses></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes><gateway_code>aBcD1234</gateway_code><transaction_type>moto</transaction_type></purchase>\n",
+      "<?xml version=\"1.0\"?>\n<purchase><account><account_code>aba9209a-aa61-4790-8e61-0a2692435fee</account_code><billing_info><token_id>7z6furn4jvb9</token_id></billing_info><address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone></address></account><adjustments><adjustment><currency>USD</currency><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>at_invoice</revenue_schedule_type><product_code>abcd123</product_code></adjustment></adjustments><collection_method>automatic</collection_method><currency>USD</currency><customer_notes>Customer Notes</customer_notes><terms_and_conditions>Terms and Conditions</terms_and_conditions><vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes><shipping_address><address1>400 Dolores St</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><nickname>Home</nickname><first_name>Dolores</first_name><last_name>Du Monde</last_name></shipping_address><gateway_code>aBcD1234</gateway_code><transaction_type>moto</transaction_type></purchase>\n",
       $purchase->xml()
     );
   }

--- a/lib/recurly/purchase.php
+++ b/lib/recurly/purchase.php
@@ -13,6 +13,7 @@
  * @property string $customer_notes Optional notes field. This will default to the Customer Notes text specified on the Invoice Settings page in your Recurly admin. Custom notes made on an invoice for a one time charge will not carry over to subsequent invoices.
  * @property string $terms_and_conditions Optional Terms and Conditions field. This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Custom notes will stay with a subscription on all renewals.
  * @property string $vat_reverse_charge_notes Optional VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription. Custom notes will stay with a subscription on all renewals.
+ * @property Recurly_ShippingAddress $shipping_address Optional Shipping Address field
  * @property integer $shipping_address_id Optional id of an existing ShippingAddress to be applied to all subscriptions and adjustments in purchase.
  * @property string $gateway_code Optional base36 encoded id for the gateway you wish to use for this transaction.
  * @property Recurly_ShippingFee[] $shipping_fees Optional array of shipping fees to apply to the purchase.
@@ -116,7 +117,7 @@ class Recurly_Purchase extends Recurly_Resource
     return array(
       'account', 'adjustments', 'collection_method', 'currency', 'po_number',
       'net_terms', 'subscriptions', 'gift_card', 'coupon_codes', 'customer_notes',
-      'terms_and_conditions', 'vat_reverse_charge_notes', 'shipping_address_id',
+      'terms_and_conditions', 'vat_reverse_charge_notes', 'shipping_address', 'shipping_address_id',
       'gateway_code', 'shipping_fees', 'transaction_type'
     );
   }


### PR DESCRIPTION
- Added 'shipping_address' as a writeable attribute 
- Amended 'Purchase_Test.php' to account for 'shipping_address' as Purchase attribute instead of Account attribute