### PR TITLE
Make returns nullable

### DIFF
--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -119,14 +119,16 @@ abstract class BaseClient
     /**
      * Checks that path parameters are valid
      *
-     * @param array  $options Associatve array of tokens and their replacement values
+     * @param array $options Associatve array of tokens and their replacement values
      */
     private function _validatePathParameters(array $options = []): void
     {
         // Check to make sure that parameters are not empty values
-        $emptyValues = array_filter($options, function ($value, $key) {
-            return empty(trim($value));
-        }, ARRAY_FILTER_USE_BOTH);
+        $emptyValues = array_filter(
+            $options, function ($value, $key) {
+                return empty(trim($value));
+            }, ARRAY_FILTER_USE_BOTH
+        );
         if (!empty($emptyValues)) {
             throw new RecurlyError(join(', ', array_keys($emptyValues)) . ' cannot be an empty value');
         }

--- a/lib/recurly/resources/account.php
+++ b/lib/recurly/resources/account.php
@@ -53,9 +53,9 @@ class Account extends RecurlyResource
     * Getter method for the address attribute.
     * 
     *
-    * @return \Recurly\Resources\Address
+    * @return ?\Recurly\Resources\Address
     */
-    public function getAddress(): \Recurly\Resources\Address
+    public function getAddress(): ?\Recurly\Resources\Address
     {
         return $this->_address;
     }
@@ -99,9 +99,9 @@ class Account extends RecurlyResource
     * Getter method for the billing_info attribute.
     * 
     *
-    * @return \Recurly\Resources\BillingInfo
+    * @return ?\Recurly\Resources\BillingInfo
     */
-    public function getBillingInfo(): \Recurly\Resources\BillingInfo
+    public function getBillingInfo(): ?\Recurly\Resources\BillingInfo
     {
         return $this->_billing_info;
     }
@@ -218,7 +218,7 @@ class Account extends RecurlyResource
     */
     public function getCustomFields(): array
     {
-        return $this->_custom_fields;
+        return $this->_custom_fields ?? [] ;
     }
 
     /**
@@ -609,7 +609,7 @@ class Account extends RecurlyResource
     */
     public function getShippingAddresses(): array
     {
-        return $this->_shipping_addresses;
+        return $this->_shipping_addresses ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/account.php
+++ b/lib/recurly/resources/account.php
@@ -76,9 +76,9 @@ class Account extends RecurlyResource
     * Getter method for the bill_to attribute.
     * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
     *
-    * @return string
+    * @return ?string
     */
-    public function getBillTo(): string
+    public function getBillTo(): ?string
     {
         return $this->_bill_to;
     }
@@ -122,9 +122,9 @@ class Account extends RecurlyResource
     * Getter method for the cc_emails attribute.
     * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCcEmails(): string
+    public function getCcEmails(): ?string
     {
         return $this->_cc_emails;
     }
@@ -145,9 +145,9 @@ class Account extends RecurlyResource
     * Getter method for the code attribute.
     * The unique identifier of the account. This cannot be changed once the account is created.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -168,9 +168,9 @@ class Account extends RecurlyResource
     * Getter method for the company attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getCompany(): string
+    public function getCompany(): ?string
     {
         return $this->_company;
     }
@@ -191,9 +191,9 @@ class Account extends RecurlyResource
     * Getter method for the created_at attribute.
     * When the account was created.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -237,9 +237,9 @@ class Account extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * If present, when the account was last marked inactive.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -260,9 +260,9 @@ class Account extends RecurlyResource
     * Getter method for the email attribute.
     * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
     *
-    * @return string
+    * @return ?string
     */
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->_email;
     }
@@ -283,9 +283,9 @@ class Account extends RecurlyResource
     * Getter method for the exemption_certificate attribute.
     * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExemptionCertificate(): string
+    public function getExemptionCertificate(): ?string
     {
         return $this->_exemption_certificate;
     }
@@ -306,9 +306,9 @@ class Account extends RecurlyResource
     * Getter method for the first_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->_first_name;
     }
@@ -467,9 +467,9 @@ class Account extends RecurlyResource
     * Getter method for the hosted_login_token attribute.
     * The unique token for automatically logging the account in to the hosted management pages. You may automatically log the user into their hosted management pages by directing the user to: `https://{subdomain}.recurly.com/account/{hosted_login_token}`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getHostedLoginToken(): string
+    public function getHostedLoginToken(): ?string
     {
         return $this->_hosted_login_token;
     }
@@ -490,9 +490,9 @@ class Account extends RecurlyResource
     * Getter method for the id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -513,9 +513,9 @@ class Account extends RecurlyResource
     * Getter method for the last_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->_last_name;
     }
@@ -536,9 +536,9 @@ class Account extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -559,9 +559,9 @@ class Account extends RecurlyResource
     * Getter method for the parent_account_id attribute.
     * The UUID of the parent account associated with this account.
     *
-    * @return string
+    * @return ?string
     */
-    public function getParentAccountId(): string
+    public function getParentAccountId(): ?string
     {
         return $this->_parent_account_id;
     }
@@ -582,9 +582,9 @@ class Account extends RecurlyResource
     * Getter method for the preferred_locale attribute.
     * Used to determine the language and locale of emails sent on behalf of the merchant to the customer.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPreferredLocale(): string
+    public function getPreferredLocale(): ?string
     {
         return $this->_preferred_locale;
     }
@@ -628,9 +628,9 @@ class Account extends RecurlyResource
     * Getter method for the state attribute.
     * Accounts can be either active or inactive.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -674,9 +674,9 @@ class Account extends RecurlyResource
     * Getter method for the updated_at attribute.
     * When the account was last changed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -697,9 +697,9 @@ class Account extends RecurlyResource
     * Getter method for the username attribute.
     * A secondary value for the account.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUsername(): string
+    public function getUsername(): ?string
     {
         return $this->_username;
     }
@@ -720,9 +720,9 @@ class Account extends RecurlyResource
     * Getter method for the vat_number attribute.
     * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
     *
-    * @return string
+    * @return ?string
     */
-    public function getVatNumber(): string
+    public function getVatNumber(): ?string
     {
         return $this->_vat_number;
     }

--- a/lib/recurly/resources/account.php
+++ b/lib/recurly/resources/account.php
@@ -329,9 +329,9 @@ class Account extends RecurlyResource
     * Getter method for the has_active_subscription attribute.
     * Indicates if the account has an active subscription.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getHasActiveSubscription(): bool
+    public function getHasActiveSubscription(): ?bool
     {
         return $this->_has_active_subscription;
     }
@@ -352,9 +352,9 @@ class Account extends RecurlyResource
     * Getter method for the has_canceled_subscription attribute.
     * Indicates if the account has a canceled subscription.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getHasCanceledSubscription(): bool
+    public function getHasCanceledSubscription(): ?bool
     {
         return $this->_has_canceled_subscription;
     }
@@ -375,9 +375,9 @@ class Account extends RecurlyResource
     * Getter method for the has_future_subscription attribute.
     * Indicates if the account has a future subscription.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getHasFutureSubscription(): bool
+    public function getHasFutureSubscription(): ?bool
     {
         return $this->_has_future_subscription;
     }
@@ -398,9 +398,9 @@ class Account extends RecurlyResource
     * Getter method for the has_live_subscription attribute.
     * Indicates if the account has a subscription that is either active, canceled, future, or paused.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getHasLiveSubscription(): bool
+    public function getHasLiveSubscription(): ?bool
     {
         return $this->_has_live_subscription;
     }
@@ -421,9 +421,9 @@ class Account extends RecurlyResource
     * Getter method for the has_past_due_invoice attribute.
     * Indicates if the account has a past due invoice.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getHasPastDueInvoice(): bool
+    public function getHasPastDueInvoice(): ?bool
     {
         return $this->_has_past_due_invoice;
     }
@@ -444,9 +444,9 @@ class Account extends RecurlyResource
     * Getter method for the has_paused_subscription attribute.
     * Indicates if the account has a paused subscription.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getHasPausedSubscription(): bool
+    public function getHasPausedSubscription(): ?bool
     {
         return $this->_has_paused_subscription;
     }
@@ -651,9 +651,9 @@ class Account extends RecurlyResource
     * Getter method for the tax_exempt attribute.
     * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getTaxExempt(): bool
+    public function getTaxExempt(): ?bool
     {
         return $this->_tax_exempt;
     }

--- a/lib/recurly/resources/account_acquisition.php
+++ b/lib/recurly/resources/account_acquisition.php
@@ -30,9 +30,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the account attribute.
     * Account mini details
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -99,9 +99,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the cost attribute.
     * Account balance
     *
-    * @return \Recurly\Resources\AccountAcquisitionCost
+    * @return ?\Recurly\Resources\AccountAcquisitionCost
     */
-    public function getCost(): \Recurly\Resources\AccountAcquisitionCost
+    public function getCost(): ?\Recurly\Resources\AccountAcquisitionCost
     {
         return $this->_cost;
     }

--- a/lib/recurly/resources/account_acquisition.php
+++ b/lib/recurly/resources/account_acquisition.php
@@ -53,9 +53,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the campaign attribute.
     * An arbitrary identifier for the marketing campaign that led to the acquisition of this account.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCampaign(): string
+    public function getCampaign(): ?string
     {
         return $this->_campaign;
     }
@@ -76,9 +76,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the channel attribute.
     * The channel through which the account was acquired.
     *
-    * @return string
+    * @return ?string
     */
-    public function getChannel(): string
+    public function getChannel(): ?string
     {
         return $this->_channel;
     }
@@ -122,9 +122,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the created_at attribute.
     * When the account acquisition data was created.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -145,9 +145,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -168,9 +168,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -191,9 +191,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the subchannel attribute.
     * An arbitrary subchannel string representing a distinction/subcategory within a broader channel.
     *
-    * @return string
+    * @return ?string
     */
-    public function getSubchannel(): string
+    public function getSubchannel(): ?string
     {
         return $this->_subchannel;
     }
@@ -214,9 +214,9 @@ class AccountAcquisition extends RecurlyResource
     * Getter method for the updated_at attribute.
     * When the account acquisition data was last changed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/account_acquisition_cost.php
+++ b/lib/recurly/resources/account_acquisition_cost.php
@@ -23,9 +23,9 @@ class AccountAcquisitionCost extends RecurlyResource
     * Getter method for the amount attribute.
     * The amount of the corresponding currency used to acquire the account.
     *
-    * @return float
+    * @return ?float
     */
-    public function getAmount(): float
+    public function getAmount(): ?float
     {
         return $this->_amount;
     }
@@ -46,9 +46,9 @@ class AccountAcquisitionCost extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }

--- a/lib/recurly/resources/account_balance.php
+++ b/lib/recurly/resources/account_balance.php
@@ -95,9 +95,9 @@ class AccountBalance extends RecurlyResource
     * Getter method for the past_due attribute.
     * 
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getPastDue(): bool
+    public function getPastDue(): ?bool
     {
         return $this->_past_due;
     }

--- a/lib/recurly/resources/account_balance.php
+++ b/lib/recurly/resources/account_balance.php
@@ -26,9 +26,9 @@ class AccountBalance extends RecurlyResource
     * Getter method for the account attribute.
     * Account mini details
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -53,7 +53,7 @@ class AccountBalance extends RecurlyResource
     */
     public function getBalances(): array
     {
-        return $this->_balances;
+        return $this->_balances ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/account_balance.php
+++ b/lib/recurly/resources/account_balance.php
@@ -72,9 +72,9 @@ class AccountBalance extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/account_balance_amount.php
+++ b/lib/recurly/resources/account_balance_amount.php
@@ -23,9 +23,9 @@ class AccountBalanceAmount extends RecurlyResource
     * Getter method for the amount attribute.
     * Total amount the account is past due.
     *
-    * @return float
+    * @return ?float
     */
-    public function getAmount(): float
+    public function getAmount(): ?float
     {
         return $this->_amount;
     }
@@ -46,9 +46,9 @@ class AccountBalanceAmount extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }

--- a/lib/recurly/resources/account_mini.php
+++ b/lib/recurly/resources/account_mini.php
@@ -30,9 +30,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the bill_to attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getBillTo(): string
+    public function getBillTo(): ?string
     {
         return $this->_bill_to;
     }
@@ -53,9 +53,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the code attribute.
     * The unique identifier of the account.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -76,9 +76,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the company attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getCompany(): string
+    public function getCompany(): ?string
     {
         return $this->_company;
     }
@@ -99,9 +99,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the email attribute.
     * The email address used for communicating with this customer.
     *
-    * @return string
+    * @return ?string
     */
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->_email;
     }
@@ -122,9 +122,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the first_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->_first_name;
     }
@@ -145,9 +145,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -168,9 +168,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the last_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->_last_name;
     }
@@ -191,9 +191,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -214,9 +214,9 @@ class AccountMini extends RecurlyResource
     * Getter method for the parent_account_id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getParentAccountId(): string
+    public function getParentAccountId(): ?string
     {
         return $this->_parent_account_id;
     }

--- a/lib/recurly/resources/account_note.php
+++ b/lib/recurly/resources/account_note.php
@@ -27,9 +27,9 @@ class AccountNote extends RecurlyResource
     * Getter method for the account_id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountId(): string
+    public function getAccountId(): ?string
     {
         return $this->_account_id;
     }
@@ -50,9 +50,9 @@ class AccountNote extends RecurlyResource
     * Getter method for the created_at attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -73,9 +73,9 @@ class AccountNote extends RecurlyResource
     * Getter method for the id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -96,9 +96,9 @@ class AccountNote extends RecurlyResource
     * Getter method for the message attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getMessage(): string
+    public function getMessage(): ?string
     {
         return $this->_message;
     }
@@ -119,9 +119,9 @@ class AccountNote extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/account_note.php
+++ b/lib/recurly/resources/account_note.php
@@ -142,9 +142,9 @@ class AccountNote extends RecurlyResource
     * Getter method for the user attribute.
     * 
     *
-    * @return \Recurly\Resources\User
+    * @return ?\Recurly\Resources\User
     */
-    public function getUser(): \Recurly\Resources\User
+    public function getUser(): ?\Recurly\Resources\User
     {
         return $this->_user;
     }

--- a/lib/recurly/resources/add_on.php
+++ b/lib/recurly/resources/add_on.php
@@ -181,9 +181,9 @@ class AddOn extends RecurlyResource
     * Getter method for the display_quantity attribute.
     * Determines if the quantity field is displayed on the hosted pages for the add-on.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getDisplayQuantity(): bool
+    public function getDisplayQuantity(): ?bool
     {
         return $this->_display_quantity;
     }
@@ -319,9 +319,9 @@ class AddOn extends RecurlyResource
     * Getter method for the optional attribute.
     * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getOptional(): bool
+    public function getOptional(): ?bool
     {
         return $this->_optional;
     }

--- a/lib/recurly/resources/add_on.php
+++ b/lib/recurly/resources/add_on.php
@@ -43,9 +43,9 @@ class AddOn extends RecurlyResource
     * Getter method for the accounting_code attribute.
     * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountingCode(): string
+    public function getAccountingCode(): ?string
     {
         return $this->_accounting_code;
     }
@@ -66,9 +66,9 @@ class AddOn extends RecurlyResource
     * Getter method for the code attribute.
     * The unique identifier for the add-on within its plan.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -89,9 +89,9 @@ class AddOn extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -135,9 +135,9 @@ class AddOn extends RecurlyResource
     * Getter method for the default_quantity attribute.
     * Default quantity for the hosted pages.
     *
-    * @return int
+    * @return ?int
     */
-    public function getDefaultQuantity(): int
+    public function getDefaultQuantity(): ?int
     {
         return $this->_default_quantity;
     }
@@ -158,9 +158,9 @@ class AddOn extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * Deleted at
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -204,9 +204,9 @@ class AddOn extends RecurlyResource
     * Getter method for the external_sku attribute.
     * Optional, stock keeping unit to link the item to other inventory systems.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExternalSku(): string
+    public function getExternalSku(): ?string
     {
         return $this->_external_sku;
     }
@@ -227,9 +227,9 @@ class AddOn extends RecurlyResource
     * Getter method for the id attribute.
     * Add-on ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -273,9 +273,9 @@ class AddOn extends RecurlyResource
     * Getter method for the name attribute.
     * Describes your add-on and will appear in subscribers' invoices.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -296,9 +296,9 @@ class AddOn extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -342,9 +342,9 @@ class AddOn extends RecurlyResource
     * Getter method for the plan_id attribute.
     * Plan ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getPlanId(): string
+    public function getPlanId(): ?string
     {
         return $this->_plan_id;
     }
@@ -365,9 +365,9 @@ class AddOn extends RecurlyResource
     * Getter method for the revenue_schedule_type attribute.
     * When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRevenueScheduleType(): string
+    public function getRevenueScheduleType(): ?string
     {
         return $this->_revenue_schedule_type;
     }
@@ -388,9 +388,9 @@ class AddOn extends RecurlyResource
     * Getter method for the state attribute.
     * Add-ons can be either active or inactive.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -411,9 +411,9 @@ class AddOn extends RecurlyResource
     * Getter method for the tax_code attribute.
     * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTaxCode(): string
