### PR TITLE
Ensure that path parameters are not empty strings

### DIFF
--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -117,6 +117,22 @@ abstract class BaseClient
     }
 
     /**
+     * Checks that path parameters are valid
+     *
+     * @param array  $options Associatve array of tokens and their replacement values
+     */
+    private function _validatePathParameters(array $options = []): void
+    {
+        // Check to make sure that parameters are not empty values
+        $emptyValues = array_filter($options, function ($value, $key) {
+            return empty(trim($value));
+        }, ARRAY_FILTER_USE_BOTH);
+        if (!empty($emptyValues)) {
+            throw new RecurlyError(join(', ', array_keys($emptyValues)) . ' cannot be an empty value');
+        }
+    }
+
+    /**
      * Replaces placeholder values with supplied values
      * 
      * @param string $path    Tokenized path to make replacements on
@@ -126,6 +142,7 @@ abstract class BaseClient
      */
     protected function interpolatePath(string $path, array $options = []): string
     {
+        $this->_validatePathParameters($options);
         return array_reduce(
             array_keys($options), function ($p, $i) use ($options) {
                 return str_replace("{{$i}}", rawurlencode($options[$i]), $p);

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -18,6 +18,12 @@ final class BaseClientTest extends RecurlyTestCase
         $this->client->clearScenarios();
     }
 
+    public function testParameterValidation(): void
+    {
+        $this->expectException(\Recurly\RecurlyError::class);
+        $resource = $this->client->getResource("");
+    }
+
     public function testGetResource200(): void
     {
         $url = "https://v3.recurly.com/resources/iexist";


### PR DESCRIPTION
Adding a validation method that will ensure that path parameters are not empty strings to address issues where a `get_*` operation (`/resources/{resource_id}`) does not get handled by the API as a `list_*` operations (`/resources/`). 