### PR TITLE
Enable gzip compression on HTTP responses

### DIFF
--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -147,6 +147,7 @@ abstract class BaseClient
             "Authorization" => "Basic {$auth_token}",
             "Accept" => "application/vnd.recurly.{$this->apiVersion()}",
             "Content-Type" => "application/json",
+            "Accept-Encoding" => "gzip",
         );
     }
 }

--- a/lib/recurly/http_adapter.php
+++ b/lib/recurly/http_adapter.php
@@ -40,6 +40,14 @@ class HttpAdapter
         $options['header'] = $headers_str;
         $context = stream_context_create(['http' => $options]);
         $result = file_get_contents($url, false, $context);
+
+        if (!empty($result)) {
+            foreach($http_response_header as $h) {
+                if(preg_match('/Content-Encoding:.*gzip/i', $h)) {
+                    $result = gzdecode($result);
+                }
+            }
+        }
         return array($result, $http_response_header);
     }
 }

--- a/tests/mock_client.php
+++ b/tests/mock_client.php
@@ -98,6 +98,7 @@ class MockClient extends BaseClient
             "Authorization" => "Basic {$auth_token}",
             "Accept" => "application/vnd.recurly.v2999-01-01",
             "Content-Type" => "application/json",
+            "Accept-Encoding" => "gzip",
         ];
     }
 }


### PR DESCRIPTION
Adds the `Accept-Encoding: gzip` header to the request and decodes gzipped responses where appropriate.

When requesting ~4500 transactions using the `list_transactions` method, there was ~18% speed improvement and the overall payload size was reduced by ~600%