+    public function getTaxCode(): ?string
     {
         return $this->_tax_code;
     }
@@ -434,9 +434,9 @@ class AddOn extends RecurlyResource
     * Getter method for the tier_type attribute.
     * The type of tiering used by the Add-on.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTierType(): string
+    public function getTierType(): ?string
     {
         return $this->_tier_type;
     }
@@ -480,9 +480,9 @@ class AddOn extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/add_on.php
+++ b/lib/recurly/resources/add_on.php
@@ -116,7 +116,7 @@ class AddOn extends RecurlyResource
     */
     public function getCurrencies(): array
     {
-        return $this->_currencies;
+        return $this->_currencies ?? [] ;
     }
 
     /**
@@ -250,9 +250,9 @@ class AddOn extends RecurlyResource
     * Getter method for the item attribute.
     * Just the important parts.
     *
-    * @return \Recurly\Resources\ItemMini
+    * @return ?\Recurly\Resources\ItemMini
     */
-    public function getItem(): \Recurly\Resources\ItemMini
+    public function getItem(): ?\Recurly\Resources\ItemMini
     {
         return $this->_item;
     }
@@ -461,7 +461,7 @@ class AddOn extends RecurlyResource
     */
     public function getTiers(): array
     {
-        return $this->_tiers;
+        return $this->_tiers ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/add_on_mini.php
+++ b/lib/recurly/resources/add_on_mini.php
@@ -28,9 +28,9 @@ class AddOnMini extends RecurlyResource
     * Getter method for the accounting_code attribute.
     * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountingCode(): string
+    public function getAccountingCode(): ?string
     {
         return $this->_accounting_code;
     }
@@ -51,9 +51,9 @@ class AddOnMini extends RecurlyResource
     * Getter method for the code attribute.
     * The unique identifier for the add-on within its plan.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -74,9 +74,9 @@ class AddOnMini extends RecurlyResource
     * Getter method for the external_sku attribute.
     * Optional, stock keeping unit to link the item to other inventory systems.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExternalSku(): string
+    public function getExternalSku(): ?string
     {
         return $this->_external_sku;
     }
@@ -97,9 +97,9 @@ class AddOnMini extends RecurlyResource
     * Getter method for the id attribute.
     * Add-on ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -120,9 +120,9 @@ class AddOnMini extends RecurlyResource
     * Getter method for the item_id attribute.
     * Item ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getItemId(): string
+    public function getItemId(): ?string
     {
         return $this->_item_id;
     }
@@ -143,9 +143,9 @@ class AddOnMini extends RecurlyResource
     * Getter method for the name attribute.
     * Describes your add-on and will appear in subscribers' invoices.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -166,9 +166,9 @@ class AddOnMini extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/add_on_pricing.php
+++ b/lib/recurly/resources/add_on_pricing.php
@@ -23,9 +23,9 @@ class AddOnPricing extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -46,9 +46,9 @@ class AddOnPricing extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Unit price
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }

--- a/lib/recurly/resources/address.php
+++ b/lib/recurly/resources/address.php
@@ -30,9 +30,9 @@ class Address extends RecurlyResource
     * Getter method for the city attribute.
     * City
     *
-    * @return string
+    * @return ?string
     */
-    public function getCity(): string
+    public function getCity(): ?string
     {
         return $this->_city;
     }
@@ -53,9 +53,9 @@ class Address extends RecurlyResource
     * Getter method for the country attribute.
     * Country, 2-letter ISO code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCountry(): string
+    public function getCountry(): ?string
     {
         return $this->_country;
     }
@@ -76,9 +76,9 @@ class Address extends RecurlyResource
     * Getter method for the first_name attribute.
     * First name
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->_first_name;
     }
@@ -99,9 +99,9 @@ class Address extends RecurlyResource
     * Getter method for the last_name attribute.
     * Last name
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->_last_name;
     }
@@ -122,9 +122,9 @@ class Address extends RecurlyResource
     * Getter method for the phone attribute.
     * Phone number
     *
-    * @return string
+    * @return ?string
     */
-    public function getPhone(): string
+    public function getPhone(): ?string
     {
         return $this->_phone;
     }
@@ -145,9 +145,9 @@ class Address extends RecurlyResource
     * Getter method for the postal_code attribute.
     * Zip or postal code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPostalCode(): string
+    public function getPostalCode(): ?string
     {
         return $this->_postal_code;
     }
@@ -168,9 +168,9 @@ class Address extends RecurlyResource
     * Getter method for the region attribute.
     * State or province.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRegion(): string
+    public function getRegion(): ?string
     {
         return $this->_region;
     }
@@ -191,9 +191,9 @@ class Address extends RecurlyResource
     * Getter method for the street1 attribute.
     * Street 1
     *
-    * @return string
+    * @return ?string
     */
-    public function getStreet1(): string
+    public function getStreet1(): ?string
     {
         return $this->_street1;
     }
@@ -214,9 +214,9 @@ class Address extends RecurlyResource
     * Getter method for the street2 attribute.
     * Street 2
     *
-    * @return string
+    * @return ?string
     */
-    public function getStreet2(): string
+    public function getStreet2(): ?string
     {
         return $this->_street2;
     }

--- a/lib/recurly/resources/billing_info.php
+++ b/lib/recurly/resources/billing_info.php
@@ -35,9 +35,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the account_id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountId(): string
+    public function getAccountId(): ?string
     {
         return $this->_account_id;
     }
@@ -81,9 +81,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the company attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getCompany(): string
+    public function getCompany(): ?string
     {
         return $this->_company;
     }
@@ -104,9 +104,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the created_at attribute.
     * When the billing information was created.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -127,9 +127,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the first_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->_first_name;
     }
@@ -173,9 +173,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -196,9 +196,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the last_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->_last_name;
     }
@@ -219,9 +219,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -265,9 +265,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the updated_at attribute.
     * When the billing information was last changed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -334,9 +334,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the vat_number attribute.
     * Customer's VAT number (to avoid having the VAT applied). This is only used for automatically collected invoices.
     *
-    * @return string
+    * @return ?string
     */
-    public function getVatNumber(): string
+    public function getVatNumber(): ?string
     {
         return $this->_vat_number;
     }

--- a/lib/recurly/resources/billing_info.php
+++ b/lib/recurly/resources/billing_info.php
@@ -311,9 +311,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the valid attribute.
     * 
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getValid(): bool
+    public function getValid(): ?bool
     {
         return $this->_valid;
     }

--- a/lib/recurly/resources/billing_info.php
+++ b/lib/recurly/resources/billing_info.php
@@ -58,9 +58,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the address attribute.
     * 
     *
-    * @return \Recurly\Resources\Address
+    * @return ?\Recurly\Resources\Address
     */
-    public function getAddress(): \Recurly\Resources\Address
+    public function getAddress(): ?\Recurly\Resources\Address
     {
         return $this->_address;
     }
@@ -150,9 +150,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the fraud attribute.
     * Most recent fraud result.
     *
-    * @return \Recurly\Resources\FraudInfo
+    * @return ?\Recurly\Resources\FraudInfo
     */
-    public function getFraud(): \Recurly\Resources\FraudInfo
+    public function getFraud(): ?\Recurly\Resources\FraudInfo
     {
         return $this->_fraud;
     }
@@ -242,9 +242,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the payment_method attribute.
     * 
     *
-    * @return \Recurly\Resources\PaymentMethod
+    * @return ?\Recurly\Resources\PaymentMethod
     */
-    public function getPaymentMethod(): \Recurly\Resources\PaymentMethod
+    public function getPaymentMethod(): ?\Recurly\Resources\PaymentMethod
     {
         return $this->_payment_method;
     }
@@ -288,9 +288,9 @@ class BillingInfo extends RecurlyResource
     * Getter method for the updated_by attribute.
     * 
     *
-    * @return \Recurly\Resources\BillingInfoUpdatedBy
+    * @return ?\Recurly\Resources\BillingInfoUpdatedBy
     */
-    public function getUpdatedBy(): \Recurly\Resources\BillingInfoUpdatedBy
+    public function getUpdatedBy(): ?\Recurly\Resources\BillingInfoUpdatedBy
     {
         return $this->_updated_by;
     }

--- a/lib/recurly/resources/billing_info_updated_by.php
+++ b/lib/recurly/resources/billing_info_updated_by.php
@@ -23,9 +23,9 @@ class BillingInfoUpdatedBy extends RecurlyResource
     * Getter method for the country attribute.
     * Country of IP address, if known by Recurly.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCountry(): string
+    public function getCountry(): ?string
     {
         return $this->_country;
     }
@@ -46,9 +46,9 @@ class BillingInfoUpdatedBy extends RecurlyResource
     * Getter method for the ip attribute.
     * Customer's IP address when updating their billing information.
     *
-    * @return string
+    * @return ?string
     */
-    public function getIp(): string
+    public function getIp(): ?string
     {
         return $this->_ip;
     }

--- a/lib/recurly/resources/binary_file.php
+++ b/lib/recurly/resources/binary_file.php
@@ -22,9 +22,9 @@ class BinaryFile extends RecurlyResource
     * Getter method for the data attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getData(): string
+    public function getData(): ?string
     {
         return $this->_data;
     }

--- a/lib/recurly/resources/coupon.php
+++ b/lib/recurly/resources/coupon.php
@@ -97,9 +97,9 @@ class Coupon extends RecurlyResource
     * Getter method for the code attribute.
     * The code the customer enters to redeem the coupon.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -120,9 +120,9 @@ class Coupon extends RecurlyResource
     * Getter method for the coupon_type attribute.
     * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCouponType(): string
+    public function getCouponType(): ?string
     {
         return $this->_coupon_type;
     }
@@ -143,9 +143,9 @@ class Coupon extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -193,9 +193,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
 - "temporal" coupons will apply to invoices for the duration determined by the `temporal_unit` and `temporal_amount` attributes.
 
     *
-    * @return string
+    * @return ?string
     */
-    public function getDuration(): string
+    public function getDuration(): ?string
     {
         return $this->_duration;
     }
@@ -216,9 +216,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the expired_at attribute.
     * The date and time the coupon was expired early or reached its `max_redemptions`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExpiredAt(): string
+    public function getExpiredAt(): ?string
     {
         return $this->_expired_at;
     }
@@ -239,9 +239,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the free_trial_amount attribute.
     * Sets the duration of time the `free_trial_unit` is for.
     *
-    * @return int
+    * @return ?int
     */
-    public function getFreeTrialAmount(): int
+    public function getFreeTrialAmount(): ?int
     {
         return $this->_free_trial_amount;
     }
@@ -262,9 +262,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the free_trial_unit attribute.
     * Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine the duration of time the coupon is for.
     *
-    * @return string
+    * @return ?string
     */
-    public function getFreeTrialUnit(): string
+    public function getFreeTrialUnit(): ?string
     {
         return $this->_free_trial_unit;
     }
@@ -285,9 +285,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the hosted_page_description attribute.
     * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
     *
-    * @return string
+    * @return ?string
     */
-    public function getHostedPageDescription(): string
+    public function getHostedPageDescription(): ?string
     {
         return $this->_hosted_page_description;
     }
@@ -308,9 +308,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the id attribute.
     * Coupon ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -331,9 +331,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the invoice_description attribute.
     * Description of the coupon on the invoice.
     *
-    * @return string
+    * @return ?string
     */
-    public function getInvoiceDescription(): string
+    public function getInvoiceDescription(): ?string
     {
         return $this->_invoice_description;
     }
@@ -354,9 +354,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the max_redemptions attribute.
     * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
     *
-    * @return int
+    * @return ?int
     */
-    public function getMaxRedemptions(): int
+    public function getMaxRedemptions(): ?int
     {
         return $this->_max_redemptions;
     }
@@ -377,9 +377,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the max_redemptions_per_account attribute.
     * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
     *
-    * @return int
+    * @return ?int
     */
-    public function getMaxRedemptionsPerAccount(): int
+    public function getMaxRedemptionsPerAccount(): ?int
     {
         return $this->_max_redemptions_per_account;
     }
@@ -400,9 +400,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the name attribute.
     * The internal name for the coupon.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -423,9 +423,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -492,9 +492,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the redeem_by attribute.
     * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRedeemBy(): string
+    public function getRedeemBy(): ?string
     {
         return $this->_redeem_by;
     }
@@ -515,9 +515,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the redeemed_at attribute.
     * The date and time the unique coupon code was redeemed. This is only present for bulk coupons.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRedeemedAt(): string
+    public function getRedeemedAt(): ?string
     {
         return $this->_redeemed_at;
     }
@@ -538,9 +538,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the redemption_resource attribute.
     * Whether the discount is for all eligible charges on the account, or only a specific subscription.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRedemptionResource(): string
+    public function getRedemptionResource(): ?string
     {
         return $this->_redemption_resource;
     }
@@ -561,9 +561,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the state attribute.
     * Indicates if the coupon is redeemable, and if it is not, why.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -584,9 +584,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the temporal_amount attribute.
     * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
     *
-    * @return int
+    * @return ?int
     */
-    public function getTemporalAmount(): int
+    public function getTemporalAmount(): ?int
     {
         return $this->_temporal_amount;
     }
@@ -607,9 +607,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the temporal_unit attribute.
     * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTemporalUnit(): string
+    public function getTemporalUnit(): ?string
     {
         return $this->_temporal_unit;
     }
@@ -630,9 +630,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the unique_code_template attribute.
     * On a bulk coupon, the template from which unique coupon codes are generated.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUniqueCodeTemplate(): string
+    public function getUniqueCodeTemplate(): ?string
     {
         return $this->_unique_code_template;
     }
@@ -653,9 +653,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the unique_coupon_codes_count attribute.
     * When this number reaches `max_redemptions` the coupon will no longer be redeemable.
     *
-    * @return int
+    * @return ?int
     */
-    public function getUniqueCouponCodesCount(): int
+    public function getUniqueCouponCodesCount(): ?int
     {
         return $this->_unique_coupon_codes_count;
     }
@@ -676,9 +676,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/coupon.php
+++ b/lib/recurly/resources/coupon.php
@@ -51,9 +51,9 @@ class Coupon extends RecurlyResource
     * Getter method for the applies_to_all_plans attribute.
     * The coupon is valid for all plans if true. If false then `plans` and `plans_names` will list the applicable plans.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getAppliesToAllPlans(): bool
+    public function getAppliesToAllPlans(): ?bool
     {
         return $this->_applies_to_all_plans;
     }
@@ -74,9 +74,9 @@ class Coupon extends RecurlyResource
     * Getter method for the applies_to_non_plan_charges attribute.
     * The coupon is valid for one-time, non-plan charges if true.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getAppliesToNonPlanCharges(): bool
+    public function getAppliesToNonPlanCharges(): ?bool
     {
         return $this->_applies_to_non_plan_charges;
     }

--- a/lib/recurly/resources/coupon.php
+++ b/lib/recurly/resources/coupon.php
@@ -168,9 +168,9 @@ class Coupon extends RecurlyResource
 property and one of the following properties: `percent`, `fixed`, `trial`.
 
     *
-    * @return \Recurly\Resources\CouponDiscount
+    * @return ?\Recurly\Resources\CouponDiscount
     */
-    public function getDiscount(): \Recurly\Resources\CouponDiscount
+    public function getDiscount(): ?\Recurly\Resources\CouponDiscount
     {
         return $this->_discount;
     }
@@ -450,7 +450,7 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     */
     public function getPlans(): array
     {
-        return $this->_plans;
+        return $this->_plans ?? [] ;
     }
 
     /**
@@ -473,7 +473,7 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     */
     public function getPlansNames(): array
     {
-        return $this->_plans_names;
+        return $this->_plans_names ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/coupon_discount.php
+++ b/lib/recurly/resources/coupon_discount.php
@@ -30,7 +30,7 @@ class CouponDiscount extends RecurlyResource
     */
     public function getCurrencies(): array
     {
-        return $this->_currencies;
+        return $this->_currencies ?? [] ;
     }
 
     /**
@@ -72,9 +72,9 @@ class CouponDiscount extends RecurlyResource
     * Getter method for the trial attribute.
     * This is only present when `type=free_trial`.
     *
-    * @return \Recurly\Resources\CouponDiscountTrial
+    * @return ?\Recurly\Resources\CouponDiscountTrial
     */
-    public function getTrial(): \Recurly\Resources\CouponDiscountTrial
+    public function getTrial(): ?\Recurly\Resources\CouponDiscountTrial
     {
         return $this->_trial;
     }

--- a/lib/recurly/resources/coupon_discount.php
+++ b/lib/recurly/resources/coupon_discount.php
@@ -49,9 +49,9 @@ class CouponDiscount extends RecurlyResource
     * Getter method for the percent attribute.
     * This is only present when `type=percent`.
     *
-    * @return int
+    * @return ?int
     */
-    public function getPercent(): int
+    public function getPercent(): ?int
     {
         return $this->_percent;
     }
@@ -95,9 +95,9 @@ class CouponDiscount extends RecurlyResource
     * Getter method for the type attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }

