### PR TITLE
Tiered pricing

### DIFF
--- a/Tests/Recurly/Addon_Test.php
+++ b/Tests/Recurly/Addon_Test.php
@@ -41,4 +41,22 @@ class Recurly_AddonTest extends Recurly_TestCase
 
     $this->assertEquals("<?xml version=\"1.0\"?>\n<add_on><item_code>little_llama</item_code><unit_amount_in_cents><USD>400</USD></unit_amount_in_cents></add_on>\n", $addon->xml());
   }
+
+  public function testCreateXmlTieredAddOn() {
+    $item = new Recurly_Item();
+    $addon = new Recurly_Addon();
+    $addon->plan_code = 'gold';
+    $addon->add_on_code = 'little_llama';
+    $addon->tier_type = 'tiered';
+
+    $tier1 = new Recurly_Tier();
+    $tier1->unit_amount_in_cents->addCurrency('USD', 400);
+    $tier1->ending_quantity = 800;
+    $tier2 = new Recurly_Tier();
+    $tier2->unit_amount_in_cents->addCurrency('USD', 200);
+  
+    $addon->tiers = array($tier1, $tier2);  
+
+    $this->assertEquals("<?xml version=\"1.0\"?>\n<add_on><add_on_code>little_llama</add_on_code><tier_type>tiered</tier_type><tiers><tier><unit_amount_in_cents><USD>400</USD></unit_amount_in_cents><ending_quantity>800</ending_quantity></tier><tier><unit_amount_in_cents><USD>200</USD></unit_amount_in_cents></tier></tiers></add_on>\n", $addon->xml());
+  }
 }

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -22,6 +22,8 @@
  * @property DateTime $updated_at The date and time the add-on was last updated.
  * @property string $plan_code Unique code to identify the plan.
  * @property string $measured_unit_id The id of the measured unit on your site associated with the add-on. If item_code is present, measured_unit_id must be absent.
+ * @property string $tier_type The type of tiered pricing. Types are 'tiered,' 'volume,' and 'stairstep.'
+ * @property Recurly_Tier[] $tiers The array of tiers for the add-on.
  */
 class Recurly_Addon extends Recurly_Resource
 {
@@ -65,7 +67,7 @@ class Recurly_Addon extends Recurly_Resource
       'add_on_code', 'item_code', 'name', 'display_quantity', 'default_quantity',
       'unit_amount_in_cents', 'accounting_code', 'tax_code',
       'measured_unit_id', 'usage_type', 'usage_percentage', 'add_on_type', 'revenue_schedule_type',
-      'optional', 'display_quantity_on_hosted_page'
+      'optional', 'display_quantity_on_hosted_page', 'tier_type', 'tiers'
     );
   }
 }

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -276,6 +276,8 @@ abstract class Recurly_Base
     'subscription_add_on' => 'Recurly_SubscriptionAddOn',
     'tax_detail' => 'Recurly_Tax_Detail',
     'tax_details' => 'array',
+    'tier' => 'Recurly_Tier',
+    'tiers' => 'array',
     'transaction' => 'Recurly_Transaction',
     'transactions' => 'Recurly_TransactionList',
     'transaction_error' => 'Recurly_TransactionError',

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -24,7 +24,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.25';
+  public static $apiVersion = '2.26';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).

--- a/lib/recurly/tier.php
+++ b/lib/recurly/tier.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * class Recurly_Tier
+ * @property int $unit_amount_in_cents Price of 1 unit of the add-on in cents.
+ * @property int $ending_quantity The maximum number of units per tier. The final tier is always to infinity. This means the last tier should have a `ending_quantity` of `NULL` or `999999999`.
+ */
+
+class Recurly_Tier extends Recurly_Resource
+{
+  function __construct($href = null, $client = null) {
+    parent::__construct($href, $client);
+    $this->unit_amount_in_cents = new Recurly_CurrencyList('unit_amount_in_cents');
+  }
+
+  protected function getNodeName() {
+    return 'tier';
+  }
+
+  protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {
+    if ($this->isEmbedded($node, 'tiers')) {
+      $tierNode = $node->appendChild($doc->createElement($this->getNodeName()));
+      parent::populateXmlDoc($doc, $tierNode, $obj, $nested);
+    } else {
+      parent::populateXmlDoc($doc, $node, $obj, $nested);
+    }
+  }
+
+  protected function getWriteableAttributes()
+  {
+    return array(
+      'unit_amount_in_cents', 'ending_quantity'
+    );
+  }
+}


### PR DESCRIPTION
To create add-on with tiered pricing:
```php
$add_on = new Recurly_Addon();
$add_on->plan_code = $plan->plan_code;
$add_on->add_on_code = 'plant';
$add_on->name = 'Plant';
$add_on->tier_type = 'tiered';

$tier1 = new Recurly_Tier();
$tier1->unit_amount_in_cents->addCurrency('USD', 400);
$tier1->ending_quantity = 800;
$tier2 = new Recurly_Tier();
$tier2->unit_amount_in_cents->addCurrency('USD', 200);

$add_on->tiers = array($tier1, $tier2);
$add_on->create();
```