### PR TITLE
default parameter gives error

### DIFF
--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -56,7 +56,7 @@ class Recurly_Adjustment extends Recurly_Resource
    *
    * @param Integer the quantity you wish to refund, defaults to refunding the entire quantity
    * @param Boolean indicates whether you want this adjustment refund prorated
-   * @param String indicates the refund order to apply, valid options: {'credit','transaction'}, defaults to 'credit'
+   * @param String indicates the refund order to apply, valid options: {'credit_first', 'transaction_first'}, defaults to 'credit_first'
    * @return Recurly_Invoice the new refund invoice
    * @throws Recurly_Error if the adjustment cannot be refunded.
    */

--- a/lib/recurly/adjustment.php
+++ b/lib/recurly/adjustment.php
@@ -60,7 +60,7 @@ class Recurly_Adjustment extends Recurly_Resource
    * @return Recurly_Invoice the new refund invoice
    * @throws Recurly_Error if the adjustment cannot be refunded.
    */
-  public function refund($quantity = null, $prorate = false, $refund_apply_order = 'credit') {
+  public function refund($quantity = null, $prorate = false, $refund_apply_order = 'credit_first') {
     if ($this->state == 'pending') {
       throw new Recurly_Error("Only invoiced adjustments can be refunded");
     }


### PR DESCRIPTION
$refund_apply_order argument in Recurly_Adjustment::refund method is set to string 'credit'. 
The API responds with an error "Invalid refund_method (must be one of transaction_first, credit_first, all_transaction, all_credit)"
Recurly_Invoice::function argument however $refund_method is set to 'credit_first'
therefore I found this error when doing refunds with the following use-case 
```
$adjustment = \Recurly_Adjustment::get('53f47d7....');
$adjustment->refund();
```
Thanks