### PR TITLE
Release 3.1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "recurly/recurly-client",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "type": "library",
     "description": "The PHP client library for the Recurly API",
     "keywords": ["recurly", "payments", "pay"],

--- a/lib/recurly/version.php
+++ b/lib/recurly/version.php
@@ -4,5 +4,5 @@ namespace Recurly;
 
 class Version
 {
-    public const CURRENT = '3.1.0';
+    public const CURRENT = '3.1.1';
 }


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-php/compare/3.1.0...HEAD)

**Fixed bugs:**

- Parsing 'false' as null inside the v3 API [\#495](https://github.com/recurly/recurly-client-php/issues/495)

**Merged pull requests:**

- Make returns nullable [\#496](https://github.com/recurly/recurly-client-php/pull/496) ([bhelx](https://github.com/bhelx))
- Ensure that path parameters are not empty strings [\#494](https://github.com/recurly/recurly-client-php/pull/494) ([douglasmiller](https://github.com/douglasmiller))