### PR TITLE
Include tier attributes in request body

### DIFF
--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -264,6 +264,19 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     );
   }
 
+  public function testUpdateSubscriptionWithAddOnsQuantityBasedPricing() {
+    $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200-QBP.xml');
+    $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
+
+    $subscription->collection_method = "automatic";
+    $subscription->subscription_add_ons[0]->tiers[0]->ending_quantity = 50;
+
+    $this->assertEquals(
+      "<?xml version=\"1.0\"?>\n<subscription><subscription_add_ons><subscription_add_on><add_on_code>marketing_emails</add_on_code><quantity>1</quantity><revenue_schedule_type>evenly</revenue_schedule_type><tier_type>tiered</tier_type><tiers><tier><unit_amount_in_cents>123</unit_amount_in_cents><ending_quantity>50</ending_quantity></tier><tier><unit_amount_in_cents>80</unit_amount_in_cents><ending_quantity>999999999</ending_quantity></tier></tiers></subscription_add_on></subscription_add_ons><collection_method>automatic</collection_method></subscription>\n",
+      $subscription->xml()
+    );
+  }
+
   public function testGetSubscriptionRedemptions() {
     $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200.xml');
     $this->client->addResponse('GET', 'https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/redemptions', 'subscriptions/redemptions-200.xml');

--- a/Tests/fixtures/subscriptions/show-200-QBP.xml
+++ b/Tests/fixtures/subscriptions/show-200-QBP.xml
@@ -1,0 +1,68 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab">
+  <account href="https://api.recurly.com/v2/accounts/verena"/>
+  <redemptions href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/redemptions"/>
+  <plan href="https://api.recurly.com/v2/plans/silver">
+    <plan_code>silver</plan_code>
+    <name>Silver Plan</name>
+  </plan>
+  <uuid>012345678901234567890123456789ab</uuid>
+  <state>active</state>
+  <net_terms type="integer">10</net_terms>
+  <collection_method>manual</collection_method>
+  <po_number>1000</po_number>
+  <quantity type="integer">1</quantity>
+  <total_amount_in_cents type="integer">1000</total_amount_in_cents>
+  <activated_at type="datetime">2011-04-30T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2011-04-01T07:00:00Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2011-05-01T06:59:59Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <customer_notes>Some Customer Notes</customer_notes>
+  <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
+  <started_with_gift type="boolean">false</started_with_gift>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <converted_at nil="nil"></converted_at>
+  <remaining_pause_cycles type="integer">1</remaining_pause_cycles>>
+  <paused_at type="datetime">2020-01-01T01:00:00Z</paused_at>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+      <add_on_type>fixed</add_on_type>
+      <add_on_code>marketing_emails</add_on_code>
+      <name>Marketing Emails</name>
+      <quantity type="integer">1</quantity>
+      <revenue_schedule_type>evenly</revenue_schedule_type>
+      <tier_type>tiered</tier_type>
+      <tiers type="array">
+        <tier>
+          <ending_quantity type="integer">60</ending_quantity>
+          <unit_amount_in_cents type="integer">123</unit_amount_in_cents>
+        </tier>
+        <tier>
+          <ending_quantity type="integer">999999999</ending_quantity>
+          <unit_amount_in_cents type="integer">80</unit_amount_in_cents>
+        </tier>
+      </tiers>
+    </subscription_add_on>
+  </subscription_add_ons>
+  <custom_fields type="array">
+    <custom_field>
+      <name>shasta</name>
+      <value>ate my tacos</value>
+    </custom_field>
+    <custom_field>
+      <name>license-number</name>
+      <value>0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz</value>
+    </custom_field>
+  </custom_fields>
+  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/cancel" method="put"/>
+  <a name="terminate" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/terminate" method="put"/>
+</subscription>

--- a/lib/recurly/tier.php
+++ b/lib/recurly/tier.php
@@ -33,6 +33,7 @@ class Recurly_Tier extends Recurly_Resource
     );
   }
 
+  // Includes tier attributes in request body for subscription add-ons
   protected function getChangedAttributes($nested = false) {
     return $this->_values;
   }

--- a/lib/recurly/tier.php
+++ b/lib/recurly/tier.php
@@ -32,4 +32,8 @@ class Recurly_Tier extends Recurly_Resource
       'unit_amount_in_cents', 'ending_quantity'
     );
   }
+
+  protected function getChangedAttributes($nested = false) {
+    return $this->_values;
+  }
 }


### PR DESCRIPTION
Reported issue: When using the subscription_update call, a plan with tiered pricing will fail, with an error requesting additional parameters not specified in API Request. 

Expected result: Subscription should update, regardless of tiered add-on state.

Actual result: Subscription will fail to update, with errors around tiers, unit_amount_in_cents and tier_quantity.

Sample xml: 
```xml
<subscription>
  <timeframe>now</timeframe>
  <subscription_add_ons>
    <subscription_add_on>
      <add_on_code>muppy</add_on_code>
      <quantity>3</quantity>
      <revenue_schedule_type>evenly</revenue_schedule_type>
      <tier_type>tiered</tier_type>
      <tiers>
        <tier></tier>
        <tier></tier>
      </tiers>
    </subscription_add_on>
  </subscription_add_ons>
  <collection_method>automatic</collection_method>
  <custom_fields></custom_fields>
</subscription>
```

Solution:
Include `tier` attributes in request body. This also activates PUT /v2/subscriptions/:subscription_id  

Sample xml:
```xml
<subscription>
  <timeframe>now</timeframe>
  <subscription_add_ons>
    <subscription_add_on>
      <add_on_code>muppy</add_on_code>
      <quantity>3</quantity>
      <revenue_schedule_type>evenly</revenue_schedule_type>
      <tier_type>tiered</tier_type>
      <tiers>
        <tier>
          <unit_amount_in_cents>400</unit_amount_in_cents> 
          <ending_quantity>800</ending_quantity>
        </tier>
        <tier>
          <unit_amount_in_cents>200</unit_amount_in_cents>
          <ending_quantity>999999999</ending_quantity>
        </tier>
      </tiers>
    </subscription_add_on>
  </subscription_add_ons>
  <collection_method>automatic</collection_method>
  <custom_fields></custom_fields>
</subscription>
```