--- a/lib/recurly/resources/coupon_discount_pricing.php
+++ b/lib/recurly/resources/coupon_discount_pricing.php
@@ -23,9 +23,9 @@ class CouponDiscountPricing extends RecurlyResource
     * Getter method for the amount attribute.
     * Value of the fixed discount that this coupon applies.
     *
-    * @return float
+    * @return ?float
     */
-    public function getAmount(): float
+    public function getAmount(): ?float
     {
         return $this->_amount;
     }
@@ -46,9 +46,9 @@ class CouponDiscountPricing extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }

--- a/lib/recurly/resources/coupon_discount_trial.php
+++ b/lib/recurly/resources/coupon_discount_trial.php
@@ -23,9 +23,9 @@ class CouponDiscountTrial extends RecurlyResource
     * Getter method for the length attribute.
     * Trial length measured in the units specified by the sibling `unit` property
     *
-    * @return int
+    * @return ?int
     */
-    public function getLength(): int
+    public function getLength(): ?int
     {
         return $this->_length;
     }
@@ -46,9 +46,9 @@ class CouponDiscountTrial extends RecurlyResource
     * Getter method for the unit attribute.
     * Temporal unit of the free trial
     *
-    * @return string
+    * @return ?string
     */
-    public function getUnit(): string
+    public function getUnit(): ?string
     {
         return $this->_unit;
     }

--- a/lib/recurly/resources/coupon_mini.php
+++ b/lib/recurly/resources/coupon_mini.php
@@ -29,9 +29,9 @@ class CouponMini extends RecurlyResource
     * Getter method for the code attribute.
     * The code the customer enters to redeem the coupon.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -52,9 +52,9 @@ class CouponMini extends RecurlyResource
     * Getter method for the coupon_type attribute.
     * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCouponType(): string
+    public function getCouponType(): ?string
     {
         return $this->_coupon_type;
     }
@@ -100,9 +100,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the expired_at attribute.
     * The date and time the coupon was expired early or reached its `max_redemptions`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExpiredAt(): string
+    public function getExpiredAt(): ?string
     {
         return $this->_expired_at;
     }
@@ -123,9 +123,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the id attribute.
     * Coupon ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -146,9 +146,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the name attribute.
     * The internal name for the coupon.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -169,9 +169,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -192,9 +192,9 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
     * Getter method for the state attribute.
     * Indicates if the coupon is redeemable, and if it is not, why.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }

--- a/lib/recurly/resources/coupon_mini.php
+++ b/lib/recurly/resources/coupon_mini.php
@@ -77,9 +77,9 @@ class CouponMini extends RecurlyResource
 property and one of the following properties: `percent`, `fixed`, `trial`.
 
     *
-    * @return \Recurly\Resources\CouponDiscount
+    * @return ?\Recurly\Resources\CouponDiscount
     */
-    public function getDiscount(): \Recurly\Resources\CouponDiscount
+    public function getDiscount(): ?\Recurly\Resources\CouponDiscount
     {
         return $this->_discount;
     }

--- a/lib/recurly/resources/coupon_redemption.php
+++ b/lib/recurly/resources/coupon_redemption.php
@@ -77,9 +77,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -100,9 +100,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -123,9 +123,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the discounted attribute.
     * The amount that was discounted upon the application of the coupon, formatted with the currency.
     *
-    * @return float
+    * @return ?float
     */
-    public function getDiscounted(): float
+    public function getDiscounted(): ?float
     {
         return $this->_discounted;
     }
@@ -146,9 +146,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the id attribute.
     * Coupon Redemption ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -169,9 +169,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the object attribute.
     * Will always be `coupon`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -192,9 +192,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the removed_at attribute.
     * The date and time the redemption was removed from the account (un-redeemed).
     *
-    * @return string
+    * @return ?string
     */
-    public function getRemovedAt(): string
+    public function getRemovedAt(): ?string
     {
         return $this->_removed_at;
     }
@@ -215,9 +215,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the state attribute.
     * Coupon Redemption state
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -238,9 +238,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/coupon_redemption.php
+++ b/lib/recurly/resources/coupon_redemption.php
@@ -31,9 +31,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the account attribute.
     * The Account on which the coupon was applied.
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -54,9 +54,9 @@ class CouponRedemption extends RecurlyResource
     * Getter method for the coupon attribute.
     * 
     *
-    * @return \Recurly\Resources\Coupon
+    * @return ?\Recurly\Resources\Coupon
     */
-    public function getCoupon(): \Recurly\Resources\Coupon
+    public function getCoupon(): ?\Recurly\Resources\Coupon
     {
         return $this->_coupon;
     }

--- a/lib/recurly/resources/coupon_redemption_mini.php
+++ b/lib/recurly/resources/coupon_redemption_mini.php
@@ -27,9 +27,9 @@ class CouponRedemptionMini extends RecurlyResource
     * Getter method for the coupon attribute.
     * 
     *
-    * @return \Recurly\Resources\CouponMini
+    * @return ?\Recurly\Resources\CouponMini
     */
-    public function getCoupon(): \Recurly\Resources\CouponMini
+    public function getCoupon(): ?\Recurly\Resources\CouponMini
     {
         return $this->_coupon;
     }

--- a/lib/recurly/resources/coupon_redemption_mini.php
+++ b/lib/recurly/resources/coupon_redemption_mini.php
@@ -50,9 +50,9 @@ class CouponRedemptionMini extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -73,9 +73,9 @@ class CouponRedemptionMini extends RecurlyResource
     * Getter method for the discounted attribute.
     * The amount that was discounted upon the application of the coupon, formatted with the currency.
     *
-    * @return float
+    * @return ?float
     */
-    public function getDiscounted(): float
+    public function getDiscounted(): ?float
     {
         return $this->_discounted;
     }
@@ -96,9 +96,9 @@ class CouponRedemptionMini extends RecurlyResource
     * Getter method for the id attribute.
     * Coupon Redemption ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -119,9 +119,9 @@ class CouponRedemptionMini extends RecurlyResource
     * Getter method for the object attribute.
     * Will always be `coupon`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -142,9 +142,9 @@ class CouponRedemptionMini extends RecurlyResource
     * Getter method for the state attribute.
     * Invoice state
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }

--- a/lib/recurly/resources/credit_payment.php
+++ b/lib/recurly/resources/credit_payment.php
@@ -35,9 +35,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the account attribute.
     * Account mini details
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -104,9 +104,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the applied_to_invoice attribute.
     * Invoice mini details
     *
-    * @return \Recurly\Resources\InvoiceMini
+    * @return ?\Recurly\Resources\InvoiceMini
     */
-    public function getAppliedToInvoice(): \Recurly\Resources\InvoiceMini
+    public function getAppliedToInvoice(): ?\Recurly\Resources\InvoiceMini
     {
         return $this->_applied_to_invoice;
     }
@@ -242,9 +242,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the original_invoice attribute.
     * Invoice mini details
     *
-    * @return \Recurly\Resources\InvoiceMini
+    * @return ?\Recurly\Resources\InvoiceMini
     */
-    public function getOriginalInvoice(): \Recurly\Resources\InvoiceMini
+    public function getOriginalInvoice(): ?\Recurly\Resources\InvoiceMini
     {
         return $this->_original_invoice;
     }
@@ -265,9 +265,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the refund_transaction attribute.
     * 
     *
-    * @return \Recurly\Resources\Transaction
+    * @return ?\Recurly\Resources\Transaction
     */
-    public function getRefundTransaction(): \Recurly\Resources\Transaction
+    public function getRefundTransaction(): ?\Recurly\Resources\Transaction
     {
         return $this->_refund_transaction;
     }

--- a/lib/recurly/resources/credit_payment.php
+++ b/lib/recurly/resources/credit_payment.php
@@ -58,9 +58,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the action attribute.
     * The action for which the credit was created.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAction(): string
+    public function getAction(): ?string
     {
         return $this->_action;
     }
@@ -81,9 +81,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the amount attribute.
     * Total credit payment amount applied to the charge invoice.
     *
-    * @return float
+    * @return ?float
     */
-    public function getAmount(): float
+    public function getAmount(): ?float
     {
         return $this->_amount;
     }
@@ -127,9 +127,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -150,9 +150,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -173,9 +173,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the id attribute.
     * Credit Payment ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -196,9 +196,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -219,9 +219,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the original_credit_payment_id attribute.
     * For credit payments with action `refund`, this is the credit payment that was refunded.
     *
-    * @return string
+    * @return ?string
     */
-    public function getOriginalCreditPaymentId(): string
+    public function getOriginalCreditPaymentId(): ?string
     {
         return $this->_original_credit_payment_id;
     }
@@ -288,9 +288,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -311,9 +311,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the uuid attribute.
     * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUuid(): string
+    public function getUuid(): ?string
     {
         return $this->_uuid;
     }
@@ -334,9 +334,9 @@ class CreditPayment extends RecurlyResource
     * Getter method for the voided_at attribute.
     * Voided at
     *
-    * @return string
+    * @return ?string
     */
-    public function getVoidedAt(): string
+    public function getVoidedAt(): ?string
     {
         return $this->_voided_at;
     }

--- a/lib/recurly/resources/custom_field.php
+++ b/lib/recurly/resources/custom_field.php
@@ -23,9 +23,9 @@ class CustomField extends RecurlyResource
     * Getter method for the name attribute.
     * Fields must be created in the UI before values can be assigned to them.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -46,9 +46,9 @@ class CustomField extends RecurlyResource
     * Getter method for the value attribute.
     * Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
     *
-    * @return string
+    * @return ?string
     */
-    public function getValue(): string
+    public function getValue(): ?string
     {
         return $this->_value;
     }

--- a/lib/recurly/resources/custom_field_definition.php
+++ b/lib/recurly/resources/custom_field_definition.php
@@ -31,9 +31,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -54,9 +54,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * Definitions are initially soft deleted, and once all the values are removed from the accouts or subscriptions, will be hard deleted an no longer visible.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -77,9 +77,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the display_name attribute.
     * Used to label the field when viewing and editing the field in Recurly's admin UI.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDisplayName(): string
+    public function getDisplayName(): ?string
     {
         return $this->_display_name;
     }
@@ -100,9 +100,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the id attribute.
     * Custom field definition ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -123,9 +123,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the name attribute.
     * Used by the API to identify the field or reading and writing. The name can only be used once per Recurly object type.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -146,9 +146,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -169,9 +169,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the related_type attribute.
     * Related Recurly object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getRelatedType(): string
+    public function getRelatedType(): ?string
     {
         return $this->_related_type;
     }
@@ -192,9 +192,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the tooltip attribute.
     * Displayed as a tooltip when editing the field in the Recurly admin UI.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTooltip(): string
+    public function getTooltip(): ?string
     {
         return $this->_tooltip;
     }
@@ -215,9 +215,9 @@ class CustomFieldDefinition extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -243,9 +243,9 @@ class CustomFieldDefinition extends RecurlyResource
 - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI.
 
     *
-    * @return string
+    * @return ?string
     */
-    public function getUserAccess(): string
+    public function getUserAccess(): ?string
     {
         return $this->_user_access;
     }

--- a/lib/recurly/resources/error.php
+++ b/lib/recurly/resources/error.php
@@ -25,9 +25,9 @@ class Error extends RecurlyResource
     * Getter method for the message attribute.
     * Message
     *
-    * @return string
+    * @return ?string
     */
-    public function getMessage(): string
+    public function getMessage(): ?string
     {
         return $this->_message;
     }
@@ -71,9 +71,9 @@ class Error extends RecurlyResource
     * Getter method for the type attribute.
     * Type
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }

--- a/lib/recurly/resources/error.php
+++ b/lib/recurly/resources/error.php
@@ -52,7 +52,7 @@ class Error extends RecurlyResource
     */
     public function getParams(): array
     {
-        return $this->_params;
+        return $this->_params ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/error_may_have_transaction.php
+++ b/lib/recurly/resources/error_may_have_transaction.php
@@ -53,7 +53,7 @@ class ErrorMayHaveTransaction extends RecurlyResource
     */
     public function getParams(): array
     {
-        return $this->_params;
+        return $this->_params ?? [] ;
     }
 
     /**
@@ -72,9 +72,9 @@ class ErrorMayHaveTransaction extends RecurlyResource
     * Getter method for the transaction_error attribute.
     * This is only included on errors with `type=transaction`.
     *
-    * @return \Recurly\Resources\TransactionError
+    * @return ?\Recurly\Resources\TransactionError
     */
-    public function getTransactionError(): \Recurly\Resources\TransactionError
+    public function getTransactionError(): ?\Recurly\Resources\TransactionError
     {
         return $this->_transaction_error;
     }

--- a/lib/recurly/resources/error_may_have_transaction.php
+++ b/lib/recurly/resources/error_may_have_transaction.php
@@ -26,9 +26,9 @@ class ErrorMayHaveTransaction extends RecurlyResource
     * Getter method for the message attribute.
     * Message
     *
-    * @return string
+    * @return ?string
     */
-    public function getMessage(): string
+    public function getMessage(): ?string
     {
         return $this->_message;
     }
@@ -95,9 +95,9 @@ class ErrorMayHaveTransaction extends RecurlyResource
     * Getter method for the type attribute.
     * Type
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }

--- a/lib/recurly/resources/fraud_info.php
+++ b/lib/recurly/resources/fraud_info.php
@@ -47,9 +47,9 @@ class FraudInfo extends RecurlyResource
     * Getter method for the risk_rules_triggered attribute.
     * Kount rules
     *
-    * @return object
+    * @return ?object
     */
-    public function getRiskRulesTriggered(): object
+    public function getRiskRulesTriggered(): ?object
     {
         return $this->_risk_rules_triggered;
     }

--- a/lib/recurly/resources/fraud_info.php
+++ b/lib/recurly/resources/fraud_info.php
@@ -24,9 +24,9 @@ class FraudInfo extends RecurlyResource
     * Getter method for the decision attribute.
     * Kount decision
     *
-    * @return string
+    * @return ?string
     */
-    public function getDecision(): string
+    public function getDecision(): ?string
     {
         return $this->_decision;
     }
@@ -70,9 +70,9 @@ class FraudInfo extends RecurlyResource
     * Getter method for the score attribute.
     * Kount score
     *
-    * @return int
+    * @return ?int
     */
-    public function getScore(): int
+    public function getScore(): ?int
     {
         return $this->_score;
     }

--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -58,9 +58,9 @@ class Invoice extends RecurlyResource
     * Getter method for the account attribute.
     * Account mini details
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -81,9 +81,9 @@ class Invoice extends RecurlyResource
     * Getter method for the address attribute.
     * 
     *
-    * @return \Recurly\Resources\InvoiceAddress
+    * @return ?\Recurly\Resources\InvoiceAddress
     */
-    public function getAddress(): \Recurly\Resources\InvoiceAddress
+    public function getAddress(): ?\Recurly\Resources\InvoiceAddress
     {
         return $this->_address;
     }
@@ -200,7 +200,7 @@ class Invoice extends RecurlyResource
     */
     public function getCreditPayments(): array
     {
-        return $this->_credit_payments;
+        return $this->_credit_payments ?? [] ;
     }
 
     /**
@@ -334,9 +334,9 @@ class Invoice extends RecurlyResource
     * Getter method for the line_items attribute.
     * 
     *
-    * @return \Recurly\Resources\LineItemList
+    * @return ?\Recurly\Resources\LineItemList
     */
-    public function getLineItems(): \Recurly\Resources\LineItemList
+    public function getLineItems(): ?\Recurly\Resources\LineItemList
     {
         return $this->_line_items;
     }
@@ -541,9 +541,9 @@ class Invoice extends RecurlyResource
     * Getter method for the shipping_address attribute.
     * 
     *
-    * @return \Recurly\Resources\ShippingAddress
+    * @return ?\Recurly\Resources\ShippingAddress
     */
-    public function getShippingAddress(): \Recurly\Resources\ShippingAddress
+    public function getShippingAddress(): ?\Recurly\Resources\ShippingAddress
     {
         return $this->_shipping_address;
     }
@@ -591,7 +591,7 @@ class Invoice extends RecurlyResource
     */
     public function getSubscriptionIds(): array
     {
-        return $this->_subscription_ids;
+        return $this->_subscription_ids ?? [] ;
     }
 
     /**
@@ -656,9 +656,9 @@ class Invoice extends RecurlyResource
     * Getter method for the tax_info attribute.
     * Tax info
     *
-    * @return \Recurly\Resources\TaxInfo
+    * @return ?\Recurly\Resources\TaxInfo
     */
-    public function getTaxInfo(): \Recurly\Resources\TaxInfo
+    public function getTaxInfo(): ?\Recurly\Resources\TaxInfo
     {
         return $this->_tax_info;
     }
