### PR TITLE
Add vat_number to ShippingAddress class

### DIFF
--- a/Tests/Recurly/ShippingAddress_Test.php
+++ b/Tests/Recurly/ShippingAddress_Test.php
@@ -21,6 +21,7 @@ class Recurly_ShippingAddressTest extends Recurly_TestCase
     $shad->zip = "94110";
     $shad->country = "US";
     $shad->company = "Recurly Inc.";
+    $shad->vat_number = "12345";
 
     return $shad;
   }
@@ -29,7 +30,7 @@ class Recurly_ShippingAddressTest extends Recurly_TestCase
     $shad = $this->mockShippingAddress();
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address>\n",
+      "<?xml version=\"1.0\"?>\n<shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company><vat_number>12345</vat_number></shipping_address>\n",
       $shad->xml()
     );
   }

--- a/lib/recurly/shipping_address.php
+++ b/lib/recurly/shipping_address.php
@@ -16,7 +16,7 @@ class Recurly_ShippingAddress extends Recurly_Resource
     return array(
       'address1', 'address2', 'city', 'state',
       'zip', 'country', 'phone', 'email', 'nickname',
-      'first_name', 'last_name', 'company'
+      'first_name', 'last_name', 'company', 'vat_number'
     );
   }
   protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {


### PR DESCRIPTION
`vatNumber` is a supported attribute for `ShippingAddress` but has not yet been included in the PHP client library. This PR addresses that issue.