### PR TITLE
Use helper method to safeguard against empty path parameters

### DIFF
--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -65,14 +65,12 @@ class Recurly_BaseTest extends Recurly_TestCase {
   }
 
   public function testPassingEmptyResourceCode() {
-    {
-      $this->expectException(Recurly_Error::class);
-      $uri = Recurly_Base::_safeUri(
-        Recurly_Client::PATH_SUBSCRIPTIONS, "", 
-        Recurly_Client::PATH_ADDONS, "marketing_emails",
-        Recurly_Client::PATH_USAGE, 123456
-      );    
-    }
+    $this->expectException(Recurly_Error::class);
+    $uri = Recurly_Base::_safeUri(
+      Recurly_Client::PATH_SUBSCRIPTIONS, "", 
+      Recurly_Client::PATH_ADDONS, "marketing_emails",
+      Recurly_Client::PATH_USAGE, 123456
+    );    
   }
 
   public function testUrlEncodingReplacement() {

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -67,7 +67,7 @@ class Recurly_BaseTest extends Recurly_TestCase {
   public function testPassingEmptyResourceCode() {
     $this->client->addResponse('GET', '/accounts/abcdef1234567890', 'accounts/show-200.xml');
     try {
-      $uri = Recurly_Base::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode(""));
+      $uri = Recurly_Base::_safeUri(Recurly_Client::PATH_ACCOUNTS, "");
       Recurly_Base::_get($uri, $this->client);
       $this->fail("Expected Recurly_Error");  
     } catch (Recurly_Error $e) {
@@ -76,9 +76,11 @@ class Recurly_BaseTest extends Recurly_TestCase {
 
     $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab/add_ons/marketing_emails/usage/123456', 'usage/show-200.xml');
     try {
-      $uri = Recurly_Base::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode("")) . 
-        Recurly_Base::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode("marketing_emails")) . 
-        Recurly_Base::_uriForResource(Recurly_Client::PATH_USAGE, rawurlencode(123456));
+      $uri = Recurly_Base::_safeUri(
+        Recurly_Client::PATH_SUBSCRIPTIONS, "", 
+        Recurly_Client::PATH_ADDONS, "marketing_emails",
+        Recurly_Client::PATH_USAGE, 123456
+      );
         $this->fail("Expected Recurly_Error");  
     } catch (Recurly_Error $e) {
       $this->assertEquals('Resource code cannot be an empty value', $e->getMessage());

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -65,25 +65,22 @@ class Recurly_BaseTest extends Recurly_TestCase {
   }
 
   public function testPassingEmptyResourceCode() {
-    $this->client->addResponse('GET', '/accounts/abcdef1234567890', 'accounts/show-200.xml');
-    try {
-      $uri = Recurly_Base::_safeUri(Recurly_Client::PATH_ACCOUNTS, "");
-      Recurly_Base::_get($uri, $this->client);
-      $this->fail("Expected Recurly_Error");  
-    } catch (Recurly_Error $e) {
-      $this->assertEquals('Resource code cannot be an empty value', $e->getMessage());
-    }
-
-    $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab/add_ons/marketing_emails/usage/123456', 'usage/show-200.xml');
-    try {
+    {
+      $this->expectException(Recurly_Error::class);
       $uri = Recurly_Base::_safeUri(
         Recurly_Client::PATH_SUBSCRIPTIONS, "", 
         Recurly_Client::PATH_ADDONS, "marketing_emails",
         Recurly_Client::PATH_USAGE, 123456
-      );
-        $this->fail("Expected Recurly_Error");  
+      );    
+    }
+  }
+
+  public function testUrlEncodingReplacement() {
+    try {
+      $uri = Recurly_Base::_safeUri(Recurly_Client::PATH_ACCOUNTS, "/abcdef1234567890");
+      $this->assertEquals("/accounts/abcdef1234567890", $uri);
     } catch (Recurly_Error $e) {
-      $this->assertEquals('Resource code cannot be an empty value', $e->getMessage());
+      $this->assertEquals('Encoded strings were not replaced', $e->getMessage());
     }
   }
 }

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -74,11 +74,7 @@ class Recurly_BaseTest extends Recurly_TestCase {
   }
 
   public function testUrlEncodingReplacement() {
-    try {
-      $uri = Recurly_Base::_safeUri(Recurly_Client::PATH_ACCOUNTS, "/abcdef1234567890");
-      $this->assertEquals("/accounts/abcdef1234567890", $uri);
-    } catch (Recurly_Error $e) {
-      $this->assertEquals('Encoded strings were not replaced', $e->getMessage());
-    }
+    $uri = Recurly_Base::_safeUri(Recurly_Client::PATH_ACCOUNTS, "/abcdef1234567890");
+    $this->assertEquals("/accounts/%2Fabcdef1234567890", $uri);
   }
 }

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -63,4 +63,25 @@ class Recurly_BaseTest extends Recurly_TestCase {
     $this->assertTrue(method_exists($adjustment, 'getHeaders'),'Adjustments Class does not have method getHeaders');
     $this->assertInternalType('array', $adjustment->getHeaders());
   }
+
+  public function testPassingEmptyResourceCode() {
+    $this->client->addResponse('GET', '/accounts/abcdef1234567890', 'accounts/show-200.xml');
+    try {
+      $uri = Recurly_Base::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode(""));
+      Recurly_Base::_get($uri, $this->client);
+      $this->fail("Expected Recurly_Error");  
+    } catch (Recurly_Error $e) {
+      $this->assertEquals('Resource code cannot be an empty value', $e->getMessage());
+    }
+
+    $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab/add_ons/marketing_emails/usage/123456', 'usage/show-200.xml');
+    try {
+      $uri = Recurly_Base::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode("")) . 
+        Recurly_Base::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode("marketing_emails")) . 
+        Recurly_Base::_uriForResource(Recurly_Client::PATH_USAGE, rawurlencode(123456));
+        $this->fail("Expected Recurly_Error");  
+    } catch (Recurly_Error $e) {
+      $this->assertEquals('Resource code cannot be an empty value', $e->getMessage());
+    }
+  }
 }

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -99,7 +99,7 @@ class Recurly_Account extends Recurly_Resource
       return Recurly_Account::uriForAccount($this->account_code);
   }
   protected static function uriForAccount($accountCode) {
-    return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode);
+    return self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -99,7 +99,7 @@ class Recurly_Account extends Recurly_Resource
       return Recurly_Account::uriForAccount($this->account_code);
   }
   protected static function uriForAccount($accountCode) {
-    return self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    return self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/account_acquisition.php
+++ b/lib/recurly/account_acquisition.php
@@ -22,7 +22,8 @@ class Recurly_AccountAcquisition extends Recurly_Resource
   }
 
   protected static function uriForAccountAcquisition($accountCode) {
-    return '/accounts/' . rawurlencode($accountCode) . '/acquisition';
+    $path =  self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    return $path . '/acquisition';
   }
 
   public function create() {

--- a/lib/recurly/account_acquisition.php
+++ b/lib/recurly/account_acquisition.php
@@ -22,7 +22,7 @@ class Recurly_AccountAcquisition extends Recurly_Resource
   }
 
   protected static function uriForAccountAcquisition($accountCode) {
-    return self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, '/acquisition');
+    return self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, 'acquisition');
   }
 
   public function create() {

--- a/lib/recurly/account_acquisition.php
+++ b/lib/recurly/account_acquisition.php
@@ -22,8 +22,7 @@ class Recurly_AccountAcquisition extends Recurly_Resource
   }
 
   protected static function uriForAccountAcquisition($accountCode) {
-    $path =  self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    return $path . '/acquisition';
+    return self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, '/acquisition');
   }
 
   public function create() {

--- a/lib/recurly/account_balance.php
+++ b/lib/recurly/account_balance.php
@@ -9,7 +9,7 @@
 class Recurly_AccountBalance extends Recurly_Resource
 {
   public static function get($accountCode, $client = null) {
-    return Recurly_Base::_get(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_BALANCE, $client);
+    return Recurly_Base::_get(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_BALANCE), $client);
   }
 
   function __construct($href = null, $client = null) {

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -37,7 +37,7 @@ class Recurly_Addon extends Recurly_Resource
   }
 
   public function create() {
-    $this->_save(Recurly_Client::POST, Recurly_Client::PATH_PLANS . '/' . rawurlencode($this->plan_code) . Recurly_Client::PATH_ADDONS);
+    $this->_save(Recurly_Client::POST, self::_safeUri(Recurly_Client::PATH_PLANS, $this->plan_code, Recurly_Client::PATH_ADDONS));
   }
 
   public function update() {
@@ -54,9 +54,9 @@ class Recurly_Addon extends Recurly_Resource
     else
       return Recurly_Addon::uriForAddOn($this->plan_code, $this->add_on_code);
   }
+  
   protected static function uriForAddOn($planCode, $addonCode) {
-    $path = self::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode($addonCode));
-    return (Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) .$path);
+    return self::_safeUri(Recurly_Client::PATH_PLANS, $planCode, Recurly_Client::PATH_ADDONS, $addonCode);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/addon.php
+++ b/lib/recurly/addon.php
@@ -55,8 +55,8 @@ class Recurly_Addon extends Recurly_Resource
       return Recurly_Addon::uriForAddOn($this->plan_code, $this->add_on_code);
   }
   protected static function uriForAddOn($planCode, $addonCode) {
-    return (Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) .
-            Recurly_Client::PATH_ADDONS . '/' . rawurlencode($addonCode));
+    $path = self::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode($addonCode));
+    return (Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) .$path);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/addon_list.php
+++ b/lib/recurly/addon_list.php
@@ -4,7 +4,8 @@ class Recurly_AddonList extends Recurly_Pager
 {
   public static function get($planCode, $params = null, $client = null)
   {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode) . Recurly_Client::PATH_ADDONS, $params);
