### PR TITLE
Add 'Delete' to ShippingAddress object

### DIFF
--- a/Tests/Recurly/ShippingAddress_Test.php
+++ b/Tests/Recurly/ShippingAddress_Test.php
@@ -61,4 +61,18 @@ class Recurly_ShippingAddressTest extends Recurly_TestCase
     }
   }
 
+  public function testDeleteShippingAddress() {
+    $this->client->addResponse('GET', '/accounts/abcdef1234567890/shipping_addresses', 'shipping_addresses/index-200.xml');
+    $this->client->addResponse('DELETE', 'https://api.recurly.com/v2/accounts/abcdef1234567890/shipping_addresses/1234567', 'shipping_addresses/destroy-204.xml');
+
+    $shipping_addresses = Recurly_ShippingAddressList::get('abcdef1234567890', null, $this->client);
+
+    foreach ($shipping_addresses as $shipping_address) {
+      if ($shipping_address->id == 1234567) {
+        $shipping_address->delete();
+      }
+      $this->assertInstanceOf('Recurly_ShippingAddress', $shipping_address);
+    }
+  }
+
 }

--- a/Tests/fixtures/shipping_addresses/destroy-204.xml
+++ b/Tests/fixtures/shipping_addresses/destroy-204.xml
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/lib/recurly/shipping_address.php
+++ b/lib/recurly/shipping_address.php
@@ -9,6 +9,10 @@ class Recurly_ShippingAddress extends Recurly_Resource
     $this->_save(Recurly_Client::PUT, $this->getHref());
   }
 
+  public function delete() {
+    return Recurly_Base::_delete($this->getHref(), $this->_client);
+  }
+
   protected function getNodeName() {
     return 'shipping_address';
   }


### PR DESCRIPTION
- Add `delete` function to ShippingAddress object
- Add unit test 
<!--
To delete first shipping address associated with account:
```
$shipping_addresses = Recurly_ShippingAddressList::get($account->account_code);
$shipping_address = $shipping_addresses[0];
$shipping_address->delete() ;
```
-->

To delete a shipping address by id (id = 2922857578120715120 in this example):
```
$shipping_addresses = Recurly_ShippingAddressList::get($account->account_code);

foreach ($shipping_addresses as $address) {
    if ($address->id == 2922857578120715120){
      $address->delete();
    }
}
```

To delete all shipping addresses associated with account:
```
$shipping_addresses = Recurly_ShippingAddressList::get($account->account_code);

foreach ($shipping_addresses as $address) {
    $address->delete();
} 
```