### PR TITLE
Release 2.12.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,21 @@
 
 ## Version 2.12.10 (December 31, 2019)
 
-* Add vat_number to ShippingAddress class [PR] (https://github.com/recurly/recurly-client-php/pull/443)
-* Update the documentation and testing matrix for current PHP releases [PR] (https://github.com/recurly/recurly-client-php/pull/445)
-* Simplify the PHPUnit configuration [PR] (https://github.com/recurly/recurly-client-php/pull/446)
-* Ensure PHP 7.4 compatibility [PR] (https://github.com/recurly/recurly-client-php/pull/449)
+* Add vat_number to ShippingAddress class [PR](https://github.com/recurly/recurly-client-php/pull/443)
+* Update the documentation and testing matrix for current PHP releases [PR](https://github.com/recurly/recurly-client-php/pull/445)
+* Simplify the PHPUnit configuration [PR](https://github.com/recurly/recurly-client-php/pull/446)
+* Ensure PHP 7.4 compatibility [PR](https://github.com/recurly/recurly-client-php/pull/449)
 
 ## Version 2.12.9 (November 21, 2019)
 
 This brings us up to API version 2.24. There are no breaking changes
 
-* Add Item class [PR] (https://github.com/recurly/recurly-client-php/pull/441)
+* Add Item class [PR](https://github.com/recurly/recurly-client-php/pull/441)
 
 ## Version 2.12.8 (October 22nd, 2019)
 
-* Add shipping address to Purchase [PR] (https://github.com/recurly/recurly-client-php/pull/435)
-* Subscription timeframe changes [PR] (https://github.com/recurly/recurly-client-php/pull/419)
+* Add shipping address to Purchase [PR](https://github.com/recurly/recurly-client-php/pull/435)
+* Subscription timeframe changes [PR](https://github.com/recurly/recurly-client-php/pull/419)
 
 ## Version 2.12.7 (September 20th, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.10 (December 31, 2019)
+
+* Add vat_number to ShippingAddress class [PR] (https://github.com/recurly/recurly-client-php/pull/443)
+* Update the documentation and testing matrix for current PHP releases [PR] (https://github.com/recurly/recurly-client-php/pull/445)
+* Simplify the PHPUnit configuration [PR] (https://github.com/recurly/recurly-client-php/pull/446)
+* Ensure PHP 7.4 compatibility [PR] (https://github.com/recurly/recurly-client-php/pull/449)
+
 ## Version 2.12.9 (November 21, 2019)
 
 This brings us up to API version 2.24. There are no breaking changes

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -51,16 +51,16 @@ class Recurly_BaseTest extends Recurly_TestCase {
     $this->client->addResponse('GET', 'accounts', 'accounts/index-200.xml');
     $accounts = Recurly_Base::_get('accounts', $this->client);
     $this->assertTrue(method_exists($accounts, 'getHeaders'),"Accounts Class does not have method getHeaders");
-    $this->assertInternalType('array',$accounts->getHeaders());
+    $this->assertIsArray($accounts->getHeaders());
 
     $this->client->addResponse('GET', 'subscriptions', 'subscriptions/index-200.xml');
     $subscriptions = Recurly_Base::_get('subscriptions', $this->client);
     $this->assertTrue(method_exists($subscriptions, 'getHeaders'),'Subscriptions Class does not have method getHeaders');
-    $this->assertInternalType('array',$subscriptions->getHeaders());
+    $this->assertIsArray($subscriptions->getHeaders());
 
     $this->client->addResponse('GET', 'abcdef1234567890', 'adjustments/show-200.xml');
     $adjustment = Recurly_Base::_get('abcdef1234567890', $this->client);
     $this->assertTrue(method_exists($adjustment, 'getHeaders'),'Adjustments Class does not have method getHeaders');
-    $this->assertInternalType('array',$adjustment->getHeaders());
+    $this->assertIsArray($adjustment->getHeaders());
   }
 }

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -51,28 +51,16 @@ class Recurly_BaseTest extends Recurly_TestCase {
     $this->client->addResponse('GET', 'accounts', 'accounts/index-200.xml');
     $accounts = Recurly_Base::_get('accounts', $this->client);
     $this->assertTrue(method_exists($accounts, 'getHeaders'),"Accounts Class does not have method getHeaders");
-<<<<<<< HEAD
-    $this->assertIsArray($accounts->getHeaders());
-=======
     $this->assertInternalType('array', $accounts->getHeaders());
->>>>>>> f2bc6ef161edf4e99acbc1eaec1a73cb628b986e
 
     $this->client->addResponse('GET', 'subscriptions', 'subscriptions/index-200.xml');
     $subscriptions = Recurly_Base::_get('subscriptions', $this->client);
     $this->assertTrue(method_exists($subscriptions, 'getHeaders'),'Subscriptions Class does not have method getHeaders');
-<<<<<<< HEAD
-    $this->assertIsArray($subscriptions->getHeaders());
-=======
     $this->assertInternalType('array', $subscriptions->getHeaders());
->>>>>>> f2bc6ef161edf4e99acbc1eaec1a73cb628b986e
 
     $this->client->addResponse('GET', 'abcdef1234567890', 'adjustments/show-200.xml');
     $adjustment = Recurly_Base::_get('abcdef1234567890', $this->client);
     $this->assertTrue(method_exists($adjustment, 'getHeaders'),'Adjustments Class does not have method getHeaders');
-<<<<<<< HEAD
-    $this->assertIsArray($adjustment->getHeaders());
-=======
     $this->assertInternalType('array', $adjustment->getHeaders());
->>>>>>> f2bc6ef161edf4e99acbc1eaec1a73cb628b986e
   }
 }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -50,7 +50,7 @@ class Recurly_Client
   private static $apiUrl = 'https://%s.recurly.com/v2';
 
 
-  const API_CLIENT_VERSION = '2.12.9';
+  const API_CLIENT_VERSION = '2.12.10';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
Release 2.12.10

* Add vat_number to ShippingAddress class (https://github.com/recurly/recurly-client-php/pull/443)
* Update the documentation and testing matrix for current PHP releases (https://github.com/recurly/recurly-client-php/pull/445)
* Simplify the PHPUnit configuration (https://github.com/recurly/recurly-client-php/pull/446)
* Ensure PHP 7.4 compatibility (https://github.com/recurly/recurly-client-php/pull/449)