+    $planPath = self::_uriForResource(Recurly_Client::PATH_PLANS, rawurlencode($planCode));
+    $uri = self::_uriWithParams($planPath . Recurly_Client::PATH_ADDONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/addon_list.php
+++ b/lib/recurly/addon_list.php
@@ -4,8 +4,7 @@ class Recurly_AddonList extends Recurly_Pager
 {
   public static function get($planCode, $params = null, $client = null)
   {
-    $planPath = self::_uriForResource(Recurly_Client::PATH_PLANS, rawurlencode($planCode));
-    $uri = self::_uriWithParams($planPath . Recurly_Client::PATH_ADDONS, $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_PLANS, $planCode, Recurly_Client::PATH_ADDONS), $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -38,8 +38,7 @@
 class Recurly_Adjustment extends Recurly_Resource
 {
   public static function get($adjustment_uuid, $client = null) {
-    $path = self::_uriForResource(Recurly_Client::PATH_ADJUSTMENTS, rawurlencode($adjustment_uuid));
-    return Recurly_Base::_get($path, $client);
+    return Recurly_Base::_get(self::_safeUri(Recurly_Client::PATH_ADJUSTMENTS, $adjustment_uuid), $client);
   }
 
   public function create() {
@@ -83,11 +82,7 @@ class Recurly_Adjustment extends Recurly_Resource
   }
 
   protected function createUriForAccount() {
-    if (empty($this->account_code))
-      throw new Recurly_Error("'account_code' is not specified");
-
-    return (Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($this->account_code) .
-        Recurly_Client::PATH_ADJUSTMENTS);
+    return self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $this->account_code, Recurly_Client::PATH_ADJUSTMENTS);
   }
 
   protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -38,7 +38,8 @@
 class Recurly_Adjustment extends Recurly_Resource
 {
   public static function get($adjustment_uuid, $client = null) {
-    return Recurly_Base::_get(Recurly_Client::PATH_ADJUSTMENTS . '/' . rawurlencode($adjustment_uuid), $client);
+    $path = self::_uriForResource(Recurly_Client::PATH_ADJUSTMENTS, rawurlencode($adjustment_uuid));
+    return Recurly_Base::_get($path, $client);
   }
 
   public function create() {

--- a/lib/recurly/adjustment_list.php
+++ b/lib/recurly/adjustment_list.php
@@ -3,7 +3,8 @@
 class Recurly_AdjustmentList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_ADJUSTMENTS, $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_ADJUSTMENTS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/adjustment_list.php
+++ b/lib/recurly/adjustment_list.php
@@ -3,8 +3,10 @@
 class Recurly_AdjustmentList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_ADJUSTMENTS, $params);
+    $uri = self::_uriWithParams(
+      self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_ADJUSTMENTS), 
+      $params
+    );
     return new self($uri, $client);
   }
 

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -114,26 +114,37 @@ abstract class Recurly_Base
 
   /**
    * Returns URI for resource, throwing error if resource code is an empty string
-   * @param string First Recurly Client path
    * @param string Resource codes and paths
    * @return string URI
    * @throws Recurly_Error
    */
   public static function _safeUri(...$params) {
-    $path = "";
-    foreach($params as $string) {
-      if (empty(trim($string))) {
+    $uri = '';
+    // throws error if param is an empty string
+    foreach($params as $param) {
+      if (empty(trim($param))) {
         throw new Recurly_Error("Resource code cannot be an empty value");
       }
-      // removes extra forward slash that is encoded when a second path constant is passed
-      // example: const PATH_ACCOUNTS = '/accounts';
-      $path .= '/' . preg_replace("(%2F)", "", rawurlencode($string));
     }
-    return $path;
+    // first and every other following param is a resource index PATH, e.g. 'accounts' 
+    for ($i = 0; $i <= count($params); $i+=2) {  
+      if (isset($params[$i])){
+        $path = '/' . $params[$i];
+        $uri .= $path;
+      }
+      // resource code follows resource index, e.g. 'accounts/account_code'
+      if (isset($params[$i+1])){
+        $code = '/' . rawurlencode($params[$i+1]);
+        $uri .= $code;
+      }
+    }
+    return $uri;
   }
 
-  // URI for page resource index
   protected static function _uriWithParams($uri, $params = null) {
+    if ($uri[0] !== '/' && strpos($uri, "https") === false){
+      $uri = '/' . $uri;
+    }
     if (is_null($params) || !is_array($params)) {
       return $uri;
     }
@@ -142,7 +153,6 @@ abstract class Recurly_Base
     foreach ($params as $k => $v) {
       $vals[] = $k . '=' . urlencode($v);
     }
-
     return $uri . '?' . implode('&', $vals);
   }
 

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -114,16 +114,22 @@ abstract class Recurly_Base
 
   /**
    * Returns URI for resource, throwing error if resource code is an empty string
-   * @param string Recurly Client path
-   * @param string Resource code
+   * @param string First Recurly Client path
+   * @param string Resource codes and paths
    * @return string URI
    * @throws Recurly_Error
    */
-  public static function _uriForResource($path, $resource_code) {
-    if (empty(trim($resource_code))) {
-      throw new Recurly_Error("Resource code cannot be an empty value");
+  public static function _safeUri($req, ...$params) {
+    $path = "";
+    foreach($params as $string) {
+      if (empty(trim($string))) {
+        throw new Recurly_Error("Resource code cannot be an empty value");
+      }
+      // removes extra forward slash that is encoded when a second path constant is passed
+      // example: const PATH_ACCOUNTS = '/accounts';
+      $path .= '/' . preg_replace("(%2F)", "", rawurlencode($string));
     }
-    return $path . '/' . $resource_code;
+    return $req . $path;
   }
 
   // URI for page resource index

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -112,6 +112,21 @@ abstract class Recurly_Base
     return null;
   }
 
+  /**
+   * Returns URI for resource, throwing error if resource code is an empty string
+   * @param string Recurly Client path
+   * @param string Resource code
+   * @return string URI
+   * @throws Recurly_Error
+   */
+  public static function _uriForResource($path, $resource_code) {
+    if (empty(trim($resource_code))) {
+      throw new Recurly_Error("Resource code cannot be an empty value");
+    }
+    return $path . '/' . $resource_code;
+  }
+
+  // URI for page resource index
   protected static function _uriWithParams($uri, $params = null) {
     if (is_null($params) || !is_array($params)) {
       return $uri;

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -120,23 +120,13 @@ abstract class Recurly_Base
    */
   public static function _safeUri(...$params) {
     $uri = '';
-    // throws error if param is an empty string
     foreach($params as $param) {
+      // throws error if param is an empty string
       if (empty(trim($param))) {
         throw new Recurly_Error("Resource code cannot be an empty value");
       }
-    }
-    // first and every other following param is a resource index PATH, e.g. 'accounts' 
-    for ($i = 0; $i <= count($params); $i+=2) {  
-      if (isset($params[$i])){
-        $path = '/' . $params[$i];
-        $uri .= $path;
-      }
-      // resource code follows resource index, e.g. 'accounts/account_code'
-      if (isset($params[$i+1])){
-        $code = '/' . rawurlencode($params[$i+1]);
-        $uri .= $code;
-      }
+      $path = '/' . rawurlencode($param);
+      $uri .= $path;
     }
     return $uri;
   }

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -119,7 +119,7 @@ abstract class Recurly_Base
    * @return string URI
    * @throws Recurly_Error
    */
-  public static function _safeUri($req, ...$params) {
+  public static function _safeUri(...$params) {
     $path = "";
     foreach($params as $string) {
       if (empty(trim($string))) {
@@ -129,7 +129,7 @@ abstract class Recurly_Base
       // example: const PATH_ACCOUNTS = '/accounts';
       $path .= '/' . preg_replace("(%2F)", "", rawurlencode($string));
     }
-    return $req . $path;
+    return $path;
   }
 
   // URI for page resource index

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -92,7 +92,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       throw new Recurly_Error("'account_code' not specified.");
   }
   protected static function uriForBillingInfo($accountCode) {
-    $path = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $path = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode);
     return $path . Recurly_Client::PATH_BILLING_INFO;
   }
 

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -92,8 +92,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       throw new Recurly_Error("'account_code' not specified.");
   }
   protected static function uriForBillingInfo($accountCode) {
-    $path = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode);
-    return $path . Recurly_Client::PATH_BILLING_INFO;
+    return self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_BILLING_INFO);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -92,7 +92,8 @@ class Recurly_BillingInfo extends Recurly_Resource
       throw new Recurly_Error("'account_code' not specified.");
   }
   protected static function uriForBillingInfo($accountCode) {
-    return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_BILLING_INFO;
+    $path = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    return $path . Recurly_Client::PATH_BILLING_INFO;
   }
 
   protected function getNodeName() {

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -61,27 +61,27 @@ class Recurly_Client
   const DELETE = 'DELETE';
   const HEAD = 'HEAD';
 
-  const PATH_ACCOUNTS = '/accounts';
-  const PATH_ADDONS = '/add_ons';
-  const PATH_ADJUSTMENTS = '/adjustments';
-  const PATH_BALANCE = '/balance';
-  const PATH_BILLING_INFO = '/billing_info';
-  const PATH_COUPON = '/coupon';
-  const PATH_COUPON_REDEMPTION = '/redemption';
-  const PATH_COUPON_REDEMPTIONS = '/redemptions';
-  const PATH_COUPONS = '/coupons';
-  const PATH_CREDIT_PAYMENTS = '/credit_payments';
-  const PATH_GIFT_CARDS = '/gift_cards';
-  const PATH_UNIQUE_COUPONS = '/unique_coupon_codes';
-  const PATH_INVOICES = '/invoices';
-  const PATH_ITEMS = '/items';
-  const PATH_NOTES = '/notes';
-  const PATH_PLANS = '/plans';
-  const PATH_SHIPPING_METHOD = '/shipping_methods';
-  const PATH_SUBSCRIPTIONS = '/subscriptions';
-  const PATH_TRANSACTIONS = '/transactions';
-  const PATH_MEASURED_UNITS = '/measured_units';
-  const PATH_USAGE = '/usage';
+  const PATH_ACCOUNTS = 'accounts';
+  const PATH_ADDONS = 'add_ons';
+  const PATH_ADJUSTMENTS = 'adjustments';
+  const PATH_BALANCE = 'balance';
+  const PATH_BILLING_INFO = 'billing_info';
+  const PATH_COUPON = 'coupon';
+  const PATH_COUPON_REDEMPTION = 'redemption';
+  const PATH_COUPON_REDEMPTIONS = 'redemptions';
+  const PATH_COUPONS = 'coupons';
+  const PATH_CREDIT_PAYMENTS = 'credit_payments';
+  const PATH_GIFT_CARDS = 'gift_cards';
+  const PATH_UNIQUE_COUPONS = 'unique_coupon_codes';
+  const PATH_INVOICES = 'invoices';
+  const PATH_ITEMS = 'items';
+  const PATH_NOTES = 'notes';
+  const PATH_PLANS = 'plans';
+  const PATH_SHIPPING_METHOD = 'shipping_methods';
+  const PATH_SUBSCRIPTIONS = 'subscriptions';
+  const PATH_TRANSACTIONS = 'transactions';
+  const PATH_MEASURED_UNITS = 'measured_units';
+  const PATH_USAGE = 'usage';
 
   /**
    * Create a new Recurly Client

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -156,7 +156,7 @@ class Recurly_Coupon extends Recurly_Resource
       return Recurly_Coupon::uriForCoupon($this->coupon_code);
   }
   protected static function uriForCoupon($couponCode) {
-    return Recurly_Client::PATH_COUPONS . '/' . rawurlencode($couponCode);
+    return self::_uriForResource(Recurly_Client::PATH_COUPONS, rawurlencode($couponCode));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -156,7 +156,7 @@ class Recurly_Coupon extends Recurly_Resource
       return Recurly_Coupon::uriForCoupon($this->coupon_code);
   }
   protected static function uriForCoupon($couponCode) {
-    return self::_uriForResource(Recurly_Client::PATH_COUPONS, rawurlencode($couponCode));
+    return self::_safeUri(Recurly_Client::PATH_COUPONS, $couponCode);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/credit_payment_list.php
+++ b/lib/recurly/credit_payment_list.php
@@ -8,7 +8,8 @@ class Recurly_CreditPaymentList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_CREDIT_PAYMENTS, $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_CREDIT_PAYMENTS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/credit_payment_list.php
+++ b/lib/recurly/credit_payment_list.php
@@ -8,8 +8,10 @@ class Recurly_CreditPaymentList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_CREDIT_PAYMENTS, $params);
+    $uri = self::_uriWithParams(
+      self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_CREDIT_PAYMENTS), 
+      $params
+    );
     return new self($uri, $client);
   }
 

--- a/lib/recurly/export_file.php
+++ b/lib/recurly/export_file.php
@@ -14,7 +14,7 @@ class Recurly_ExportFile extends Recurly_Resource
    * @throws Recurly_Error
    */
   public static function get($date, $name, $client = null) {
-    return self::_get('/export_dates/' . rawurlencode($date) . '/export_files/' . rawurlencode($name), $client);
+    return self::_get(self::_safeUri("/export_dates", $date, "/export_files", $name), $client);
   }
 
   public function getDownloadUrl() {

--- a/lib/recurly/export_file.php
+++ b/lib/recurly/export_file.php
@@ -14,7 +14,7 @@ class Recurly_ExportFile extends Recurly_Resource
    * @throws Recurly_Error
    */
   public static function get($date, $name, $client = null) {
-    return self::_get(self::_safeUri("/export_dates", $date, "/export_files", $name), $client);
+    return self::_get(self::_safeUri("export_dates", $date, "export_files", $name), $client);
   }
 
   public function getDownloadUrl() {

--- a/lib/recurly/export_file_list.php
+++ b/lib/recurly/export_file_list.php
@@ -11,7 +11,8 @@ class Recurly_ExportFileList extends Recurly_Pager
    * @return Recurly_ExportFileList
    */
   public static function get($date, $params = null, $client = null) {
-    return new self(self::_uriWithParams('/export_dates/' . rawurlencode($date) . '/export_files', $params), $client);
+    $datePath = self::_uriForResource('/export_dates', rawurlencode($date));
+    return new self(self::_uriWithParams($datePath . '/export_files', $params), $client);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/export_file_list.php
+++ b/lib/recurly/export_file_list.php
@@ -12,7 +12,7 @@ class Recurly_ExportFileList extends Recurly_Pager
    */
   public static function get($date, $params = null, $client = null) {
     return new self(self::_uriWithParams(
-      self::_safeUri('/export_dates', $date, '/export_files'), $params
+      self::_safeUri('export_dates', $date, 'export_files'), $params
     ), $client);
   }
 

--- a/lib/recurly/export_file_list.php
+++ b/lib/recurly/export_file_list.php
@@ -11,8 +11,9 @@ class Recurly_ExportFileList extends Recurly_Pager
    * @return Recurly_ExportFileList
    */
   public static function get($date, $params = null, $client = null) {
-    $datePath = self::_uriForResource('/export_dates', rawurlencode($date));
-    return new self(self::_uriWithParams($datePath . '/export_files', $params), $client);
+    return new self(self::_uriWithParams(
+      self::_safeUri('/export_dates', $date, '/export_files'), $params
+    ), $client);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/gift_card.php
+++ b/lib/recurly/gift_card.php
@@ -72,7 +72,7 @@ class Recurly_GiftCard extends Recurly_Resource
   }
 
   protected static function uriForGiftCard($giftCardIdentifier) {
-    return self::_uriForResource(Recurly_Client::PATH_GIFT_CARDS, rawurlencode(($giftCardIdentifier)));
+    return self::_safeUri(Recurly_Client::PATH_GIFT_CARDS, $giftCardIdentifier);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/gift_card.php
+++ b/lib/recurly/gift_card.php
@@ -72,7 +72,7 @@ class Recurly_GiftCard extends Recurly_Resource
   }
 
   protected static function uriForGiftCard($giftCardIdentifier) {
-    return Recurly_Client::PATH_GIFT_CARDS. '/' . rawurlencode($giftCardIdentifier);
+    return self::_uriForResource(Recurly_Client::PATH_GIFT_CARDS, rawurlencode(($giftCardIdentifier)));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -111,7 +111,7 @@ class Recurly_Invoice extends Recurly_Resource
    * @throws Recurly_Error
    */
   public static function previewPendingCharges($accountCode, $attributes = array(), $client = null) {
-    $uri = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_INVOICES, '/preview');
+    $uri = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_INVOICES, 'preview');
     $invoice = new self();
     return Recurly_InvoiceCollection::_post($uri, $invoice->setValues($attributes)->xml(), $client);
   }

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -254,6 +254,6 @@ class Recurly_Invoice extends Recurly_Resource
       throw new Recurly_Error("Invoice number not specified");
   }
   protected static function uriForInvoice($invoiceNumber) {
-    return Recurly_Client::PATH_INVOICES . '/' . rawurlencode($invoiceNumber);
+    return self::_uriForResource(Recurly_Client::PATH_INVOICES, rawurlencode($invoiceNumber));
   }
 }

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -97,7 +97,7 @@ class Recurly_Invoice extends Recurly_Resource
    * @throws Recurly_Error
    */
   public static function invoicePendingCharges($accountCode, $attributes = array(), $client = null) {
-    $uri = Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_INVOICES;
+    $uri = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_INVOICES);
     $invoice = new self();
     return Recurly_InvoiceCollection::_post($uri, $invoice->setValues($attributes)->xml(), $client);
   }
@@ -111,7 +111,7 @@ class Recurly_Invoice extends Recurly_Resource
    * @throws Recurly_Error
    */
   public static function previewPendingCharges($accountCode, $attributes = array(), $client = null) {
-    $uri = Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_INVOICES . '/preview';
+    $uri = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_INVOICES, '/preview');
     $invoice = new self();
     return Recurly_InvoiceCollection::_post($uri, $invoice->setValues($attributes)->xml(), $client);
   }
@@ -254,6 +254,6 @@ class Recurly_Invoice extends Recurly_Resource
       throw new Recurly_Error("Invoice number not specified");
   }
   protected static function uriForInvoice($invoiceNumber) {
-    return self::_uriForResource(Recurly_Client::PATH_INVOICES, rawurlencode($invoiceNumber));
+    return self::_safeUri(Recurly_Client::PATH_INVOICES, $invoiceNumber);
   }
 }

--- a/lib/recurly/invoice_list.php
+++ b/lib/recurly/invoice_list.php
@@ -24,8 +24,7 @@ class Recurly_InvoiceList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_INVOICES, $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_INVOICES), $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/invoice_list.php
+++ b/lib/recurly/invoice_list.php
@@ -24,7 +24,8 @@ class Recurly_InvoiceList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_INVOICES, $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_INVOICES, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/item.php
+++ b/lib/recurly/item.php
@@ -61,7 +61,7 @@ class Recurly_Item extends Recurly_Resource
   }
 
   protected static function uriForItem($itemCode) {
-    return Recurly_Client::PATH_ITEMS . '/' . rawurlencode($itemCode);
+    return self::_uriForResource(Recurly_Client::PATH_ITEMS, rawurlencode($itemCode));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/item.php
+++ b/lib/recurly/item.php
@@ -61,7 +61,7 @@ class Recurly_Item extends Recurly_Resource
   }
 
   protected static function uriForItem($itemCode) {
-    return self::_uriForResource(Recurly_Client::PATH_ITEMS, rawurlencode($itemCode));
+    return self::_safeUri(Recurly_Client::PATH_ITEMS, $itemCode);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/measured_unit.php
+++ b/lib/recurly/measured_unit.php
@@ -30,7 +30,7 @@ class Recurly_MeasuredUnit extends Recurly_Resource
       return Recurly_MeasuredUnit::uriForMeasuredUnit($this->id);
   }
   protected static function uriForMeasuredUnit($id) {
-    return self::_uriForResource(Recurly_Client::PATH_MEASURED_UNITS, rawurlencode($id));
+    return self::_safeUri(Recurly_Client::PATH_MEASURED_UNITS, $id);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/measured_unit.php
+++ b/lib/recurly/measured_unit.php
@@ -30,7 +30,7 @@ class Recurly_MeasuredUnit extends Recurly_Resource
       return Recurly_MeasuredUnit::uriForMeasuredUnit($this->id);
   }
   protected static function uriForMeasuredUnit($id) {
-    return Recurly_Client::PATH_MEASURED_UNITS . '/' . rawurlencode($id);
+    return self::_uriForResource(Recurly_Client::PATH_MEASURED_UNITS, rawurlencode($id));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/note_list.php
+++ b/lib/recurly/note_list.php
@@ -3,7 +3,7 @@
 class Recurly_NoteList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $accountPath = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode);
     $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_NOTES, $params);
     return new self($uri, $client);
   }

