### PR TITLE
Release 2.12.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.13 (March 26, 2020)
+
+This brings us up to API version 2.26. There are no breaking changes
+
+* Add IBAN attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-php/pull/476)
+* Tiered pricing [PR](https://github.com/recurly/recurly-client-php/pull/482)
+* Add mandate_reference attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-php/pull/483)
+
 ## Version 2.12.12 (March 17, 2020)
 
 * Transaction: update phpdoc [PR](https://github.com/recurly/recurly-client-php/pull/460)

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -52,7 +52,7 @@ class Recurly_Client
   private static $apiUrl = 'https://%s.recurly.com/v2';
 
 
-  const API_CLIENT_VERSION = '2.12.12';
+  const API_CLIENT_VERSION = '2.12.13';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
This brings us up to API version 2.26. There are no breaking changes

* Add IBAN attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-php/pull/476)
* Tiered pricing [PR](https://github.com/recurly/recurly-client-php/pull/482)
* Add mandate_reference attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-php/pull/483)