### PR TITLE
Add IBAN attribute to BillingInfo

### DIFF
--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -9,6 +9,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
       array('GET', '/accounts/paypal1234567890/billing_info', 'billing_info/show-paypal-200.xml'),
       array('GET', '/accounts/amazon1234567890/billing_info', 'billing_info/show-amazon-200.xml'),
       array('GET', '/accounts/bankaccount1234567890/billing_info', 'billing_info/show-bank-account-200.xml'),
+      array('GET', '/accounts/sepa1234567890/billing_info', 'billing_info/show-sepa-200.xml'),
       array('PUT', '/accounts/abcdef1234567890/billing_info', 'billing_info/show-200.xml'),
       array('DELETE', '/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
       array('DELETE', 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
@@ -73,6 +74,13 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
 
     $this->assertEquals($billing_info->card_type, null);
     $this->assertEquals($billing_info->getHref(), 'https://api.recurly.com/v2/accounts/bankaccount1234567890/billing_info');
+  }
+
+  public function testGetIbanBillingInfo() {
+    $billing_info = Recurly_BillingInfo::get('sepa1234567890', $this->client);
+    $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
+    $this->assertEquals($billing_info->iban, 'US1234567890');
+    $this->assertEquals($billing_info->name_on_account, 'Account Name');
   }
 
   public function testDelete() {

--- a/Tests/fixtures/billing_info/show-sepa-200.xml
+++ b/Tests/fixtures/billing_info/show-sepa-200.xml
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<billing_info href="https://api.recurly.com/v2/accounts/sepa1234567890/billing_info">
+  <account href="https://api.recurly.com/v2/accounts/sepa1234567890"/>
+  <company nil="nil"></company>
+  <address1>123 Pretty Pretty Good St.</address1>
+  <address2 nil="nil"></address2>
+  <city>Los Angeles</city>
+  <state>CA</state>
+  <zip>90210</zip>
+  <country>US</country>
+  <phone nil="nil"></phone>
+  <vat_number nil="nil"></vat_number>
+  <iban>US1234567890</iban>
+  <name_on_account>Account Name</name_on_account>
+</billing_info>

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -37,6 +37,7 @@
  * @property-read string $last_four Credit card number, last four digits
  * @property string $card_type Visa, MasterCard, American Express, Discover, JCB, etc
  * @property-write string $three_d_secure_action_result_token_id An id returned by Recurly.js referencing the result of the 3DS authentication for PSD2
+ * @property string $iban International bank account number developed to identify an overseas bank account
  */
 class Recurly_BillingInfo extends Recurly_Resource
 {
@@ -105,7 +106,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id', 'external_hpp_type', 'gateway_token', 'gateway_code',
       'braintree_payment_nonce', 'roku_billing_agreement_id',
-      'three_d_secure_action_result_token_id', 'transaction_type'
+      'three_d_secure_action_result_token_id', 'transaction_type', 'iban'
     );
   }
 }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -24,7 +24,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.25';
+  public static $apiVersion = '2.26';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).


### PR DESCRIPTION
This feature is to allow support of the IBAN field in our V2 API for the applicable endpoints. This field is most similar to banking account information or credit card information, and is used to make payments for SEPA transactions.

IBAN numbers can be set in all endpoints that support BillingInfo:

PUT "/v2/accounts/{account_id}/billing_info"
PUT "/v2/accounts/{account_id}"
POST "/v2/accounts"
POST "/v2/subscriptions"
POST "/v2/purchases"
POST "/v2/purchases/preview"

A sample request payload is provided below:

```
<billing_info>
  <iban>IBANNUMBERHERE</iban>
  <name_on_account>Verena Example</name_on_account>
  <!-- address fields... ->
</billing_info>
```