--- a/lib/recurly/note_list.php
+++ b/lib/recurly/note_list.php
@@ -3,8 +3,7 @@
 class Recurly_NoteList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $accountPath = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode);
-    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_NOTES, $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_NOTES), $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/note_list.php
+++ b/lib/recurly/note_list.php
@@ -3,7 +3,8 @@
 class Recurly_NoteList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_NOTES, $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_NOTES, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -83,7 +83,7 @@ class Recurly_Plan extends Recurly_Resource
       return Recurly_Plan::uriForPlan($this->plan_code);
   }
   protected static function uriForPlan($planCode) {
-    return Recurly_Client::PATH_PLANS . '/' . rawurlencode($planCode);
+    return self::_uriForResource(Recurly_Client::PATH_PLANS, rawurlencode($planCode));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -83,7 +83,7 @@ class Recurly_Plan extends Recurly_Resource
       return Recurly_Plan::uriForPlan($this->plan_code);
   }
   protected static function uriForPlan($planCode) {
-    return self::_uriForResource(Recurly_Client::PATH_PLANS, rawurlencode($planCode));
+    return self::_safeUri(Recurly_Client::PATH_PLANS, $planCode);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -49,7 +49,8 @@ class Recurly_CouponRedemption extends Recurly_Resource
   }
 
   protected static function uriForAccount($accountCode) {
-    return Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_COUPON_REDEMPTION;
+    $path = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    return $path . Recurly_Client::PATH_COUPON_REDEMPTION;
   }
 
   protected function getNodeName() {

--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -49,8 +49,7 @@ class Recurly_CouponRedemption extends Recurly_Resource
   }
 
   protected static function uriForAccount($accountCode) {
-    $path = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode);
-    return $path . Recurly_Client::PATH_COUPON_REDEMPTION;
+    return self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_COUPON_REDEMPTION);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/redemption.php
+++ b/lib/recurly/redemption.php
@@ -49,7 +49,7 @@ class Recurly_CouponRedemption extends Recurly_Resource
   }
 
   protected static function uriForAccount($accountCode) {
-    $path = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $path = self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode);
     return $path . Recurly_Client::PATH_COUPON_REDEMPTION;
   }
 

