### PR TITLE
Release 2.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Recurly PHP Client Library CHANGELOG
 
-## Version 2.12.11 (Februaru 20, 2020)
+## Version 2.12.11 (February 20, 2020)
 
 This brings us up to API version 2.25. There are no breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.11 (Februaru 20, 2020)
+
+This brings us up to API version 2.25. There are no breaking changes
+
+* Allow external domains for getFile() calls [PR](https://github.com/recurly/recurly-client-php/pull/454)
+* Cleanup old upgrade warning [PR](https://github.com/recurly/recurly-client-php/pull/455)
+* Add 'Delete' to ShippingAddress object [PR](https://github.com/recurly/recurly-client-php/pull/457)
+* Add external_sku to Adjustment (included in API version 2.24) [PR](https://github.com/recurly/recurly-client-php/pull/458)
+* Add convertTrial() to Subscription [PR](https://github.com/recurly/recurly-client-php/pull/459)
+
 ## Version 2.12.10 (December 31, 2019)
 
 * Add vat_number to ShippingAddress class [PR](https://github.com/recurly/recurly-client-php/pull/443)

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -50,7 +50,7 @@ class Recurly_Client
   private static $apiUrl = 'https://%s.recurly.com/v2';
 
 
-  const API_CLIENT_VERSION = '2.12.10';
+  const API_CLIENT_VERSION = '2.12.11';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
This brings us up to API version 2.25. There are no breaking changes

* Allow external domains for `getFile()` calls (https://github.com/recurly/recurly-client-php/pull/454)
* Cleanup old upgrade warning (https://github.com/recurly/recurly-client-php/pull/455)
* Add 'Delete' to ShippingAddress object (https://github.com/recurly/recurly-client-php/pull/457)
* Add `external_sku` to Adjustment (included in API version 2.24)  (https://github.com/recurly/recurly-client-php/pull/458)
* Add `convertTrial()`to Subscription  (https://github.com/recurly/recurly-client-php/pull/459)