### PR TITLE
See #451 - empty subscription_add_ons

### DIFF
--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -60,7 +60,7 @@ class Recurly_Subscription extends Recurly_Resource
 {
   public function __construct($href = null, $client = null) {
     parent::__construct($href, $client);
-    $this->subscription_add_ons = array();
+    $this->subscription_add_ons = null;
     $this->custom_fields = new Recurly_CustomFieldList();
   }
 
@@ -78,6 +78,9 @@ class Recurly_Subscription extends Recurly_Resource
    * @throws Recurly_Error
    */
   public function create() {
+    if ($this->subscription_add_ons === null) {
+      unset($this->subscription_add_ons);
+    }
     $this->_save(Recurly_Client::POST, Recurly_Client::PATH_SUBSCRIPTIONS);
   }
 


### PR DESCRIPTION
See https://github.com/recurly/recurly-client-php/issues/451. This should avoid sending an empty array when creating a new subscription, unless when you explicitly and purposefully want to set it as an empty array.