--- a/lib/recurly/redemption_list.php
+++ b/lib/recurly/redemption_list.php
@@ -3,7 +3,8 @@
 class Recurly_CouponRedemptionList extends Recurly_Pager
 {
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/redemption_list.php
+++ b/lib/recurly/redemption_list.php
@@ -3,18 +3,17 @@
 class Recurly_CouponRedemptionList extends Recurly_Pager
 {
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_COUPON_REDEMPTIONS), $params);
     return new self($uri, $client);
   }
 
   public static function getForInvoice($invoiceNumber, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_INVOICES . '/' . rawurlencode($invoiceNumber) . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_INVOICES, $invoiceNumber, Recurly_Client::PATH_COUPON_REDEMPTIONS), $params);
     return new self($uri, $client);
   }
 
   public static function getForSubscription($subscriptionUuid, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_SUBSCRIPTIONS . '/' . rawurlencode($subscriptionUuid) . Recurly_Client::PATH_COUPON_REDEMPTIONS, $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_SUBSCRIPTIONS, $subscriptionUuid, Recurly_Client::PATH_COUPON_REDEMPTIONS), $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/resource.php
+++ b/lib/recurly/resource.php
@@ -84,6 +84,9 @@ abstract class Recurly_Resource extends Recurly_Base
    */
   protected function _save($method, $uri, $data = null)
   {
+    if ($uri[0] !== '/' and strpos($uri, "https") === false){
+      $uri = '/' . $uri;
+    }
     $this->_errors = array(); // reset errors
 
     if (is_null($data)) {

--- a/lib/recurly/shipping_address_list.php
+++ b/lib/recurly/shipping_address_list.php
@@ -3,7 +3,7 @@
 class Recurly_ShippingAddressList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, '/shipping_addresses'), $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, 'shipping_addresses'), $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/shipping_address_list.php