@@ -729,7 +729,7 @@ class Invoice extends RecurlyResource
     */
     public function getTransactions(): array
     {
-        return $this->_transactions;
+        return $this->_transactions ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -104,9 +104,9 @@ class Invoice extends RecurlyResource
     * Getter method for the balance attribute.
     * The outstanding balance remaining on this invoice.
     *
-    * @return float
+    * @return ?float
     */
-    public function getBalance(): float
+    public function getBalance(): ?float
     {
         return $this->_balance;
     }
@@ -127,9 +127,9 @@ class Invoice extends RecurlyResource
     * Getter method for the closed_at attribute.
     * Date invoice was marked paid or failed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getClosedAt(): string
+    public function getClosedAt(): ?string
     {
         return $this->_closed_at;
     }
@@ -150,9 +150,9 @@ class Invoice extends RecurlyResource
     * Getter method for the collection_method attribute.
     * An automatic invoice means a corresponding transaction is run using the account's billing information at the same time the invoice is created. Manual invoices are created without a corresponding transaction. The merchant must enter a manual payment transaction or have the customer pay the invoice with an automatic method, like credit card, PayPal, Amazon, or ACH bank payment.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCollectionMethod(): string
+    public function getCollectionMethod(): ?string
     {
         return $this->_collection_method;
     }
@@ -173,9 +173,9 @@ class Invoice extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -219,9 +219,9 @@ class Invoice extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -242,9 +242,9 @@ class Invoice extends RecurlyResource
     * Getter method for the customer_notes attribute.
     * This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCustomerNotes(): string
+    public function getCustomerNotes(): ?string
     {
         return $this->_customer_notes;
     }
@@ -265,9 +265,9 @@ class Invoice extends RecurlyResource
     * Getter method for the discount attribute.
     * Total discounts applied to this invoice.
     *
-    * @return float
+    * @return ?float
     */
-    public function getDiscount(): float
+    public function getDiscount(): ?float
     {
         return $this->_discount;
     }
@@ -288,9 +288,9 @@ class Invoice extends RecurlyResource
     * Getter method for the due_at attribute.
     * Date invoice is due. This is the date the net terms are reached.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDueAt(): string
+    public function getDueAt(): ?string
     {
         return $this->_due_at;
     }
@@ -311,9 +311,9 @@ class Invoice extends RecurlyResource
     * Getter method for the id attribute.
     * Invoice ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -357,9 +357,9 @@ class Invoice extends RecurlyResource
     * Getter method for the net_terms attribute.
     * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
     *
-    * @return int
+    * @return ?int
     */
-    public function getNetTerms(): int
+    public function getNetTerms(): ?int
     {
         return $this->_net_terms;
     }
@@ -380,9 +380,9 @@ class Invoice extends RecurlyResource
     * Getter method for the number attribute.
     * If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.
     *
-    * @return string
+    * @return ?string
     */
-    public function getNumber(): string
+    public function getNumber(): ?string
     {
         return $this->_number;
     }
@@ -403,9 +403,9 @@ class Invoice extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -426,9 +426,9 @@ class Invoice extends RecurlyResource
     * Getter method for the origin attribute.
     * The event that created the invoice.
     *
-    * @return string
+    * @return ?string
     */
-    public function getOrigin(): string
+    public function getOrigin(): ?string
     {
         return $this->_origin;
     }
@@ -449,9 +449,9 @@ class Invoice extends RecurlyResource
     * Getter method for the paid attribute.
     * The total amount of successful payments transaction on this invoice.
     *
-    * @return float
+    * @return ?float
     */
-    public function getPaid(): float
+    public function getPaid(): ?float
     {
         return $this->_paid;
     }
@@ -472,9 +472,9 @@ class Invoice extends RecurlyResource
     * Getter method for the po_number attribute.
     * For manual invoicing, this identifies the PO number associated with the subscription.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPoNumber(): string
+    public function getPoNumber(): ?string
     {
         return $this->_po_number;
     }
@@ -495,9 +495,9 @@ class Invoice extends RecurlyResource
     * Getter method for the previous_invoice_id attribute.
     * On refund invoices, this value will exist and show the invoice ID of the purchase invoice the refund was created from.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPreviousInvoiceId(): string
+    public function getPreviousInvoiceId(): ?string
     {
         return $this->_previous_invoice_id;
     }
@@ -518,9 +518,9 @@ class Invoice extends RecurlyResource
     * Getter method for the refundable_amount attribute.
     * The refundable amount on a charge invoice. It will be null for all other invoices.
     *
-    * @return float
+    * @return ?float
     */
-    public function getRefundableAmount(): float
+    public function getRefundableAmount(): ?float
     {
         return $this->_refundable_amount;
     }
@@ -564,9 +564,9 @@ class Invoice extends RecurlyResource
     * Getter method for the state attribute.
     * Invoice state
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -610,9 +610,9 @@ class Invoice extends RecurlyResource
     * Getter method for the subtotal attribute.
     * The summation of charges, discounts, and credits, before tax.
     *
-    * @return float
+    * @return ?float
     */
-    public function getSubtotal(): float
+    public function getSubtotal(): ?float
     {
         return $this->_subtotal;
     }
@@ -633,9 +633,9 @@ class Invoice extends RecurlyResource
     * Getter method for the tax attribute.
     * The total tax on this invoice.
     *
-    * @return float
+    * @return ?float
     */
-    public function getTax(): float
+    public function getTax(): ?float
     {
         return $this->_tax;
     }
@@ -679,9 +679,9 @@ class Invoice extends RecurlyResource
     * Getter method for the terms_and_conditions attribute.
     * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTermsAndConditions(): string
+    public function getTermsAndConditions(): ?string
     {
         return $this->_terms_and_conditions;
     }
@@ -702,9 +702,9 @@ class Invoice extends RecurlyResource
     * Getter method for the total attribute.
     * The final total on this invoice. The summation of invoice charges, discounts, credits, and tax.
     *
-    * @return float
+    * @return ?float
     */
-    public function getTotal(): float
+    public function getTotal(): ?float
     {
         return $this->_total;
     }
@@ -748,9 +748,9 @@ class Invoice extends RecurlyResource
     * Getter method for the type attribute.
     * Invoices are either charge, credit, or legacy invoices.
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }
@@ -771,9 +771,9 @@ class Invoice extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -794,9 +794,9 @@ class Invoice extends RecurlyResource
     * Getter method for the vat_number attribute.
     * VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
     *
-    * @return string
+    * @return ?string
     */
-    public function getVatNumber(): string
+    public function getVatNumber(): ?string
     {
         return $this->_vat_number;
     }
@@ -817,9 +817,9 @@ class Invoice extends RecurlyResource
     * Getter method for the vat_reverse_charge_notes attribute.
     * VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription.
     *
-    * @return string
+    * @return ?string
     */
-    public function getVatReverseChargeNotes(): string
+    public function getVatReverseChargeNotes(): ?string
     {
         return $this->_vat_reverse_charge_notes;
     }

--- a/lib/recurly/resources/invoice_address.php
+++ b/lib/recurly/resources/invoice_address.php
@@ -32,9 +32,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the city attribute.
     * City
     *
-    * @return string
+    * @return ?string
     */
-    public function getCity(): string
+    public function getCity(): ?string
     {
         return $this->_city;
     }
@@ -55,9 +55,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the company attribute.
     * Company
     *
-    * @return string
+    * @return ?string
     */
-    public function getCompany(): string
+    public function getCompany(): ?string
     {
         return $this->_company;
     }
@@ -78,9 +78,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the country attribute.
     * Country, 2-letter ISO code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCountry(): string
+    public function getCountry(): ?string
     {
         return $this->_country;
     }
@@ -101,9 +101,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the first_name attribute.
     * First name
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->_first_name;
     }
@@ -124,9 +124,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the last_name attribute.
     * Last name
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->_last_name;
     }
@@ -147,9 +147,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the name_on_account attribute.
     * Name on account
     *
-    * @return string
+    * @return ?string
     */
-    public function getNameOnAccount(): string
+    public function getNameOnAccount(): ?string
     {
         return $this->_name_on_account;
     }
@@ -170,9 +170,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the phone attribute.
     * Phone number
     *
-    * @return string
+    * @return ?string
     */
-    public function getPhone(): string
+    public function getPhone(): ?string
     {
         return $this->_phone;
     }
@@ -193,9 +193,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the postal_code attribute.
     * Zip or postal code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPostalCode(): string
+    public function getPostalCode(): ?string
     {
         return $this->_postal_code;
     }
@@ -216,9 +216,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the region attribute.
     * State or province.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRegion(): string
+    public function getRegion(): ?string
     {
         return $this->_region;
     }
@@ -239,9 +239,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the street1 attribute.
     * Street 1
     *
-    * @return string
+    * @return ?string
     */
-    public function getStreet1(): string
+    public function getStreet1(): ?string
     {
         return $this->_street1;
     }
@@ -262,9 +262,9 @@ class InvoiceAddress extends RecurlyResource
     * Getter method for the street2 attribute.
     * Street 2
     *
-    * @return string
+    * @return ?string
     */
-    public function getStreet2(): string
+    public function getStreet2(): ?string
     {
         return $this->_street2;
     }

--- a/lib/recurly/resources/invoice_collection.php
+++ b/lib/recurly/resources/invoice_collection.php
@@ -71,9 +71,9 @@ class InvoiceCollection extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/invoice_collection.php
+++ b/lib/recurly/resources/invoice_collection.php
@@ -25,9 +25,9 @@ class InvoiceCollection extends RecurlyResource
     * Getter method for the charge_invoice attribute.
     * 
     *
-    * @return \Recurly\Resources\Invoice
+    * @return ?\Recurly\Resources\Invoice
     */
-    public function getChargeInvoice(): \Recurly\Resources\Invoice
+    public function getChargeInvoice(): ?\Recurly\Resources\Invoice
     {
         return $this->_charge_invoice;
     }
@@ -52,7 +52,7 @@ class InvoiceCollection extends RecurlyResource
     */
     public function getCreditInvoices(): array
     {
-        return $this->_credit_invoices;
+        return $this->_credit_invoices ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/invoice_mini.php
+++ b/lib/recurly/resources/invoice_mini.php
@@ -26,9 +26,9 @@ class InvoiceMini extends RecurlyResource
     * Getter method for the id attribute.
     * Invoice ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -49,9 +49,9 @@ class InvoiceMini extends RecurlyResource
     * Getter method for the number attribute.
     * Invoice number
     *
-    * @return string
+    * @return ?string
     */
-    public function getNumber(): string
+    public function getNumber(): ?string
     {
         return $this->_number;
     }
@@ -72,9 +72,9 @@ class InvoiceMini extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -95,9 +95,9 @@ class InvoiceMini extends RecurlyResource
     * Getter method for the state attribute.
     * Invoice state
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -118,9 +118,9 @@ class InvoiceMini extends RecurlyResource
     * Getter method for the type attribute.
     * Invoice type
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }

--- a/lib/recurly/resources/item.php
+++ b/lib/recurly/resources/item.php
@@ -112,7 +112,7 @@ class Item extends RecurlyResource
     */
     public function getCurrencies(): array
     {
-        return $this->_currencies;
+        return $this->_currencies ?? [] ;
     }
 
     /**
@@ -135,7 +135,7 @@ class Item extends RecurlyResource
     */
     public function getCustomFields(): array
     {
-        return $this->_custom_fields;
+        return $this->_custom_fields ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/item.php
+++ b/lib/recurly/resources/item.php
@@ -39,9 +39,9 @@ class Item extends RecurlyResource
     * Getter method for the accounting_code attribute.
     * Accounting code for invoice line items.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountingCode(): string
+    public function getAccountingCode(): ?string
     {
         return $this->_accounting_code;
     }
@@ -62,9 +62,9 @@ class Item extends RecurlyResource
     * Getter method for the code attribute.
     * Unique code to identify the item.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -85,9 +85,9 @@ class Item extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -154,9 +154,9 @@ class Item extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * Deleted at
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -177,9 +177,9 @@ class Item extends RecurlyResource
     * Getter method for the description attribute.
     * Optional, description.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->_description;
     }
@@ -200,9 +200,9 @@ class Item extends RecurlyResource
     * Getter method for the external_sku attribute.
     * Optional, stock keeping unit to link the item to other inventory systems.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExternalSku(): string
+    public function getExternalSku(): ?string
     {
         return $this->_external_sku;
     }
@@ -223,9 +223,9 @@ class Item extends RecurlyResource
     * Getter method for the id attribute.
     * Item ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -246,9 +246,9 @@ class Item extends RecurlyResource
     * Getter method for the name attribute.
     * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -269,9 +269,9 @@ class Item extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -292,9 +292,9 @@ class Item extends RecurlyResource
     * Getter method for the revenue_schedule_type attribute.
     * Revenue schedule type
     *
-    * @return string
+    * @return ?string
     */
-    public function getRevenueScheduleType(): string
+    public function getRevenueScheduleType(): ?string
     {
         return $this->_revenue_schedule_type;
     }
@@ -315,9 +315,9 @@ class Item extends RecurlyResource
     * Getter method for the state attribute.
     * The current state of the item.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -338,9 +338,9 @@ class Item extends RecurlyResource
     * Getter method for the tax_code attribute.
     * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTaxCode(): string
+    public function getTaxCode(): ?string
     {
         return $this->_tax_code;
     }
@@ -384,9 +384,9 @@ class Item extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/item.php
+++ b/lib/recurly/resources/item.php
@@ -361,9 +361,9 @@ class Item extends RecurlyResource
     * Getter method for the tax_exempt attribute.
     * `true` exempts tax on the item, `false` applies tax on the item.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getTaxExempt(): bool
+    public function getTaxExempt(): ?bool
     {
         return $this->_tax_exempt;
     }

--- a/lib/recurly/resources/item_mini.php
+++ b/lib/recurly/resources/item_mini.php
@@ -27,9 +27,9 @@ class ItemMini extends RecurlyResource
     * Getter method for the code attribute.
     * Unique code to identify the item.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -50,9 +50,9 @@ class ItemMini extends RecurlyResource
     * Getter method for the description attribute.
     * Optional, description.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->_description;
     }
@@ -73,9 +73,9 @@ class ItemMini extends RecurlyResource
     * Getter method for the id attribute.
     * Item ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -96,9 +96,9 @@ class ItemMini extends RecurlyResource
     * Getter method for the name attribute.
     * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -119,9 +119,9 @@ class ItemMini extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -142,9 +142,9 @@ class ItemMini extends RecurlyResource
     * Getter method for the state attribute.
     * The current state of the item.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -715,9 +715,9 @@ class LineItem extends RecurlyResource
     * Getter method for the refund attribute.
     * Refund?
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getRefund(): bool
+    public function getRefund(): ?bool
     {
         return $this->_refund;
     }
