### PR TITLE
Simplify the PHPUnit configuration

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,13 +1,5 @@
 <?php
 
-
-error_reporting(E_ALL);
-ini_set('display_errors','On');
-
-// Setting timezone for time() function.
-date_default_timezone_set('America/Los_Angeles');
-
-
 /**
  * Base class for our tests that sets up a mock client.
  *

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,4 +30,9 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <ini name="date.timezone" value="America/Los_Angeles" />
+        <ini name="display_errors" value="on" />
+    </php>
+
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,11 @@
 <phpunit
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
-         backupGlobals="true"
-         backupStaticAttributes="false"
-         bootstrap="Tests/bootstrap.php"
-         cacheTokens="false"
-         colors="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         forceCoversAnnotation="false"
-         mapTestClassNameToCoveredClassName="false"
-         printerClass="PHPUnit_TextUI_ResultPrinter"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         stopOnRisky="false"
-         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
-         timeoutForSmallTests="1"
-         timeoutForMediumTests="10"
-         timeoutForLargeTests="60"
-         verbose="false">
+    bootstrap="Tests/bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    >
 
     <testsuites>
         <testsuite name="My Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,12 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+      <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">lib</directory>
+      </whitelist>
+    </filter>
+
     <php>
         <ini name="date.timezone" value="America/Los_Angeles" />
         <ini name="display_errors" value="on" />


### PR DESCRIPTION
This PR simplifies the PHPUnit configuration in the following ways:

- Configure PHP INI settings in `phpunit.xml.dist`, not the `Tests/bootstrap.php` file.
- Remove a lot of older, unneeded attributes from the `<phpunit>` element

Additionally, I've whitelisted files for generating code coverage reports.