+++ b/lib/recurly/shipping_address_list.php
@@ -3,7 +3,8 @@
 class Recurly_ShippingAddressList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams('/accounts/' . rawurlencode($accountCode) . '/shipping_addresses', $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . '/shipping_addresses', $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/shipping_address_list.php
+++ b/lib/recurly/shipping_address_list.php
@@ -3,8 +3,7 @@
 class Recurly_ShippingAddressList extends Recurly_Pager
 {
   public static function get($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    $uri = self::_uriWithParams($accountPath . '/shipping_addresses', $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, '/shipping_addresses'), $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/shipping_method.php
+++ b/lib/recurly/shipping_method.php
@@ -29,7 +29,7 @@ class Recurly_ShippingMethod extends Recurly_Resource
   }
 
   protected static function uriForShippingMethod($code) {
-    return self::_uriForResource(Recurly_Client::PATH_SHIPPING_METHOD, rawurlencode($code));
+    return self::_safeUri(Recurly_Client::PATH_SHIPPING_METHOD, $code);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/shipping_method.php
+++ b/lib/recurly/shipping_method.php
@@ -29,7 +29,7 @@ class Recurly_ShippingMethod extends Recurly_Resource
   }
 
   protected static function uriForShippingMethod($code) {
-    return Recurly_Client::PATH_SHIPPING_METHOD . '/' . rawurlencode($code);
+    return self::_uriForResource(Recurly_Client::PATH_SHIPPING_METHOD, rawurlencode($code));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -295,7 +295,7 @@ class Recurly_Subscription extends Recurly_Resource
       throw new Recurly_Error("Subscription UUID not specified");
   }
   protected static function uriForSubscription($uuid) {
-    return self::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode($uuid));
+    return self::_safeUri(Recurly_Client::PATH_SUBSCRIPTIONS, $uuid);
   }
 
   protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -295,7 +295,7 @@ class Recurly_Subscription extends Recurly_Resource
       throw new Recurly_Error("Subscription UUID not specified");
   }
   protected static function uriForSubscription($uuid) {
-    return Recurly_Client::PATH_SUBSCRIPTIONS . '/' . rawurlencode($uuid);
+    return self::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode($uuid));
   }
 
   protected function populateXmlDoc(&$doc, &$node, &$obj, $nested = false) {

--- a/lib/recurly/subscription_list.php
+++ b/lib/recurly/subscription_list.php
@@ -35,8 +35,7 @@ class Recurly_SubscriptionList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_SUBSCRIPTIONS, $params);
+    $uri = self::_uriWithParams(self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_SUBSCRIPTIONS), $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/subscription_list.php
+++ b/lib/recurly/subscription_list.php
@@ -35,7 +35,8 @@ class Recurly_SubscriptionList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_SUBSCRIPTIONS, $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_SUBSCRIPTIONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -91,7 +91,8 @@ class Recurly_Transaction extends Recurly_Resource
       throw new Recurly_Error('"uuid" is not supplied');
   }
   protected static function uriForTransaction($uuid) {
-    return Recurly_Client::PATH_TRANSACTIONS . '/' . rawurlencode($uuid);
+    // return Recurly_Client::PATH_TRANSACTIONS . '/' . rawurlencode($uuid);
+    return self::_uriForResource(Recurly_Client::PATH_TRANSACTIONS, rawurlencode($uuid));
   }
 
   protected function getNodeName() {

--- a/lib/recurly/transaction.php
+++ b/lib/recurly/transaction.php
@@ -91,8 +91,7 @@ class Recurly_Transaction extends Recurly_Resource
       throw new Recurly_Error('"uuid" is not supplied');
   }
   protected static function uriForTransaction($uuid) {
-    // return Recurly_Client::PATH_TRANSACTIONS . '/' . rawurlencode($uuid);
-    return self::_uriForResource(Recurly_Client::PATH_TRANSACTIONS, rawurlencode($uuid));
+    return self::_safeUri(Recurly_Client::PATH_TRANSACTIONS, $uuid);
   }
 
   protected function getNodeName() {

--- a/lib/recurly/transaction_list.php
+++ b/lib/recurly/transaction_list.php
@@ -16,7 +16,8 @@ class Recurly_TransactionList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_ACCOUNTS . '/' . rawurlencode($accountCode) . Recurly_Client::PATH_TRANSACTIONS, $params);
+    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
+    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_TRANSACTIONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/transaction_list.php
+++ b/lib/recurly/transaction_list.php
@@ -16,8 +16,10 @@ class Recurly_TransactionList extends Recurly_Pager
   }
 
   public static function getForAccount($accountCode, $params = null, $client = null) {
-    $accountPath = self::_uriForResource(Recurly_Client::PATH_ACCOUNTS, rawurlencode($accountCode));
-    $uri = self::_uriWithParams($accountPath . Recurly_Client::PATH_TRANSACTIONS, $params);
+    $uri = self::_uriWithParams(
+      self::_safeUri(Recurly_Client::PATH_ACCOUNTS, $accountCode, Recurly_Client::PATH_TRANSACTIONS), 
+      $params
+    );
     return new self($uri, $client);
   }
 

