### PR TITLE
Add additional attributes to support item-backed add-ons

### DIFF
--- a/Tests/Recurly/Addon_Test.php
+++ b/Tests/Recurly/Addon_Test.php
@@ -30,4 +30,15 @@ class Recurly_AddonTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Addon', $addon);
     $addon->delete();
   }
+
+  public function testCreateXmlItemBackedAddOn() {
+    $item = new Recurly_Item();
+    $item->item_code = 'little_llama';
+    $addon = new Recurly_Addon();
+    $addon->plan_code = 'gold';
+    $addon->item_code = $item->item_code;
+    $addon->unit_amount_in_cents->addCurrency('USD', 400);
+
+    $this->assertEquals("<?xml version=\"1.0\"?>\n<add_on><item_code>little_llama</item_code><unit_amount_in_cents><USD>400</USD></unit_amount_in_cents></add_on>\n", $addon->xml());
+  }
 }

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -4,21 +4,24 @@
  * class Recurly_Addon
  * @property Recurly_Stub $plan The URL of the associated Recurly_Plan for this add-on.
  * @property Recurly_Stub $measured_unit The URL of the associated Recurly_MeasuredUnit for this add-on.
- * @property string $add_on_code The add-on code. Max of 50 characters.
- * @property string $name The add-on name. Max of 255 characters.
+ * @property Recurly_Stub $item The URL of the associated Recurly_Item for this add-on, if one exists.
+ * @property string $add_on_code The add-on code. Max of 50 characters. If item_code is present, add_on_code must be absent. If item_code is not present, add_on_code is required.
+ * @property string $name The add-on name. Max of 255 characters. If item_code is present, name must be absent. If item_code is not present, name is required.
+ * @property string $item_code Item code for an existing active item to be used as an add-on on the plan.
  * @property int $default_quantity Default quantity for the hosted pages, defaults to 1.
  * @property int $default_quantity_on_hosted_page If true, displays a quantity field on the hosted pages for the add-on.
- * @property string $tax_code Optional field for EU VAT merchants and Avalara AvaTax Pro merchants. If you are using Recurly's EU VAT feature, you can use values of: [unknown, physical, digital]. If you have your own AvaTax account configured, you can use Avalara's tax codes to assign custom tax rules.
- * @property Recurly_CurrencyList $unit_amount_in_cents Array of unit amounts with their currency code. Max 10000000. Ex. $5.00 USD would be <USD>500</USD>.
- * @property string $accounting_code Accounting code for invoice line items for the add-on. Max of 20 characters.
- * @property string $add_on_type Whether the add-on is Fixed-Price or Usage-Based. Allowed values: [fixed, usage].
+ * @property string $tax_code Optional field for EU VAT merchants and Avalara AvaTax Pro merchants. If you are using Recurly's EU VAT feature, you can use values of: [unknown, physical, digital]. If you have your own AvaTax account configured, you can use Avalara's tax codes to assign custom tax rules. If item_code is present, tax_code must be absent.
+ * @property Recurly_CurrencyList $unit_amount_in_cents Array of unit amounts with their currency code. Max 10000000. Ex. $5.00 USD would be <USD>500</USD>. Optional if item_code is present and existing item has default pricing. Otherwise unit_amount_in_cents is required.
+ * @property string $accounting_code Accounting code for invoice line items for the add-on, defaults to the value of add_on_code. Max of 20 characters. If item_code is present, accounting_code must be absent.
+ * @property string $add_on_type Whether the add-on is Fixed-Price (fixed), or Usage-Based (usage). If item_code is present, add_on_type must be absent.
  * @property boolean $optional Whether the add-on is optional for the customer to include in their purchase on the hosted payment page.
- * @property string $usage_type string If add_on_type = usage, you will see usage_type, which can be price or percentage. If price, the price is defined in unit_amount_in_cents. If percentage, the percentage is defined in usage_percentage.
- * @property float $usage_percentage If add_on_type = usage, you will see usage_percentage, which can have a value if usage_type = percentage. Must be between 0.0000 and 100.0000.
- * @property string $revenue_schedule_type Optional field for setting a revenue schedule type. This will determine how revenue for the associated Plan should be recognized. When creating a Plan, if you supply an end_date and end_date available schedule types are never, evenly, at_range_start, or at_range_end.
+ * @property string $usage_type string If add_on_type = usage, you must set a usage_type, which can be 'price' or 'percentage'. If 'price', the price is defined in unit_amount_in_cents. If 'percentage', the percentage is defined in usage_percentage. If 'item_code' present, usage_type must be absent.
+ * @property float $usage_percentage If add_on_type = usage and usage_type = percentage, you must set a usage_percentage. Must be between 0.0000 and 100.0000. If item_code is present, usage_percentage must be absent.
+ * @property string $revenue_schedule_type Optional field for setting a revenue schedule type. This will determine how revenue for the associated Plan should be recognized. When creating a Plan, if you supply an end_date and end_date available schedule types are never, evenly, at_range_start, or at_range_end. If item_code is present, revenue_schedule_type must be absent.
  * @property DateTime $created_at The date and time the add-on was created.
  * @property DateTime $updated_at The date and time the add-on was last updated.
  * @property string $plan_code Unique code to identify the plan.
+ * @property string $measured_unit_id The id of the measured unit on your site associated with the add-on. If item_code is present, measured_unit_id must be absent.
  */
 class Recurly_Addon extends Recurly_Resource
 {
@@ -59,9 +62,9 @@ class Recurly_Addon extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return array(
-      'add_on_code', 'name', 'display_quantity', 'default_quantity',
+      'add_on_code', 'item_code', 'name', 'display_quantity', 'default_quantity',
       'unit_amount_in_cents', 'accounting_code', 'tax_code',
-      'measured_unit_id', 'usage_type', 'add_on_type', 'revenue_schedule_type',
+      'measured_unit_id', 'usage_type', 'usage_percentage', 'add_on_type', 'revenue_schedule_type',
       'optional', 'display_quantity_on_hosted_page'
     );
   }


### PR DESCRIPTION
To create item-backed add-on:
```php
$add_on = new Recurly_Addon();
$add_on->plan_code = $plan->plan_code;
$add_on->item_code = $item->item_code;
$add_on->unit_amount_in_cents->addCurrency('USD', 400);
$add_on->create();
```

To get item-backed add-on:
```php
Recurly_Addon::get($plan->plan_code, $item->item_code);
```

To update item-backed add-on:
```php
$add_on->unit_amount_in_cents['USD'] = 200;
$add_on->update();
```

When add-on has an associated item, only the following attributes are updatable:
```php
unit_amount_in_cents
default_quantity
display_quantity_on_hosted_page
optional
```