### PR TITLE
[Internal] Disabling 'composer dump-autoload' in codefresh

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-composer dump-autoload
+CODEFRESH=${CI:-false}
+
+if [ "$CODEFRESH" == "false" ]; then
+    composer dump-autoload
+fi
 
 ./vendor/bin/phpunit "$@"


### PR DESCRIPTION
This should result in a slight speed increase in the CI pipeline when running the tests.