--- a/lib/recurly/unique_coupon_code_list.php
+++ b/lib/recurly/unique_coupon_code_list.php
@@ -4,7 +4,8 @@ class Recurly_UniqueCouponCodeList extends Recurly_Pager
 {
 
   public static function get($couponCode, $params = null, $client = null) {
-    $uri = self::_uriWithParams(Recurly_Client::PATH_COUPONS . '/' . rawurlencode($couponCode) . Recurly_Client::PATH_UNIQUE_COUPONS, $params);
+    $couponPath = self::_uriForResource(Recurly_Client::PATH_COUPONS, rawurlencode($couponCode));
+    $uri = self::_uriWithParams($couponPath . Recurly_Client::PATH_UNIQUE_COUPONS, $params);
     return new self($uri, $client);
   }
 

--- a/lib/recurly/unique_coupon_code_list.php
+++ b/lib/recurly/unique_coupon_code_list.php
@@ -4,8 +4,10 @@ class Recurly_UniqueCouponCodeList extends Recurly_Pager
 {
 
   public static function get($couponCode, $params = null, $client = null) {
-    $couponPath = self::_uriForResource(Recurly_Client::PATH_COUPONS, rawurlencode($couponCode));
-    $uri = self::_uriWithParams($couponPath . Recurly_Client::PATH_UNIQUE_COUPONS, $params);
+    $uri = self::_uriWithParams(
+      self::_safeUri(Recurly_Client::PATH_COUPONS, $couponCode, Recurly_Client::PATH_UNIQUE_COUPONS), 
+      $params
+    );
     return new self($uri, $client);
   }
 

--- a/lib/recurly/usage.php
+++ b/lib/recurly/usage.php
@@ -56,12 +56,19 @@ class Recurly_Usage extends Recurly_Resource
     return $this->getHref();
   }
 
+  protected static function uriForAddOns($subUuid, $addOnCode) {
+    $subPath = self::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode($subUuid));
+    return $subPath . self::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode($addOnCode));
+  }
+
   protected static function uriForUsages($subUuid, $addOnCode) {
-    return Recurly_Client::PATH_SUBSCRIPTIONS . '/' . rawurlencode($subUuid) . Recurly_Client::PATH_ADDONS . '/' . rawurlencode($addOnCode) . Recurly_Client::PATH_USAGE;
+    $addOnPath = Recurly_Usage::uriForAddOns($subUuid, $addOnCode);
+    return $addOnPath . Recurly_Client::PATH_USAGE;
   }
 
   protected static function uriForUsage($subUuid, $addOnCode, $usageId) {
-    return Recurly_Usage::uriForUsages($subUuid, $addOnCode) . '/' . rawurlencode($usageId);
+    $usagePath = self::_uriForResource(Recurly_Client::PATH_USAGE, rawurlencode($usageId));
+    return Recurly_Usage::uriForAddOns($subUuid, $addOnCode) . $usagePath;
   }
 
   protected function getNodeName() {

--- a/lib/recurly/usage.php
+++ b/lib/recurly/usage.php
@@ -56,19 +56,20 @@ class Recurly_Usage extends Recurly_Resource
     return $this->getHref();
   }
 
