### PR TITLE
Allow external domains for getFile() calls

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -283,8 +283,6 @@ class Recurly_Client
    * @throws Recurly_Error
    */
   public function getFile($uri, $file_pointer) {
-    $this->_verifyUri($uri);
-
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $uri);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);


### PR DESCRIPTION
Addresses [issue 453](https://github.com/recurly/recurly-client-php/issues/453).

- Removed `verifyUri` from `getFile`, which will allow external domains, e.g. s3.amazonaws.com

We've determined it's safe to remove this check because getFile is limited to calls that are not processed by the client and getFile does not send authentication or PII details to it's target server. Futhermore, the URL comes from Recurly's response so we can reasonably assume it will be safe to invoke. Removing this check allows us to change the downloads in the future if they move from s3.

