### PR TITLE
Prevent overwritten address on new purchase with existing account

### DIFF
--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -57,7 +57,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->account = $account;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code><address></address></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons></subscription_add_ons><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method><imported_trial>true</imported_trial></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>123</account_code></account><plan_code>gold</plan_code><currency>USD</currency><subscription_add_ons></subscription_add_ons><net_terms>10</net_terms><po_number>1000</po_number><collection_method>manual</collection_method><imported_trial>true</imported_trial></subscription>\n",
       $subscription->xml()
   );
   }
@@ -111,7 +111,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->renewal_billing_cycles = 1;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons><bulk>true</bulk><terms_and_conditions>Some Terms and Conditions</terms_and_conditions><customer_notes>Some Customer Notes</customer_notes><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields><auto_renew>false</auto_renew><renewal_billing_cycles>1</renewal_billing_cycles></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons><bulk>true</bulk><terms_and_conditions>Some Terms and Conditions</terms_and_conditions><customer_notes>Some Customer Notes</customer_notes><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields><auto_renew>false</auto_renew><renewal_billing_cycles>1</renewal_billing_cycles></subscription>\n",
       $subscription->xml()
     );
   }
@@ -174,7 +174,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $account->billing_info = $billing_info;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons><subscription_add_on><add_on_code>more</add_on_code><quantity>1</quantity></subscription_add_on></subscription_add_ons></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><username>username</username><first_name>Verena</first_name><last_name>Example</last_name><email>verena@example.com</email><accept_language>en-US</accept_language><billing_info><first_name>Verena</first_name><last_name>Example</last_name><ip_address>192.168.0.1</ip_address><number>4111-1111-1111-1111</number><month>11</month><year>2015</year><verification_value>123</verification_value></billing_info></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons><subscription_add_on><add_on_code>more</add_on_code><quantity>1</quantity></subscription_add_on></subscription_add_ons></subscription>\n",
       $subscription->xml()
     );
   }
@@ -192,7 +192,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->account->billing_info->token_id = 'abc123';
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><billing_info><token_id>abc123</token_id></billing_info><address></address></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><account><account_code>account_code</account_code><billing_info><token_id>abc123</token_id></billing_info></account><plan_code>gold</plan_code><quantity>1</quantity><currency>USD</currency><subscription_add_ons></subscription_add_ons></subscription>\n",
       $subscription->xml()
     );
   }

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -42,6 +42,7 @@ class Recurly_Account extends Recurly_Resource
     parent::__construct(null, $client);
     if (!is_null($accountCode))
       $this->account_code = $accountCode;
+    # setting address this way to prevent it from ending up in "unsavedKeys"
     $this->_values["address"] = new Recurly_Address();
     $this->custom_fields = new Recurly_CustomFieldList();
   }

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -42,7 +42,7 @@ class Recurly_Account extends Recurly_Resource
     parent::__construct(null, $client);
     if (!is_null($accountCode))
       $this->account_code = $accountCode;
-    $this->address = new Recurly_Address();
+    $this->_values["address"] = new Recurly_Address();
     $this->custom_fields = new Recurly_CustomFieldList();
   }
 

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -183,8 +183,8 @@ abstract class Recurly_Resource extends Recurly_Base
       if(!array_key_exists($attr, $this->_values)) { continue; }
 
       if(isset($this->_unsavedKeys[$attr]) ||
-        $nested && in_array($attr, $requiredAttributes) ||
-        (is_array($this->_values[$attr]) || $this->_values[$attr] instanceof ArrayAccess))
+         $nested && in_array($attr, $requiredAttributes) ||
+         (is_array($this->_values[$attr]) || $this->_values[$attr] instanceof ArrayAccess))
       {
         $attributes[$attr] = $this->$attr;
       }

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -183,8 +183,8 @@ abstract class Recurly_Resource extends Recurly_Base
       if(!array_key_exists($attr, $this->_values)) { continue; }
 
       if(isset($this->_unsavedKeys[$attr]) ||
-         $nested && in_array($attr, $requiredAttributes) ||
-         (is_array($this->_values[$attr]) || $this->_values[$attr] instanceof ArrayAccess))
+        $nested && in_array($attr, $requiredAttributes) ||
+        (is_array($this->_values[$attr]) || $this->_values[$attr] instanceof ArrayAccess))
       {
         $attributes[$attr] = $this->$attr;
       }


### PR DESCRIPTION
- When new Purchase is created with an existing account, account's address field will not be overwritten with blank values when a new address is not specified.
- When the existing account's address is changed with the new Purchase is created (rare), the account's address will be updated with the new fields.