-  protected static function uriForAddOns($subUuid, $addOnCode) {
-    $subPath = self::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode($subUuid));
-    return $subPath . self::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode($addOnCode));
-  }
-
   protected static function uriForUsages($subUuid, $addOnCode) {
-    $addOnPath = Recurly_Usage::uriForAddOns($subUuid, $addOnCode);
-    return $addOnPath . Recurly_Client::PATH_USAGE;
+    return self::_safeUri(
+      Recurly_Client::PATH_SUBSCRIPTIONS, $subUuid, 
+      Recurly_Client::PATH_ADDONS, $addOnCode,
+      Recurly_Client::PATH_USAGE
+    );
   }
 
   protected static function uriForUsage($subUuid, $addOnCode, $usageId) {
-    $usagePath = self::_uriForResource(Recurly_Client::PATH_USAGE, rawurlencode($usageId));
-    return Recurly_Usage::uriForAddOns($subUuid, $addOnCode) . $usagePath;
+    return self::_safeUri(
+      Recurly_Client::PATH_SUBSCRIPTIONS, $subUuid, 
+      Recurly_Client::PATH_ADDONS, $addOnCode,
+      Recurly_Client::PATH_USAGE, $usageId
+    );
   }
 
   protected function getNodeName() {

--- a/lib/recurly/usage_list.php
+++ b/lib/recurly/usage_list.php
@@ -3,9 +3,11 @@
 class Recurly_UsageList extends Recurly_Pager {
 
   public static function get($subUuid, $addOnCode, $params = null, $client = null) {
-    $subPath = self::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode($subUuid));
-    $addOnPath = self::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode($addOnCode));
-    $uri = $subPath . $addOnPath . Recurly_Client::PATH_USAGE;
+    $uri = self::_safeUri(
+      Recurly_Client::PATH_SUBSCRIPTIONS, $subUuid, 
+      Recurly_Client::PATH_ADDONS, $addOnCode, 
+      Recurly_Client::PATH_USAGE
+    );
     $uri = self::_uriWithParams($uri, $params);
     return new self($uri, $client);
   }

