### PR TITLE
Updating release script to be uniform across all clients

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -16,7 +16,9 @@ hub release create -c -F $RELEASED_LOG $THIS_VERSION
 
 # Copy-pasteable messages for announcments
 echo ":php: PHP $THIS_VERSION Released :php:"
-echo "Packagist (:packagist:): https://packagist.org/packages/recurly/recurly-client#$THIS_VERSION"
+echo ":packagist: Packagist: https://packagist.org/packages/recurly/recurly-client#$THIS_VERSION"
 echo "Release: https://github.com/recurly/recurly-client-php/releases/tag/$THIS_VERSION"
 echo "Changelog:"
+echo "\`\`\`"
 cat "$RELEASED_LOG"
+echo "\`\`\`"


### PR DESCRIPTION
Updating the internal use release script to have the same output format as the rest of the client libraries.