@@ -945,9 +945,9 @@ class LineItem extends RecurlyResource
     * Getter method for the tax_exempt attribute.
     * `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getTaxExempt(): bool
+    public function getTaxExempt(): ?bool
     {
         return $this->_tax_exempt;
     }
@@ -991,9 +991,9 @@ class LineItem extends RecurlyResource
     * Getter method for the taxable attribute.
     * `true` if the line item is taxable, `false` if it is not.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getTaxable(): bool
+    public function getTaxable(): ?bool
     {
         return $this->_taxable;
     }

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -89,9 +89,9 @@ class LineItem extends RecurlyResource
     * Getter method for the accounting_code attribute.
     * Internal accounting code to help you reconcile your revenue to the correct ledger. Line items created as part of a subscription invoice will use the plan or add-on's accounting code, otherwise the value will only be present if you define an accounting code when creating the line item.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountingCode(): string
+    public function getAccountingCode(): ?string
     {
         return $this->_accounting_code;
     }
@@ -112,9 +112,9 @@ class LineItem extends RecurlyResource
     * Getter method for the add_on_code attribute.
     * If the line item is a charge or credit for an add-on, this is its code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAddOnCode(): string
+    public function getAddOnCode(): ?string
     {
         return $this->_add_on_code;
     }
@@ -135,9 +135,9 @@ class LineItem extends RecurlyResource
     * Getter method for the add_on_id attribute.
     * If the line item is a charge or credit for an add-on this is its ID.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAddOnId(): string
+    public function getAddOnId(): ?string
     {
         return $this->_add_on_id;
     }
@@ -158,9 +158,9 @@ class LineItem extends RecurlyResource
     * Getter method for the amount attribute.
     * `(quantity * unit_amount) - (discount + tax)`
     *
-    * @return float
+    * @return ?float
     */
-    public function getAmount(): float
+    public function getAmount(): ?float
     {
         return $this->_amount;
     }
@@ -181,9 +181,9 @@ class LineItem extends RecurlyResource
     * Getter method for the created_at attribute.
     * When the line item was created.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -204,9 +204,9 @@ class LineItem extends RecurlyResource
     * Getter method for the credit_applied attribute.
     * The amount of credit from this line item that was applied to the invoice.
     *
-    * @return float
+    * @return ?float
     */
-    public function getCreditApplied(): float
+    public function getCreditApplied(): ?float
     {
         return $this->_credit_applied;
     }
@@ -227,9 +227,9 @@ class LineItem extends RecurlyResource
     * Getter method for the credit_reason_code attribute.
     * The reason the credit was given when line item is `type=credit`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreditReasonCode(): string
+    public function getCreditReasonCode(): ?string
     {
         return $this->_credit_reason_code;
     }
@@ -250,9 +250,9 @@ class LineItem extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -273,9 +273,9 @@ class LineItem extends RecurlyResource
     * Getter method for the description attribute.
     * Description that appears on the invoice. For subscription related items this will be filled in automatically.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->_description;
     }
@@ -296,9 +296,9 @@ class LineItem extends RecurlyResource
     * Getter method for the discount attribute.
     * The discount applied to the line item.
     *
-    * @return float
+    * @return ?float
     */
-    public function getDiscount(): float
+    public function getDiscount(): ?float
     {
         return $this->_discount;
     }
@@ -319,9 +319,9 @@ class LineItem extends RecurlyResource
     * Getter method for the end_date attribute.
     * If this date is provided, it indicates the end of a time range.
     *
-    * @return string
+    * @return ?string
     */
-    public function getEndDate(): string
+    public function getEndDate(): ?string
     {
         return $this->_end_date;
     }
@@ -342,9 +342,9 @@ class LineItem extends RecurlyResource
     * Getter method for the external_sku attribute.
     * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExternalSku(): string
+    public function getExternalSku(): ?string
     {
         return $this->_external_sku;
     }
@@ -365,9 +365,9 @@ class LineItem extends RecurlyResource
     * Getter method for the id attribute.
     * Line item ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -388,9 +388,9 @@ class LineItem extends RecurlyResource
     * Getter method for the invoice_id attribute.
     * Once the line item has been invoiced this will be the invoice's ID.
     *
-    * @return string
+    * @return ?string
     */
-    public function getInvoiceId(): string
+    public function getInvoiceId(): ?string
     {
         return $this->_invoice_id;
     }
@@ -411,9 +411,9 @@ class LineItem extends RecurlyResource
     * Getter method for the invoice_number attribute.
     * Once the line item has been invoiced this will be the invoice's number. If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.
     *
-    * @return string
+    * @return ?string
     */
-    public function getInvoiceNumber(): string
+    public function getInvoiceNumber(): ?string
     {
         return $this->_invoice_number;
     }
@@ -434,9 +434,9 @@ class LineItem extends RecurlyResource
     * Getter method for the item_code attribute.
     * Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
     *
-    * @return string
+    * @return ?string
     */
-    public function getItemCode(): string
+    public function getItemCode(): ?string
     {
         return $this->_item_code;
     }
@@ -457,9 +457,9 @@ class LineItem extends RecurlyResource
     * Getter method for the item_id attribute.
     * System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
     *
-    * @return string
+    * @return ?string
     */
-    public function getItemId(): string
+    public function getItemId(): ?string
     {
         return $this->_item_id;
     }
@@ -485,9 +485,9 @@ class LineItem extends RecurlyResource
 - "carryforwards" can be ignored. They exist to consume any remaining credit balance. A new credit with the same amount will be created and placed back on the account.
 
     *
-    * @return string
+    * @return ?string
     */
-    public function getLegacyCategory(): string
+    public function getLegacyCategory(): ?string
     {
         return $this->_legacy_category;
     }
@@ -508,9 +508,9 @@ class LineItem extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -531,9 +531,9 @@ class LineItem extends RecurlyResource
     * Getter method for the origin attribute.
     * A credit created from an original charge will have the value of the charge's origin.
     *
-    * @return string
+    * @return ?string
     */
-    public function getOrigin(): string
+    public function getOrigin(): ?string
     {
         return $this->_origin;
     }
@@ -554,9 +554,9 @@ class LineItem extends RecurlyResource
     * Getter method for the original_line_item_invoice_id attribute.
     * The invoice where the credit originated. Will only have a value if the line item is a credit created from a previous credit, or if the credit was created from a charge refund.
     *
-    * @return string
+    * @return ?string
     */
-    public function getOriginalLineItemInvoiceId(): string
+    public function getOriginalLineItemInvoiceId(): ?string
     {
         return $this->_original_line_item_invoice_id;
     }
@@ -577,9 +577,9 @@ class LineItem extends RecurlyResource
     * Getter method for the plan_code attribute.
     * If the line item is a charge or credit for a plan or add-on, this is the plan's code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPlanCode(): string
+    public function getPlanCode(): ?string
     {
         return $this->_plan_code;
     }
@@ -600,9 +600,9 @@ class LineItem extends RecurlyResource
     * Getter method for the plan_id attribute.
     * If the line item is a charge or credit for a plan or add-on, this is the plan's ID.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPlanId(): string
+    public function getPlanId(): ?string
     {
         return $this->_plan_id;
     }
@@ -623,9 +623,9 @@ class LineItem extends RecurlyResource
     * Getter method for the previous_line_item_id attribute.
     * Will only have a value if the line item is a credit created from a previous credit, or if the credit was created from a charge refund.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPreviousLineItemId(): string
+    public function getPreviousLineItemId(): ?string
     {
         return $this->_previous_line_item_id;
     }
@@ -646,9 +646,9 @@ class LineItem extends RecurlyResource
     * Getter method for the product_code attribute.
     * For plan-related line items this will be the plan's code, for add-on related line items it will be the add-on's code. For item-related line itmes it will be the item's `external_sku`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getProductCode(): string
+    public function getProductCode(): ?string
     {
         return $this->_product_code;
     }
@@ -669,9 +669,9 @@ class LineItem extends RecurlyResource
     * Getter method for the proration_rate attribute.
     * When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.
     *
-    * @return float
+    * @return ?float
     */
-    public function getProrationRate(): float
+    public function getProrationRate(): ?float
     {
         return $this->_proration_rate;
     }
@@ -692,9 +692,9 @@ class LineItem extends RecurlyResource
     * Getter method for the quantity attribute.
     * This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
     *
-    * @return int
+    * @return ?int
     */
-    public function getQuantity(): int
+    public function getQuantity(): ?int
     {
         return $this->_quantity;
     }
@@ -738,9 +738,9 @@ class LineItem extends RecurlyResource
     * Getter method for the refunded_quantity attribute.
     * For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
     *
-    * @return int
+    * @return ?int
     */
-    public function getRefundedQuantity(): int
+    public function getRefundedQuantity(): ?int
     {
         return $this->_refunded_quantity;
     }
@@ -761,9 +761,9 @@ class LineItem extends RecurlyResource
     * Getter method for the revenue_schedule_type attribute.
     * Revenue schedule type
     *
-    * @return string
+    * @return ?string
     */
-    public function getRevenueScheduleType(): string
+    public function getRevenueScheduleType(): ?string
     {
         return $this->_revenue_schedule_type;
     }
@@ -807,9 +807,9 @@ class LineItem extends RecurlyResource
     * Getter method for the start_date attribute.
     * If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date.
     *
-    * @return string
+    * @return ?string
     */
-    public function getStartDate(): string
+    public function getStartDate(): ?string
     {
         return $this->_start_date;
     }
@@ -830,9 +830,9 @@ class LineItem extends RecurlyResource
     * Getter method for the state attribute.
     * Pending line items are charges or credits on an account that have not been applied to an invoice yet. Invoiced line items will always have an `invoice_id` value.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -853,9 +853,9 @@ class LineItem extends RecurlyResource
     * Getter method for the subscription_id attribute.
     * If the line item is a charge or credit for a subscription, this is its ID.
     *
-    * @return string
+    * @return ?string
     */
-    public function getSubscriptionId(): string
+    public function getSubscriptionId(): ?string
     {
         return $this->_subscription_id;
     }
@@ -876,9 +876,9 @@ class LineItem extends RecurlyResource
     * Getter method for the subtotal attribute.
     * `quantity * unit_amount`
     *
-    * @return float
+    * @return ?float
     */
-    public function getSubtotal(): float
+    public function getSubtotal(): ?float
     {
         return $this->_subtotal;
     }
@@ -899,9 +899,9 @@ class LineItem extends RecurlyResource
     * Getter method for the tax attribute.
     * The tax amount for the line item.
     *
-    * @return float
+    * @return ?float
     */
-    public function getTax(): float
+    public function getTax(): ?float
     {
         return $this->_tax;
     }
@@ -922,9 +922,9 @@ class LineItem extends RecurlyResource
     * Getter method for the tax_code attribute.
     * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTaxCode(): string
+    public function getTaxCode(): ?string
     {
         return $this->_tax_code;
     }
@@ -1014,9 +1014,9 @@ class LineItem extends RecurlyResource
     * Getter method for the type attribute.
     * Charges are positive line items that debit the account. Credits are negative line items that credit the account.
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }
@@ -1037,9 +1037,9 @@ class LineItem extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Positive amount for a charge, negative amount for a credit.
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }
@@ -1060,9 +1060,9 @@ class LineItem extends RecurlyResource
     * Getter method for the updated_at attribute.
     * When the line item was last changed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -1083,9 +1083,9 @@ class LineItem extends RecurlyResource
     * Getter method for the uuid attribute.
     * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUuid(): string
+    public function getUuid(): ?string
     {
         return $this->_uuid;
     }

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -66,9 +66,9 @@ class LineItem extends RecurlyResource
     * Getter method for the account attribute.
     * Account mini details
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -784,9 +784,9 @@ class LineItem extends RecurlyResource
     * Getter method for the shipping_address attribute.
     * 
     *
-    * @return \Recurly\Resources\ShippingAddress
+    * @return ?\Recurly\Resources\ShippingAddress
     */
-    public function getShippingAddress(): \Recurly\Resources\ShippingAddress
+    public function getShippingAddress(): ?\Recurly\Resources\ShippingAddress
     {
         return $this->_shipping_address;
     }
@@ -968,9 +968,9 @@ class LineItem extends RecurlyResource
     * Getter method for the tax_info attribute.
     * Tax info
     *
-    * @return \Recurly\Resources\TaxInfo
+    * @return ?\Recurly\Resources\TaxInfo
     */
-    public function getTaxInfo(): \Recurly\Resources\TaxInfo
+    public function getTaxInfo(): ?\Recurly\Resources\TaxInfo
     {
         return $this->_tax_info;
     }

--- a/lib/recurly/resources/line_item_list.php
+++ b/lib/recurly/resources/line_item_list.php
@@ -49,9 +49,9 @@ class LineItemList extends RecurlyResource
     * Getter method for the has_more attribute.
     * Indicates there are more results on subsequent pages.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getHasMore(): bool
+    public function getHasMore(): ?bool
     {
         return $this->_has_more;
     }

--- a/lib/recurly/resources/line_item_list.php
+++ b/lib/recurly/resources/line_item_list.php
@@ -72,9 +72,9 @@ class LineItemList extends RecurlyResource
     * Getter method for the next attribute.
     * Path to subsequent page of results.
     *
-    * @return string
+    * @return ?string
     */
-    public function getNext(): string
+    public function getNext(): ?string
     {
         return $this->_next;
     }
@@ -95,9 +95,9 @@ class LineItemList extends RecurlyResource
     * Getter method for the object attribute.
     * Will always be List.
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/line_item_list.php
+++ b/lib/recurly/resources/line_item_list.php
@@ -30,7 +30,7 @@ class LineItemList extends RecurlyResource
     */
     public function getData(): array
     {
-        return $this->_data;
+        return $this->_data ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/payment_method.php
+++ b/lib/recurly/resources/payment_method.php
@@ -34,9 +34,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the account_type attribute.
     * The bank account type. Only present for ACH payment methods.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountType(): string
+    public function getAccountType(): ?string
     {
         return $this->_account_type;
     }
@@ -57,9 +57,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the billing_agreement_id attribute.
     * Billing Agreement identifier. Only present for Amazon or Paypal payment methods.
     *
-    * @return string
+    * @return ?string
     */
-    public function getBillingAgreementId(): string
+    public function getBillingAgreementId(): ?string
     {
         return $this->_billing_agreement_id;
     }
@@ -80,9 +80,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the card_type attribute.
     * Visa, MasterCard, American Express, Discover, JCB, etc.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCardType(): string
+    public function getCardType(): ?string
     {
         return $this->_card_type;
     }
@@ -103,9 +103,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the exp_month attribute.
     * Expiration month.
     *
-    * @return int
+    * @return ?int
     */
-    public function getExpMonth(): int
+    public function getExpMonth(): ?int
     {
         return $this->_exp_month;
     }
@@ -126,9 +126,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the exp_year attribute.
     * Expiration year.
     *
-    * @return int
+    * @return ?int
     */
-    public function getExpYear(): int
+    public function getExpYear(): ?int
     {
         return $this->_exp_year;
     }
@@ -149,9 +149,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the first_six attribute.
     * Credit card number's first six digits.
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstSix(): string
+    public function getFirstSix(): ?string
     {
         return $this->_first_six;
     }
@@ -172,9 +172,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the gateway_code attribute.
     * An identifier for a specific payment gateway.
     *
-    * @return string
+    * @return ?string
     */
-    public function getGatewayCode(): string
+    public function getGatewayCode(): ?string
     {
         return $this->_gateway_code;
     }
@@ -195,9 +195,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the gateway_token attribute.
     * A token used in place of a credit card in order to perform transactions.
     *
-    * @return string
+    * @return ?string
     */
-    public function getGatewayToken(): string
+    public function getGatewayToken(): ?string
     {
         return $this->_gateway_token;
     }
@@ -218,9 +218,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the last_four attribute.
     * Credit card number's last four digits. Will refer to bank account if payment method is ACH.
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastFour(): string
+    public function getLastFour(): ?string
     {
         return $this->_last_four;
     }
@@ -241,9 +241,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the last_two attribute.
     * The IBAN bank account's last two digits.
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastTwo(): string
+    public function getLastTwo(): ?string
     {
         return $this->_last_two;
     }
@@ -264,9 +264,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the object attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -287,9 +287,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the routing_number attribute.
     * The bank account's routing number. Only present for ACH payment methods.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRoutingNumber(): string
+    public function getRoutingNumber(): ?string
     {
         return $this->_routing_number;
     }
@@ -310,9 +310,9 @@ class PaymentMethod extends RecurlyResource
     * Getter method for the routing_number_bank attribute.
     * The bank name of this routing number.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRoutingNumberBank(): string
+    public function getRoutingNumberBank(): ?string
     {
         return $this->_routing_number_bank;
     }

--- a/lib/recurly/resources/plan.php
+++ b/lib/recurly/resources/plan.php
@@ -68,9 +68,9 @@ class Plan extends RecurlyResource
     * Getter method for the auto_renew attribute.
     * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getAutoRenew(): bool
+    public function getAutoRenew(): ?bool
     {
         return $this->_auto_renew;
     }
@@ -459,9 +459,9 @@ class Plan extends RecurlyResource
     * Getter method for the tax_exempt attribute.
     * `true` exempts tax on the plan, `false` applies tax on the plan.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getTaxExempt(): bool
+    public function getTaxExempt(): ?bool
     {
         return $this->_tax_exempt;
     }

--- a/lib/recurly/resources/plan.php
+++ b/lib/recurly/resources/plan.php
@@ -45,9 +45,9 @@ class Plan extends RecurlyResource
     * Getter method for the accounting_code attribute.
     * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountingCode(): string
+    public function getAccountingCode(): ?string
     {
         return $this->_accounting_code;
     }
@@ -91,9 +91,9 @@ class Plan extends RecurlyResource
     * Getter method for the code attribute.
     * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -114,9 +114,9 @@ class Plan extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -160,9 +160,9 @@ class Plan extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * Deleted at
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -183,9 +183,9 @@ class Plan extends RecurlyResource
     * Getter method for the description attribute.
     * Optional description, not displayed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->_description;
     }
@@ -229,9 +229,9 @@ class Plan extends RecurlyResource
     * Getter method for the id attribute.
     * Plan ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -252,9 +252,9 @@ class Plan extends RecurlyResource
     * Getter method for the interval_length attribute.
     * Length of the plan's billing interval in `interval_unit`.
     *
-    * @return int
+    * @return ?int
     */
-    public function getIntervalLength(): int
+    public function getIntervalLength(): ?int
     {
         return $this->_interval_length;
     }
@@ -275,9 +275,9 @@ class Plan extends RecurlyResource
     * Getter method for the interval_unit attribute.
     * Unit for the plan's billing interval.
     *
-    * @return string
+    * @return ?string
     */
-    public function getIntervalUnit(): string
+    public function getIntervalUnit(): ?string
     {
         return $this->_interval_unit;
     }
@@ -298,9 +298,9 @@ class Plan extends RecurlyResource
     * Getter method for the name attribute.
     * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -321,9 +321,9 @@ class Plan extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -344,9 +344,9 @@ class Plan extends RecurlyResource
     * Getter method for the revenue_schedule_type attribute.
     * Revenue schedule type
     *
-    * @return string
+    * @return ?string
     */
-    public function getRevenueScheduleType(): string
+    public function getRevenueScheduleType(): ?string
     {
         return $this->_revenue_schedule_type;
     }
@@ -367,9 +367,9 @@ class Plan extends RecurlyResource
     * Getter method for the setup_fee_accounting_code attribute.
     * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getSetupFeeAccountingCode(): string
+    public function getSetupFeeAccountingCode(): ?string
     {
         return $this->_setup_fee_accounting_code;
     }
@@ -390,9 +390,9 @@ class Plan extends RecurlyResource
     * Getter method for the setup_fee_revenue_schedule_type attribute.
     * Setup fee revenue schedule type
     *
-    * @return string
+    * @return ?string
     */
-    public function getSetupFeeRevenueScheduleType(): string
+    public function getSetupFeeRevenueScheduleType(): ?string
     {
         return $this->_setup_fee_revenue_schedule_type;
     }
@@ -413,9 +413,9 @@ class Plan extends RecurlyResource
     * Getter method for the state attribute.
     * The current state of the plan.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -436,9 +436,9 @@ class Plan extends RecurlyResource
     * Getter method for the tax_code attribute.
     * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTaxCode(): string
+    public function getTaxCode(): ?string
     {
         return $this->_tax_code;
     }
@@ -482,9 +482,9 @@ class Plan extends RecurlyResource
     * Getter method for the total_billing_cycles attribute.
     * Automatically terminate subscriptions after a defined number of billing cycles. Number of billing cycles before the plan automatically stops renewing, defaults to `null` for continuous, automatic renewal.
     *
-    * @return int
+    * @return ?int
     */
-    public function getTotalBillingCycles(): int
+    public function getTotalBillingCycles(): ?int
     {
         return $this->_total_billing_cycles;
     }
@@ -505,9 +505,9 @@ class Plan extends RecurlyResource
     * Getter method for the trial_length attribute.
     * Length of plan's trial period in `trial_units`. `0` means `no trial`.
     *
-    * @return int
+    * @return ?int
     */
-    public function getTrialLength(): int
+    public function getTrialLength(): ?int
     {
         return $this->_trial_length;
     }
@@ -528,9 +528,9 @@ class Plan extends RecurlyResource
     * Getter method for the trial_unit attribute.
     * Units for the plan's trial period.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTrialUnit(): string
+    public function getTrialUnit(): ?string
     {
         return $this->_trial_unit;
     }
@@ -551,9 +551,9 @@ class Plan extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/plan.php
+++ b/lib/recurly/resources/plan.php
@@ -141,7 +141,7 @@ class Plan extends RecurlyResource
     */
     public function getCurrencies(): array
     {
-        return $this->_currencies;
+        return $this->_currencies ?? [] ;
     }
 
     /**
@@ -206,9 +206,9 @@ class Plan extends RecurlyResource
     * Getter method for the hosted_pages attribute.
     * Hosted pages settings
     *
-    * @return \Recurly\Resources\PlanHostedPages
+    * @return ?\Recurly\Resources\PlanHostedPages
     */
-    public function getHostedPages(): \Recurly\Resources\PlanHostedPages
+    public function getHostedPages(): ?\Recurly\Resources\PlanHostedPages
     {
         return $this->_hosted_pages;
     }

--- a/lib/recurly/resources/plan_hosted_pages.php
+++ b/lib/recurly/resources/plan_hosted_pages.php
@@ -48,9 +48,9 @@ class PlanHostedPages extends RecurlyResource
     * Getter method for the cancel_url attribute.
     * URL to redirect to on canceled signup on the hosted payment pages.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCancelUrl(): string
+    public function getCancelUrl(): ?string
     {
         return $this->_cancel_url;
     }
@@ -94,9 +94,9 @@ class PlanHostedPages extends RecurlyResource
     * Getter method for the success_url attribute.
     * URL to redirect to after signup on the hosted payment pages.
     *
-    * @return string
+    * @return ?string
     */
-    public function getSuccessUrl(): string
+    public function getSuccessUrl(): ?string
     {
         return $this->_success_url;
     }

--- a/lib/recurly/resources/plan_hosted_pages.php
+++ b/lib/recurly/resources/plan_hosted_pages.php
@@ -25,9 +25,9 @@ class PlanHostedPages extends RecurlyResource
     * Getter method for the bypass_confirmation attribute.
     * If `true`, the customer will be sent directly to your `success_url` after a successful signup, bypassing Recurly's hosted confirmation page.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getBypassConfirmation(): bool
+    public function getBypassConfirmation(): ?bool
     {
         return $this->_bypass_confirmation;
     }
@@ -71,9 +71,9 @@ class PlanHostedPages extends RecurlyResource
     * Getter method for the display_quantity attribute.
     * Determines if the quantity field is displayed on the hosted pages for the plan.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getDisplayQuantity(): bool
+    public function getDisplayQuantity(): ?bool
     {
         return $this->_display_quantity;
     }

--- a/lib/recurly/resources/plan_mini.php
+++ b/lib/recurly/resources/plan_mini.php
@@ -25,9 +25,9 @@ class PlanMini extends RecurlyResource
     * Getter method for the code attribute.
     * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -48,9 +48,9 @@ class PlanMini extends RecurlyResource
     * Getter method for the id attribute.
     * Plan ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -71,9 +71,9 @@ class PlanMini extends RecurlyResource
     * Getter method for the name attribute.
     * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -94,9 +94,9 @@ class PlanMini extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/plan_pricing.php
+++ b/lib/recurly/resources/plan_pricing.php
@@ -24,9 +24,9 @@ class PlanPricing extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -47,9 +47,9 @@ class PlanPricing extends RecurlyResource
     * Getter method for the setup_fee attribute.
     * Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
     *
-    * @return float
+    * @return ?float
     */
-    public function getSetupFee(): float
+    public function getSetupFee(): ?float
     {
         return $this->_setup_fee;
     }
@@ -70,9 +70,9 @@ class PlanPricing extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Unit price
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }

--- a/lib/recurly/resources/pricing.php
+++ b/lib/recurly/resources/pricing.php
@@ -23,9 +23,9 @@ class Pricing extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -46,9 +46,9 @@ class Pricing extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Unit price
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }

--- a/lib/recurly/resources/settings.php
+++ b/lib/recurly/resources/settings.php
@@ -52,9 +52,9 @@ class Settings extends RecurlyResource
 - none:      No Address
 
     *
-    * @return string
+    * @return ?string
     */
-    public function getBillingAddressRequirement(): string
+    public function getBillingAddressRequirement(): ?string
     {
         return $this->_billing_address_requirement;
     }
@@ -75,9 +75,9 @@ class Settings extends RecurlyResource
     * Getter method for the default_currency attribute.
     * The default 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getDefaultCurrency(): string
+    public function getDefaultCurrency(): ?string
     {
         return $this->_default_currency;
     }

--- a/lib/recurly/resources/settings.php
+++ b/lib/recurly/resources/settings.php
@@ -29,7 +29,7 @@ class Settings extends RecurlyResource
     */
     public function getAcceptedCurrencies(): array
     {
-        return $this->_accepted_currencies;
+        return $this->_accepted_currencies ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/shipping_address.php
+++ b/lib/recurly/resources/shipping_address.php
@@ -39,9 +39,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the account_id attribute.
     * Account ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getAccountId(): string
+    public function getAccountId(): ?string
     {
         return $this->_account_id;
     }
@@ -62,9 +62,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the city attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getCity(): string
+    public function getCity(): ?string
     {
         return $this->_city;
     }
@@ -85,9 +85,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the company attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getCompany(): string
+    public function getCompany(): ?string
     {
         return $this->_company;
     }
@@ -108,9 +108,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the country attribute.
     * Country, 2-letter ISO code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCountry(): string
+    public function getCountry(): ?string
     {
         return $this->_country;
     }
@@ -131,9 +131,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -154,9 +154,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the email attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->_email;
     }
@@ -177,9 +177,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the first_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->_first_name;
     }
@@ -200,9 +200,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the id attribute.
     * Shipping Address ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -223,9 +223,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the last_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->_last_name;
     }
@@ -246,9 +246,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the nickname attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getNickname(): string
+    public function getNickname(): ?string
     {
         return $this->_nickname;
     }
@@ -269,9 +269,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -292,9 +292,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the phone attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getPhone(): string
+    public function getPhone(): ?string
     {
         return $this->_phone;
     }
@@ -315,9 +315,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the postal_code attribute.
     * Zip or postal code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPostalCode(): string
+    public function getPostalCode(): ?string
     {
         return $this->_postal_code;
     }
@@ -338,9 +338,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the region attribute.
     * State or province.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRegion(): string
+    public function getRegion(): ?string
     {
         return $this->_region;
     }
@@ -361,9 +361,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the street1 attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getStreet1(): string
+    public function getStreet1(): ?string
     {
         return $this->_street1;
     }
@@ -384,9 +384,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the street2 attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getStreet2(): string
+    public function getStreet2(): ?string
     {
         return $this->_street2;
     }
@@ -407,9 +407,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -430,9 +430,9 @@ class ShippingAddress extends RecurlyResource
     * Getter method for the vat_number attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getVatNumber(): string
+    public function getVatNumber(): ?string
     {
         return $this->_vat_number;
     }

--- a/lib/recurly/resources/shipping_method.php
+++ b/lib/recurly/resources/shipping_method.php
@@ -29,9 +29,9 @@ class ShippingMethod extends RecurlyResource
     * Getter method for the code attribute.
     * The internal name used identify the shipping method.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -52,9 +52,9 @@ class ShippingMethod extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -75,9 +75,9 @@ class ShippingMethod extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * Deleted at
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -98,9 +98,9 @@ class ShippingMethod extends RecurlyResource
     * Getter method for the id attribute.
     * Shipping Method ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -121,9 +121,9 @@ class ShippingMethod extends RecurlyResource
     * Getter method for the name attribute.
     * The name of the shipping method displayed to customers.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -144,9 +144,9 @@ class ShippingMethod extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -178,9 +178,9 @@ built-in taxes the values are:
 - `NT` – Non-Taxable
 
     *
-    * @return string
+    * @return ?string
     */
-    public function getTaxCode(): string
+    public function getTaxCode(): ?string
     {
         return $this->_tax_code;
     }
@@ -201,9 +201,9 @@ built-in taxes the values are:
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/shipping_method_mini.php
+++ b/lib/recurly/resources/shipping_method_mini.php
@@ -25,9 +25,9 @@ class ShippingMethodMini extends RecurlyResource
     * Getter method for the code attribute.
     * The internal name used identify the shipping method.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -48,9 +48,9 @@ class ShippingMethodMini extends RecurlyResource
     * Getter method for the id attribute.
     * Shipping Method ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -71,9 +71,9 @@ class ShippingMethodMini extends RecurlyResource
     * Getter method for the name attribute.
     * The name of the shipping method displayed to customers.
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -94,9 +94,9 @@ class ShippingMethodMini extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/site.php
+++ b/lib/recurly/resources/site.php
@@ -56,9 +56,9 @@ class Site extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -79,9 +79,9 @@ class Site extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * Deleted at
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -125,9 +125,9 @@ class Site extends RecurlyResource
     * Getter method for the id attribute.
     * Site ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -148,9 +148,9 @@ class Site extends RecurlyResource
     * Getter method for the mode attribute.
     * Mode
     *
-    * @return string
+    * @return ?string
     */
-    public function getMode(): string
+    public function getMode(): ?string
     {
         return $this->_mode;
     }
@@ -171,9 +171,9 @@ class Site extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -194,9 +194,9 @@ class Site extends RecurlyResource
     * Getter method for the public_api_key attribute.
     * This value is used to configure RecurlyJS to submit tokenized billing information.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPublicApiKey(): string
+    public function getPublicApiKey(): ?string
     {
         return $this->_public_api_key;
     }
@@ -240,9 +240,9 @@ class Site extends RecurlyResource
     * Getter method for the subdomain attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getSubdomain(): string
+    public function getSubdomain(): ?string
     {
         return $this->_subdomain;
     }
@@ -263,9 +263,9 @@ class Site extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/site.php
+++ b/lib/recurly/resources/site.php
@@ -33,9 +33,9 @@ class Site extends RecurlyResource
     * Getter method for the address attribute.
     * 
     *
-    * @return \Recurly\Resources\Address
+    * @return ?\Recurly\Resources\Address
     */
-    public function getAddress(): \Recurly\Resources\Address
+    public function getAddress(): ?\Recurly\Resources\Address
     {
         return $this->_address;
     }
@@ -106,7 +106,7 @@ class Site extends RecurlyResource
     */
     public function getFeatures(): array
     {
-        return $this->_features;
+        return $this->_features ?? [] ;
     }
 
     /**
@@ -217,9 +217,9 @@ class Site extends RecurlyResource
     * Getter method for the settings attribute.
     * 
     *
-    * @return \Recurly\Resources\Settings
+    * @return ?\Recurly\Resources\Settings
     */
-    public function getSettings(): \Recurly\Resources\Settings
+    public function getSettings(): ?\Recurly\Resources\Settings
     {
         return $this->_settings;
     }

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -65,9 +65,9 @@ class Subscription extends RecurlyResource
     * Getter method for the account attribute.
     * Account mini details
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -115,7 +115,7 @@ class Subscription extends RecurlyResource
     */
     public function getAddOns(): array
     {
-        return $this->_add_ons;
+        return $this->_add_ons ?? [] ;
     }
 
     /**
@@ -253,7 +253,7 @@ class Subscription extends RecurlyResource
     */
     public function getCouponRedemptions(): array
     {
-        return $this->_coupon_redemptions;
+        return $this->_coupon_redemptions ?? [] ;
     }
 
     /**
@@ -414,7 +414,7 @@ class Subscription extends RecurlyResource
     */
     public function getCustomFields(): array
     {
-        return $this->_custom_fields;
+        return $this->_custom_fields ?? [] ;
     }
 
     /**
@@ -594,9 +594,9 @@ class Subscription extends RecurlyResource
     * Getter method for the pending_change attribute.
     * Subscription Change
     *
-    * @return \Recurly\Resources\SubscriptionChange
+    * @return ?\Recurly\Resources\SubscriptionChange
     */
-    public function getPendingChange(): \Recurly\Resources\SubscriptionChange
+    public function getPendingChange(): ?\Recurly\Resources\SubscriptionChange
     {
         return $this->_pending_change;
     }
@@ -617,9 +617,9 @@ class Subscription extends RecurlyResource
     * Getter method for the plan attribute.
     * Just the important parts.
     *
-    * @return \Recurly\Resources\PlanMini
+    * @return ?\Recurly\Resources\PlanMini
     */
-    public function getPlan(): \Recurly\Resources\PlanMini
+    public function getPlan(): ?\Recurly\Resources\PlanMini
     {
         return $this->_plan;
     }
@@ -778,9 +778,9 @@ class Subscription extends RecurlyResource
     * Getter method for the shipping attribute.
     * Subscription shipping details
     *
-    * @return \Recurly\Resources\SubscriptionShipping
+    * @return ?\Recurly\Resources\SubscriptionShipping
     */
-    public function getShipping(): \Recurly\Resources\SubscriptionShipping
+    public function getShipping(): ?\Recurly\Resources\SubscriptionShipping
     {
         return $this->_shipping;
     }

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -157,9 +157,9 @@ class Subscription extends RecurlyResource
     * Getter method for the auto_renew attribute.
     * Whether the subscription renews at the end of its term.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getAutoRenew(): bool
+    public function getAutoRenew(): ?bool
     {
         return $this->_auto_renew;
     }

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -88,9 +88,9 @@ class Subscription extends RecurlyResource
     * Getter method for the activated_at attribute.
     * Activated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getActivatedAt(): string
+    public function getActivatedAt(): ?string
     {
         return $this->_activated_at;
     }
@@ -134,9 +134,9 @@ class Subscription extends RecurlyResource
     * Getter method for the add_ons_total attribute.
     * Total price of add-ons
     *
-    * @return float
+    * @return ?float
     */
-    public function getAddOnsTotal(): float
+    public function getAddOnsTotal(): ?float
     {
         return $this->_add_ons_total;
     }
@@ -180,9 +180,9 @@ class Subscription extends RecurlyResource
     * Getter method for the bank_account_authorized_at attribute.
     * Recurring subscriptions paid with ACH will have this attribute set. This timestamp is used for alerting customers to reauthorize in 3 years in accordance with NACHA rules. If a subscription becomes inactive or the billing info is no longer a bank account, this timestamp is cleared.
     *
-    * @return string
+    * @return ?string
     */
-    public function getBankAccountAuthorizedAt(): string
+    public function getBankAccountAuthorizedAt(): ?string
     {
         return $this->_bank_account_authorized_at;
     }
@@ -203,9 +203,9 @@ class Subscription extends RecurlyResource
     * Getter method for the canceled_at attribute.
     * Canceled at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCanceledAt(): string
+    public function getCanceledAt(): ?string
     {
         return $this->_canceled_at;
     }
@@ -226,9 +226,9 @@ class Subscription extends RecurlyResource
     * Getter method for the collection_method attribute.
     * Collection method
     *
-    * @return string
+    * @return ?string
     */
-    public function getCollectionMethod(): string
+    public function getCollectionMethod(): ?string
     {
         return $this->_collection_method;
     }
@@ -272,9 +272,9 @@ class Subscription extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -295,9 +295,9 @@ class Subscription extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -318,9 +318,9 @@ class Subscription extends RecurlyResource
     * Getter method for the current_period_ends_at attribute.
     * Current billing period ends at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrentPeriodEndsAt(): string
+    public function getCurrentPeriodEndsAt(): ?string
     {
         return $this->_current_period_ends_at;
     }
@@ -341,9 +341,9 @@ class Subscription extends RecurlyResource
     * Getter method for the current_period_started_at attribute.
     * Current billing period started at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrentPeriodStartedAt(): string
+    public function getCurrentPeriodStartedAt(): ?string
     {
         return $this->_current_period_started_at;
     }
@@ -364,9 +364,9 @@ class Subscription extends RecurlyResource
     * Getter method for the current_term_ends_at attribute.
     * When the term ends. This is calculated by a plan's interval and `total_billing_cycles` in a term. Subscription changes with a `timeframe=renewal` will be applied on this date.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrentTermEndsAt(): string
+    public function getCurrentTermEndsAt(): ?string
     {
         return $this->_current_term_ends_at;
     }
@@ -387,9 +387,9 @@ class Subscription extends RecurlyResource
     * Getter method for the current_term_started_at attribute.
     * The start date of the term when the first billing period starts. The subscription term is the length of time that a customer will be committed to a subscription. A term can span multiple billing periods.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrentTermStartedAt(): string
+    public function getCurrentTermStartedAt(): ?string
     {
         return $this->_current_term_started_at;
     }
@@ -433,9 +433,9 @@ class Subscription extends RecurlyResource
     * Getter method for the customer_notes attribute.
     * Customer notes
     *
-    * @return string
+    * @return ?string
     */
-    public function getCustomerNotes(): string
+    public function getCustomerNotes(): ?string
     {
         return $this->_customer_notes;
     }
@@ -456,9 +456,9 @@ class Subscription extends RecurlyResource
     * Getter method for the expiration_reason attribute.
     * Expiration reason
     *
-    * @return string
+    * @return ?string
     */
-    public function getExpirationReason(): string
+    public function getExpirationReason(): ?string
     {
         return $this->_expiration_reason;
     }
@@ -479,9 +479,9 @@ class Subscription extends RecurlyResource
     * Getter method for the expires_at attribute.
     * Expires at
     *
-    * @return string
+    * @return ?string
     */
-    public function getExpiresAt(): string
+    public function getExpiresAt(): ?string
     {
         return $this->_expires_at;
     }
@@ -502,9 +502,9 @@ class Subscription extends RecurlyResource
     * Getter method for the id attribute.
     * Subscription ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -525,9 +525,9 @@ class Subscription extends RecurlyResource
     * Getter method for the net_terms attribute.
     * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
     *
-    * @return int
+    * @return ?int
     */
-    public function getNetTerms(): int
+    public function getNetTerms(): ?int
     {
         return $this->_net_terms;
     }
@@ -548,9 +548,9 @@ class Subscription extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -571,9 +571,9 @@ class Subscription extends RecurlyResource
     * Getter method for the paused_at attribute.
     * Null unless subscription is paused or will pause at the end of the current billing period.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPausedAt(): string
+    public function getPausedAt(): ?string
     {
         return $this->_paused_at;
     }
@@ -640,9 +640,9 @@ class Subscription extends RecurlyResource
     * Getter method for the po_number attribute.
     * For manual invoicing, this identifies the PO number associated with the subscription.
     *
-    * @return string
+    * @return ?string
     */
-    public function getPoNumber(): string
+    public function getPoNumber(): ?string
     {
         return $this->_po_number;
     }
@@ -663,9 +663,9 @@ class Subscription extends RecurlyResource
     * Getter method for the quantity attribute.
     * Subscription quantity
     *
-    * @return int
+    * @return ?int
     */
-    public function getQuantity(): int
+    public function getQuantity(): ?int
     {
         return $this->_quantity;
     }
@@ -686,9 +686,9 @@ class Subscription extends RecurlyResource
     * Getter method for the remaining_billing_cycles attribute.
     * The remaining billing cycles in the current term.
     *
-    * @return int
+    * @return ?int
     */
-    public function getRemainingBillingCycles(): int
+    public function getRemainingBillingCycles(): ?int
     {
         return $this->_remaining_billing_cycles;
     }
@@ -709,9 +709,9 @@ class Subscription extends RecurlyResource
     * Getter method for the remaining_pause_cycles attribute.
     * Null unless subscription is paused or will pause at the end of the current billing period.
     *
-    * @return int
+    * @return ?int
     */
-    public function getRemainingPauseCycles(): int
+    public function getRemainingPauseCycles(): ?int
     {
         return $this->_remaining_pause_cycles;
     }
@@ -732,9 +732,9 @@ class Subscription extends RecurlyResource
     * Getter method for the renewal_billing_cycles attribute.
     * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
     *
-    * @return int
+    * @return ?int
     */
-    public function getRenewalBillingCycles(): int
+    public function getRenewalBillingCycles(): ?int
     {
         return $this->_renewal_billing_cycles;
     }
@@ -755,9 +755,9 @@ class Subscription extends RecurlyResource
     * Getter method for the revenue_schedule_type attribute.
     * Revenue schedule type
     *
-    * @return string
+    * @return ?string
     */
-    public function getRevenueScheduleType(): string
+    public function getRevenueScheduleType(): ?string
     {
         return $this->_revenue_schedule_type;
     }
@@ -801,9 +801,9 @@ class Subscription extends RecurlyResource
     * Getter method for the state attribute.
     * State
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -824,9 +824,9 @@ class Subscription extends RecurlyResource
     * Getter method for the subtotal attribute.
     * Estimated total, before tax.
     *
-    * @return float
+    * @return ?float
     */
-    public function getSubtotal(): float
+    public function getSubtotal(): ?float
     {
         return $this->_subtotal;
     }
@@ -847,9 +847,9 @@ class Subscription extends RecurlyResource
     * Getter method for the terms_and_conditions attribute.
     * Terms and conditions
     *
-    * @return string
+    * @return ?string
     */
-    public function getTermsAndConditions(): string
+    public function getTermsAndConditions(): ?string
     {
         return $this->_terms_and_conditions;
     }
@@ -870,9 +870,9 @@ class Subscription extends RecurlyResource
     * Getter method for the total_billing_cycles attribute.
     * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
     *
-    * @return int
+    * @return ?int
     */
-    public function getTotalBillingCycles(): int
+    public function getTotalBillingCycles(): ?int
     {
         return $this->_total_billing_cycles;
     }
@@ -893,9 +893,9 @@ class Subscription extends RecurlyResource
     * Getter method for the trial_ends_at attribute.
     * Trial period ends at
     *
-    * @return string
+    * @return ?string
     */
-    public function getTrialEndsAt(): string
+    public function getTrialEndsAt(): ?string
     {
         return $this->_trial_ends_at;
     }
@@ -916,9 +916,9 @@ class Subscription extends RecurlyResource
     * Getter method for the trial_started_at attribute.
     * Trial period started at
     *
-    * @return string
+    * @return ?string
     */
-    public function getTrialStartedAt(): string
+    public function getTrialStartedAt(): ?string
     {
         return $this->_trial_started_at;
     }
@@ -939,9 +939,9 @@ class Subscription extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Subscription unit price
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }
@@ -962,9 +962,9 @@ class Subscription extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Last updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }
@@ -985,9 +985,9 @@ class Subscription extends RecurlyResource
     * Getter method for the uuid attribute.
     * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUuid(): string
+    public function getUuid(): ?string
     {
         return $this->_uuid;
     }

--- a/lib/recurly/resources/subscription_add_on.php
+++ b/lib/recurly/resources/subscription_add_on.php
@@ -56,9 +56,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -79,9 +79,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the expired_at attribute.
     * Expired at
     *
-    * @return string
+    * @return ?string
     */
-    public function getExpiredAt(): string
+    public function getExpiredAt(): ?string
     {
         return $this->_expired_at;
     }
@@ -102,9 +102,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the id attribute.
     * Subscription Add-on ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -125,9 +125,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -148,9 +148,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the quantity attribute.
     * Add-on quantity
     *
-    * @return int
+    * @return ?int
     */
-    public function getQuantity(): int
+    public function getQuantity(): ?int
     {
         return $this->_quantity;
     }
@@ -171,9 +171,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the subscription_id attribute.
     * Subscription ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getSubscriptionId(): string
+    public function getSubscriptionId(): ?string
     {
         return $this->_subscription_id;
     }
@@ -194,9 +194,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the tier_type attribute.
     * The type of tiering used by the Add-on.
     *
-    * @return string
+    * @return ?string
     */
-    public function getTierType(): string
+    public function getTierType(): ?string
     {
         return $this->_tier_type;
     }
@@ -240,9 +240,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * This is priced in the subscription's currency.
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }
@@ -263,9 +263,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/subscription_add_on.php
+++ b/lib/recurly/resources/subscription_add_on.php
@@ -33,9 +33,9 @@ class SubscriptionAddOn extends RecurlyResource
     * Getter method for the add_on attribute.
     * Just the important parts.
     *
-    * @return \Recurly\Resources\AddOnMini
+    * @return ?\Recurly\Resources\AddOnMini
     */
-    public function getAddOn(): \Recurly\Resources\AddOnMini
+    public function getAddOn(): ?\Recurly\Resources\AddOnMini
     {
         return $this->_add_on;
     }
@@ -221,7 +221,7 @@ class SubscriptionAddOn extends RecurlyResource
     */
     public function getTiers(): array
     {
-        return $this->_tiers;
+        return $this->_tiers ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/subscription_add_on_tier.php
+++ b/lib/recurly/resources/subscription_add_on_tier.php
@@ -23,9 +23,9 @@ class SubscriptionAddOnTier extends RecurlyResource
     * Getter method for the ending_quantity attribute.
     * Ending quantity
     *
-    * @return int
+    * @return ?int
     */
-    public function getEndingQuantity(): int
+    public function getEndingQuantity(): ?int
     {
         return $this->_ending_quantity;
     }
@@ -46,9 +46,9 @@ class SubscriptionAddOnTier extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Unit amount
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }

--- a/lib/recurly/resources/subscription_change.php
+++ b/lib/recurly/resources/subscription_change.php
@@ -60,9 +60,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the activated attribute.
     * Returns `true` if the subscription change is activated.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getActivated(): bool
+    public function getActivated(): ?bool
     {
         return $this->_activated;
     }

--- a/lib/recurly/resources/subscription_change.php
+++ b/lib/recurly/resources/subscription_change.php
@@ -37,9 +37,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the activate_at attribute.
     * Activated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getActivateAt(): string
+    public function getActivateAt(): ?string
     {
         return $this->_activate_at;
     }
@@ -106,9 +106,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -129,9 +129,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * Deleted at
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -152,9 +152,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the id attribute.
     * The ID of the Subscription Change.
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -175,9 +175,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -221,9 +221,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the quantity attribute.
     * Subscription quantity
     *
-    * @return int
+    * @return ?int
     */
-    public function getQuantity(): int
+    public function getQuantity(): ?int
     {
         return $this->_quantity;
     }
@@ -244,9 +244,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the revenue_schedule_type attribute.
     * Revenue schedule type
     *
-    * @return string
+    * @return ?string
     */
-    public function getRevenueScheduleType(): string
+    public function getRevenueScheduleType(): ?string
     {
         return $this->_revenue_schedule_type;
     }
@@ -267,9 +267,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the setup_fee_revenue_schedule_type attribute.
     * Setup fee revenue schedule type
     *
-    * @return string
+    * @return ?string
     */
-    public function getSetupFeeRevenueScheduleType(): string
+    public function getSetupFeeRevenueScheduleType(): ?string
     {
         return $this->_setup_fee_revenue_schedule_type;
     }
@@ -313,9 +313,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the subscription_id attribute.
     * The ID of the subscription that is going to be changed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getSubscriptionId(): string
+    public function getSubscriptionId(): ?string
     {
         return $this->_subscription_id;
     }
@@ -336,9 +336,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Unit amount
     *
-    * @return float
+    * @return ?float
     */
-    public function getUnitAmount(): float
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }
@@ -359,9 +359,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/subscription_change.php
+++ b/lib/recurly/resources/subscription_change.php
@@ -87,7 +87,7 @@ class SubscriptionChange extends RecurlyResource
     */
     public function getAddOns(): array
     {
-        return $this->_add_ons;
+        return $this->_add_ons ?? [] ;
     }
 
     /**
@@ -198,9 +198,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the plan attribute.
     * Just the important parts.
     *
-    * @return \Recurly\Resources\PlanMini
+    * @return ?\Recurly\Resources\PlanMini
     */
-    public function getPlan(): \Recurly\Resources\PlanMini
+    public function getPlan(): ?\Recurly\Resources\PlanMini
     {
         return $this->_plan;
     }
@@ -290,9 +290,9 @@ class SubscriptionChange extends RecurlyResource
     * Getter method for the shipping attribute.
     * Subscription shipping details
     *
-    * @return \Recurly\Resources\SubscriptionShipping
+    * @return ?\Recurly\Resources\SubscriptionShipping
     */
-    public function getShipping(): \Recurly\Resources\SubscriptionShipping
+    public function getShipping(): ?\Recurly\Resources\SubscriptionShipping
     {
         return $this->_shipping;
     }

--- a/lib/recurly/resources/subscription_shipping.php
+++ b/lib/recurly/resources/subscription_shipping.php
@@ -48,9 +48,9 @@ class SubscriptionShipping extends RecurlyResource
     * Getter method for the amount attribute.
     * Subscription's shipping cost
     *
-    * @return float
+    * @return ?float
     */
-    public function getAmount(): float
+    public function getAmount(): ?float
     {
         return $this->_amount;
     }
@@ -94,9 +94,9 @@ class SubscriptionShipping extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }

--- a/lib/recurly/resources/subscription_shipping.php
+++ b/lib/recurly/resources/subscription_shipping.php
@@ -25,9 +25,9 @@ class SubscriptionShipping extends RecurlyResource
     * Getter method for the address attribute.
     * 
     *
-    * @return \Recurly\Resources\ShippingAddress
+    * @return ?\Recurly\Resources\ShippingAddress
     */
-    public function getAddress(): \Recurly\Resources\ShippingAddress
+    public function getAddress(): ?\Recurly\Resources\ShippingAddress
     {
         return $this->_address;
     }
@@ -71,9 +71,9 @@ class SubscriptionShipping extends RecurlyResource
     * Getter method for the method attribute.
     * 
     *
-    * @return \Recurly\Resources\ShippingMethodMini
+    * @return ?\Recurly\Resources\ShippingMethodMini
     */
-    public function getMethod(): \Recurly\Resources\ShippingMethodMini
+    public function getMethod(): ?\Recurly\Resources\ShippingMethodMini
     {
         return $this->_method;
     }

--- a/lib/recurly/resources/tax_info.php
+++ b/lib/recurly/resources/tax_info.php
@@ -24,9 +24,9 @@ class TaxInfo extends RecurlyResource
     * Getter method for the rate attribute.
     * Rate
     *
-    * @return float
+    * @return ?float
     */
-    public function getRate(): float
+    public function getRate(): ?float
     {
         return $this->_rate;
     }
@@ -47,9 +47,9 @@ class TaxInfo extends RecurlyResource
     * Getter method for the region attribute.
     * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRegion(): string
+    public function getRegion(): ?string
     {
         return $this->_region;
     }
@@ -70,9 +70,9 @@ class TaxInfo extends RecurlyResource
     * Getter method for the type attribute.
     * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }

--- a/lib/recurly/resources/tier.php
+++ b/lib/recurly/resources/tier.php
@@ -28,7 +28,7 @@ class Tier extends RecurlyResource
     */
     public function getCurrencies(): array
     {
-        return $this->_currencies;
+        return $this->_currencies ?? [] ;
     }
 
     /**

--- a/lib/recurly/resources/tier.php
+++ b/lib/recurly/resources/tier.php
@@ -47,9 +47,9 @@ class Tier extends RecurlyResource
     * Getter method for the ending_quantity attribute.
     * Ending quantity
     *
-    * @return int
+    * @return ?int
     */
-    public function getEndingQuantity(): int
+    public function getEndingQuantity(): ?int
     {
         return $this->_ending_quantity;
     }

--- a/lib/recurly/resources/transaction.php
+++ b/lib/recurly/resources/transaction.php
@@ -661,9 +661,9 @@ class Transaction extends RecurlyResource
     * Getter method for the refunded attribute.
     * Indicates if part or all of this transaction was refunded.
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getRefunded(): bool
+    public function getRefunded(): ?bool
     {
         return $this->_refunded;
     }
@@ -776,9 +776,9 @@ class Transaction extends RecurlyResource
     * Getter method for the success attribute.
     * Did this transaction complete successfully?
     *
-    * @return bool
+    * @return ?bool
     */
-    public function getSuccess(): bool
+    public function getSuccess(): ?bool
     {
         return $this->_success;
     }

--- a/lib/recurly/resources/transaction.php
+++ b/lib/recurly/resources/transaction.php
@@ -58,9 +58,9 @@ class Transaction extends RecurlyResource
     * Getter method for the account attribute.
     * Account mini details
     *
-    * @return \Recurly\Resources\AccountMini
+    * @return ?\Recurly\Resources\AccountMini
     */
-    public function getAccount(): \Recurly\Resources\AccountMini
+    public function getAccount(): ?\Recurly\Resources\AccountMini
     {
         return $this->_account;
     }
@@ -127,9 +127,9 @@ class Transaction extends RecurlyResource
     * Getter method for the billing_address attribute.
     * 
     *
-    * @return \Recurly\Resources\Address
+    * @return ?\Recurly\Resources\Address
     */
-    public function getBillingAddress(): \Recurly\Resources\Address
+    public function getBillingAddress(): ?\Recurly\Resources\Address
     {
         return $this->_billing_address;
     }
@@ -472,9 +472,9 @@ class Transaction extends RecurlyResource
     * Getter method for the invoice attribute.
     * Invoice mini details
     *
-    * @return \Recurly\Resources\InvoiceMini
+    * @return ?\Recurly\Resources\InvoiceMini
     */
-    public function getInvoice(): \Recurly\Resources\InvoiceMini
+    public function getInvoice(): ?\Recurly\Resources\InvoiceMini
     {
         return $this->_invoice;
     }
@@ -615,9 +615,9 @@ class Transaction extends RecurlyResource
     * Getter method for the payment_gateway attribute.
     * 
     *
-    * @return \Recurly\Resources\TransactionPaymentGateway
+    * @return ?\Recurly\Resources\TransactionPaymentGateway
     */
-    public function getPaymentGateway(): \Recurly\Resources\TransactionPaymentGateway
+    public function getPaymentGateway(): ?\Recurly\Resources\TransactionPaymentGateway
     {
         return $this->_payment_gateway;
     }
@@ -638,9 +638,9 @@ class Transaction extends RecurlyResource
     * Getter method for the payment_method attribute.
     * 
     *
-    * @return \Recurly\Resources\PaymentMethod
+    * @return ?\Recurly\Resources\PaymentMethod
     */
-    public function getPaymentMethod(): \Recurly\Resources\PaymentMethod
+    public function getPaymentMethod(): ?\Recurly\Resources\PaymentMethod
     {
         return $this->_payment_method;
     }
@@ -757,7 +757,7 @@ class Transaction extends RecurlyResource
     */
     public function getSubscriptionIds(): array
     {
-        return $this->_subscription_ids;
+        return $this->_subscription_ids ?? [] ;
     }
 
     /**
@@ -873,9 +873,9 @@ class Transaction extends RecurlyResource
     * Getter method for the voided_by_invoice attribute.
     * Invoice mini details
     *
-    * @return \Recurly\Resources\InvoiceMini
+    * @return ?\Recurly\Resources\InvoiceMini
     */
-    public function getVoidedByInvoice(): \Recurly\Resources\InvoiceMini
+    public function getVoidedByInvoice(): ?\Recurly\Resources\InvoiceMini
     {
         return $this->_voided_by_invoice;
     }

--- a/lib/recurly/resources/transaction.php
+++ b/lib/recurly/resources/transaction.php
@@ -426,9 +426,9 @@ class Transaction extends RecurlyResource
     * Getter method for the gateway_response_values attribute.
     * The values in this field will vary from gateway to gateway.
     *
-    * @return object
+    * @return ?object
     */
-    public function getGatewayResponseValues(): object
+    public function getGatewayResponseValues(): ?object
     {
         return $this->_gateway_response_values;
     }

--- a/lib/recurly/resources/transaction.php
+++ b/lib/recurly/resources/transaction.php
@@ -81,9 +81,9 @@ class Transaction extends RecurlyResource
     * Getter method for the amount attribute.
     * Total transaction amount sent to the payment gateway.
     *
-    * @return float
+    * @return ?float
     */
-    public function getAmount(): float
+    public function getAmount(): ?float
     {
         return $this->_amount;
     }
@@ -104,9 +104,9 @@ class Transaction extends RecurlyResource
     * Getter method for the avs_check attribute.
     * When processed, result from checking the overall AVS on the transaction.
     *
-    * @return string
+    * @return ?string
     */
-    public function getAvsCheck(): string
+    public function getAvsCheck(): ?string
     {
         return $this->_avs_check;
     }
@@ -150,9 +150,9 @@ class Transaction extends RecurlyResource
     * Getter method for the collected_at attribute.
     * Collected at, or if not collected yet, the time the transaction was created.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCollectedAt(): string
+    public function getCollectedAt(): ?string
     {
         return $this->_collected_at;
     }
@@ -173,9 +173,9 @@ class Transaction extends RecurlyResource
     * Getter method for the collection_method attribute.
     * The method by which the payment was collected.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCollectionMethod(): string
+    public function getCollectionMethod(): ?string
     {
         return $this->_collection_method;
     }
@@ -196,9 +196,9 @@ class Transaction extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -219,9 +219,9 @@ class Transaction extends RecurlyResource
     * Getter method for the currency attribute.
     * 3-letter ISO 4217 currency code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->_currency;
     }
@@ -242,9 +242,9 @@ class Transaction extends RecurlyResource
     * Getter method for the customer_message attribute.
     * For declined (`success=false`) transactions, the message displayed to the customer.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCustomerMessage(): string
+    public function getCustomerMessage(): ?string
     {
         return $this->_customer_message;
     }
@@ -265,9 +265,9 @@ class Transaction extends RecurlyResource
     * Getter method for the customer_message_locale attribute.
     * Language code for the message
     *
-    * @return string
+    * @return ?string
     */
-    public function getCustomerMessageLocale(): string
+    public function getCustomerMessageLocale(): ?string
     {
         return $this->_customer_message_locale;
     }
@@ -288,9 +288,9 @@ class Transaction extends RecurlyResource
     * Getter method for the cvv_check attribute.
     * When processed, result from checking the CVV/CVC value on the transaction.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCvvCheck(): string
+    public function getCvvCheck(): ?string
     {
         return $this->_cvv_check;
     }
@@ -311,9 +311,9 @@ class Transaction extends RecurlyResource
     * Getter method for the gateway_approval_code attribute.
     * Transaction approval code from the payment gateway.
     *
-    * @return string
+    * @return ?string
     */
-    public function getGatewayApprovalCode(): string
+    public function getGatewayApprovalCode(): ?string
     {
         return $this->_gateway_approval_code;
     }
@@ -334,9 +334,9 @@ class Transaction extends RecurlyResource
     * Getter method for the gateway_message attribute.
     * Transaction message from the payment gateway.
     *
-    * @return string
+    * @return ?string
     */
-    public function getGatewayMessage(): string
+    public function getGatewayMessage(): ?string
     {
         return $this->_gateway_message;
     }
@@ -357,9 +357,9 @@ class Transaction extends RecurlyResource
     * Getter method for the gateway_reference attribute.
     * Transaction reference number from the payment gateway.
     *
-    * @return string
+    * @return ?string
     */
-    public function getGatewayReference(): string
+    public function getGatewayReference(): ?string
     {
         return $this->_gateway_reference;
     }
@@ -380,9 +380,9 @@ class Transaction extends RecurlyResource
     * Getter method for the gateway_response_code attribute.
     * For declined transactions (`success=false`), this field lists the gateway error code.
     *
-    * @return string
+    * @return ?string
     */
-    public function getGatewayResponseCode(): string
+    public function getGatewayResponseCode(): ?string
     {
         return $this->_gateway_response_code;
     }
@@ -403,9 +403,9 @@ class Transaction extends RecurlyResource
     * Getter method for the gateway_response_time attribute.
     * Time, in seconds, for gateway to process the transaction.
     *
-    * @return float
+    * @return ?float
     */
-    public function getGatewayResponseTime(): float
+    public function getGatewayResponseTime(): ?float
     {
         return $this->_gateway_response_time;
     }
@@ -449,9 +449,9 @@ class Transaction extends RecurlyResource
     * Getter method for the id attribute.
     * Transaction ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -495,9 +495,9 @@ class Transaction extends RecurlyResource
     * Getter method for the ip_address_country attribute.
     * IP address's country
     *
-    * @return string
+    * @return ?string
     */
-    public function getIpAddressCountry(): string
+    public function getIpAddressCountry(): ?string
     {
         return $this->_ip_address_country;
     }
@@ -523,9 +523,9 @@ class Transaction extends RecurlyResource
 - When the merchant enters billing information using the UI, no IP address is recorded.
 
     *
-    * @return string
+    * @return ?string
     */
-    public function getIpAddressV4(): string
+    public function getIpAddressV4(): ?string
     {
         return $this->_ip_address_v4;
     }
@@ -546,9 +546,9 @@ class Transaction extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -569,9 +569,9 @@ class Transaction extends RecurlyResource
     * Getter method for the origin attribute.
     * Describes how the transaction was triggered.
     *
-    * @return string
+    * @return ?string
     */
-    public function getOrigin(): string
+    public function getOrigin(): ?string
     {
         return $this->_origin;
     }
@@ -592,9 +592,9 @@ class Transaction extends RecurlyResource
     * Getter method for the original_transaction_id attribute.
     * If this transaction is a refund (`type=refund`), this will be the ID of the original transaction on the invoice being refunded.
     *
-    * @return string
+    * @return ?string
     */
-    public function getOriginalTransactionId(): string
+    public function getOriginalTransactionId(): ?string
     {
         return $this->_original_transaction_id;
     }
@@ -684,9 +684,9 @@ class Transaction extends RecurlyResource
     * Getter method for the status attribute.
     * The current transaction status. Note that the status may change, e.g. a `pending` transaction may become `declined` or `success` may later become `void`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getStatus(): string
+    public function getStatus(): ?string
     {
         return $this->_status;
     }
@@ -707,9 +707,9 @@ class Transaction extends RecurlyResource
     * Getter method for the status_code attribute.
     * Status code
     *
-    * @return string
+    * @return ?string
     */
-    public function getStatusCode(): string
+    public function getStatusCode(): ?string
     {
         return $this->_status_code;
     }
@@ -730,9 +730,9 @@ class Transaction extends RecurlyResource
     * Getter method for the status_message attribute.
     * For declined (`success=false`) transactions, the message displayed to the merchant.
     *
-    * @return string
+    * @return ?string
     */
-    public function getStatusMessage(): string
+    public function getStatusMessage(): ?string
     {
         return $this->_status_message;
     }
@@ -804,9 +804,9 @@ class Transaction extends RecurlyResource
 - `verify` – a $0 or $1 transaction used to verify billing information which is immediately voided.
 
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }
@@ -827,9 +827,9 @@ class Transaction extends RecurlyResource
     * Getter method for the uuid attribute.
     * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
     *
-    * @return string
+    * @return ?string
     */
-    public function getUuid(): string
+    public function getUuid(): ?string
     {
         return $this->_uuid;
     }
@@ -850,9 +850,9 @@ class Transaction extends RecurlyResource
     * Getter method for the voided_at attribute.
     * Voided at
     *
-    * @return string
+    * @return ?string
     */
-    public function getVoidedAt(): string
+    public function getVoidedAt(): ?string
     {
         return $this->_voided_at;
     }

--- a/lib/recurly/resources/transaction_error.php
+++ b/lib/recurly/resources/transaction_error.php
@@ -28,9 +28,9 @@ class TransactionError extends RecurlyResource
     * Getter method for the category attribute.
     * Category
     *
-    * @return string
+    * @return ?string
     */
-    public function getCategory(): string
+    public function getCategory(): ?string
     {
         return $this->_category;
     }
@@ -51,9 +51,9 @@ class TransactionError extends RecurlyResource
     * Getter method for the code attribute.
     * Code
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -74,9 +74,9 @@ class TransactionError extends RecurlyResource
     * Getter method for the merchant_advice attribute.
     * Merchant message
     *
-    * @return string
+    * @return ?string
     */
-    public function getMerchantAdvice(): string
+    public function getMerchantAdvice(): ?string
     {
         return $this->_merchant_advice;
     }
@@ -97,9 +97,9 @@ class TransactionError extends RecurlyResource
     * Getter method for the message attribute.
     * Customer message
     *
-    * @return string
+    * @return ?string
     */
-    public function getMessage(): string
+    public function getMessage(): ?string
     {
         return $this->_message;
     }
@@ -120,9 +120,9 @@ class TransactionError extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -143,9 +143,9 @@ class TransactionError extends RecurlyResource
     * Getter method for the three_d_secure_action_token_id attribute.
     * Returned when 3-D Secure authentication is required for a transaction. Pass this value to Recurly.js so it can continue the challenge flow.
     *
-    * @return string
+    * @return ?string
     */
-    public function getThreeDSecureActionTokenId(): string
+    public function getThreeDSecureActionTokenId(): ?string
     {
         return $this->_three_d_secure_action_token_id;
     }
@@ -166,9 +166,9 @@ class TransactionError extends RecurlyResource
     * Getter method for the transaction_id attribute.
     * Transaction ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getTransactionId(): string
+    public function getTransactionId(): ?string
     {
         return $this->_transaction_id;
     }

--- a/lib/recurly/resources/transaction_payment_gateway.php
+++ b/lib/recurly/resources/transaction_payment_gateway.php
@@ -25,9 +25,9 @@ class TransactionPaymentGateway extends RecurlyResource
     * Getter method for the id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -48,9 +48,9 @@ class TransactionPaymentGateway extends RecurlyResource
     * Getter method for the name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->_name;
     }
@@ -71,9 +71,9 @@ class TransactionPaymentGateway extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -94,9 +94,9 @@ class TransactionPaymentGateway extends RecurlyResource
     * Getter method for the type attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->_type;
     }

--- a/lib/recurly/resources/unique_coupon_code.php
+++ b/lib/recurly/resources/unique_coupon_code.php
@@ -29,9 +29,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the code attribute.
     * The code the customer enters to redeem the coupon.
     *
-    * @return string
+    * @return ?string
     */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->_code;
     }
@@ -52,9 +52,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the created_at attribute.
     * Created at
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -75,9 +75,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the expired_at attribute.
     * The date and time the coupon was expired early or reached its `max_redemptions`.
     *
-    * @return string
+    * @return ?string
     */
-    public function getExpiredAt(): string
+    public function getExpiredAt(): ?string
     {
         return $this->_expired_at;
     }
@@ -98,9 +98,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the id attribute.
     * Unique Coupon Code ID
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -121,9 +121,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -144,9 +144,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the redeemed_at attribute.
     * The date and time the unique coupon code was redeemed.
     *
-    * @return string
+    * @return ?string
     */
-    public function getRedeemedAt(): string
+    public function getRedeemedAt(): ?string
     {
         return $this->_redeemed_at;
     }
@@ -167,9 +167,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the state attribute.
     * Indicates if the unique coupon code is redeemable or why not.
     *
-    * @return string
+    * @return ?string
     */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->_state;
     }
@@ -190,9 +190,9 @@ class UniqueCouponCode extends RecurlyResource
     * Getter method for the updated_at attribute.
     * Updated at
     *
-    * @return string
+    * @return ?string
     */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->_updated_at;
     }

--- a/lib/recurly/resources/user.php
+++ b/lib/recurly/resources/user.php
@@ -29,9 +29,9 @@ class User extends RecurlyResource
     * Getter method for the created_at attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->_created_at;
     }
@@ -52,9 +52,9 @@ class User extends RecurlyResource
     * Getter method for the deleted_at attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getDeletedAt(): string
+    public function getDeletedAt(): ?string
     {
         return $this->_deleted_at;
     }
@@ -75,9 +75,9 @@ class User extends RecurlyResource
     * Getter method for the email attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->_email;
     }
@@ -98,9 +98,9 @@ class User extends RecurlyResource
     * Getter method for the first_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->_first_name;
     }
@@ -121,9 +121,9 @@ class User extends RecurlyResource
     * Getter method for the id attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->_id;
     }
@@ -144,9 +144,9 @@ class User extends RecurlyResource
     * Getter method for the last_name attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->_last_name;
     }
@@ -167,9 +167,9 @@ class User extends RecurlyResource
     * Getter method for the object attribute.
     * Object type
     *
-    * @return string
+    * @return ?string
     */
-    public function getObject(): string
+    public function getObject(): ?string
     {
         return $this->_object;
     }
@@ -190,9 +190,9 @@ class User extends RecurlyResource
     * Getter method for the time_zone attribute.
     * 
     *
-    * @return string
+    * @return ?string
     */
-    public function getTimeZone(): string
+    public function getTimeZone(): ?string
     {
         return $this->_time_zone;
     }


### PR DESCRIPTION
Resolves #495 

Type hinting on getter methods has been updated to allow for [nullable types](https://www.php.net/manual/en/migration71.new-features.php). Getter methods that are type hinted to return array types will default to an empty array instead of being nullable.