--- a/lib/recurly/usage_list.php
+++ b/lib/recurly/usage_list.php
@@ -3,7 +3,9 @@
 class Recurly_UsageList extends Recurly_Pager {
 
   public static function get($subUuid, $addOnCode, $params = null, $client = null) {
-    $uri = Recurly_Client::PATH_SUBSCRIPTIONS . '/' . rawurlencode($subUuid) . Recurly_Client::PATH_ADDONS . '/' . rawurlencode($addOnCode) . Recurly_Client::PATH_USAGE;
+    $subPath = self::_uriForResource(Recurly_Client::PATH_SUBSCRIPTIONS, rawurlencode($subUuid));
+    $addOnPath = self::_uriForResource(Recurly_Client::PATH_ADDONS, rawurlencode($addOnCode));
+    $uri = $subPath . $addOnPath . Recurly_Client::PATH_USAGE;
     $uri = self::_uriWithParams($uri, $params);
     return new self($uri, $client);
   }


### PR DESCRIPTION
Addresses same issue fixed in V3: https://github.com/recurly/recurly-client-php/pull/494

Adding a helper method to prevent empty strings from being passed in as accepted path parameters for all applicable GET requests.

Example:
`$item = Recurly_Item::get("")` would return `<Recurly_ItemList[href=/items/]>`. This occurred because `uri = 'items/'` instead of `uri = 'items/{item_code}'`. Helper method throws an error when resource code is empty.