### PR TITLE
Convert DateTime objects to ISO8601 strings

### DIFF
--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -61,7 +61,8 @@ abstract class BaseClient
         $request = new \Recurly\Request($method, $path, $body, $params);
 
         $url = $this->_buildPath($path, $params);
-        list($result, $response_header) = $this->http->execute($method, $url, $body, $this->_headers());
+        $formattedBody = $this->_formatDateTimes($body);
+        list($result, $response_header) = $this->http->execute($method, $url, $formattedBody, $this->_headers());
 
         // TODO: The $request should be added to the $response
         $response = new \Recurly\Response($result);
@@ -109,11 +110,36 @@ abstract class BaseClient
     private function _buildPath(string $path, ?array $params): string
     {
         if (isset($params) && !empty($params)) {
-            return $this->baseUrl . $path . '?' . http_build_query($params);
+            return $this->baseUrl . $path . '?' . http_build_query($this->_formatDateTimes($params));
         } else {
             return $this->baseUrl . $path;
         }
 
+    }
+
+    /**
+     * Converts any DateTime values in $arr to ISO8601 strings
+     * 
+     * @param ?array $arr The Associative array to format
+     * 
+     * @return ?array The formatted array
+     */
+    private function _formatDateTimes(?array $arr): ?array
+    {
+        if (!isset($arr)) {
+            return $arr;
+        }
+        return array_combine(
+            array_keys($arr),
+            array_map(
+                function ($value) {
+                    if ($value instanceof \DateTime) {
+                        return $value->format(\DateTime::ISO8601);
+                    }
+                    return $value;
+                }, $arr
+            )
+        );
     }
 
     /**

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -136,6 +136,10 @@ abstract class BaseClient
                     if ($value instanceof \DateTime) {
                         return $value->format(\DateTime::ISO8601);
                     }
+                    # Recursively check nested arrays
+                    if (is_array($value)) {
+                        return $this->_formatDateTimes($value);
+                    }
                     return $value;
                 }, $arr
             )

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -114,4 +114,32 @@ final class BaseClientTest extends RecurlyTestCase
         }
         $this->assertEquals($count, 1);
     }
+
+    public function testFormatsDateTimeBodyParameters(): void
+    {
+        $dateTime = new DateTime("2020-01-01 00:00:00");
+
+        $url = "https://v3.recurly.com/resources/";
+        $result = '{"id": "created", "object": "test_resource", "name": "valid"}';
+        $body = [ "date_time" => $dateTime->format(\DateTime::ISO8601) ];
+        $this->client->addScenario("POST", $url, $body, $result, "201 Created");
+        $resource = $this->client->createResource([ "date_time" => $dateTime ]);
+        $this->assertEquals($resource->getId(), "created");
+    }
+
+    public function testFormatsDateTimeQueryParameters(): void
+    {
+        $beginTime = new DateTime("2020-01-01 00:00:00");
+        $url = "https://v3.recurly.com/resources?begin_time=" . urlencode($beginTime->format(\DateTime::ISO8601));
+        $result = '{ "object": "list", "has_more": false, "next": null, "data": [{"id": "iexist", "object": "test_resource", "name": "newname"}]}';
+        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+
+        $resources = $this->client->listResources([ "begin_time" => $beginTime ]);
+        $count = 0;
+        foreach($resources as $resource) {
+            $count = $count + 1;
+            $this->assertEquals($resource->getId(), "iexist");
+        }
+        $this->assertEquals($count, 1);
+    }
 }

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -127,6 +127,22 @@ final class BaseClientTest extends RecurlyTestCase
         $this->assertEquals($resource->getId(), "created");
     }
 
+    public function testFormatsNestedDateTimeBodyParameters(): void
+    {
+        $dateTime = new DateTime("2020-01-01 00:00:00");
+
+        $url = "https://v3.recurly.com/resources/";
+        $result = '{"id": "created", "object": "test_resource", "name": "valid"}';
+        $body = [
+            "nested" => [
+                "date_time" => $dateTime->format(\DateTime::ISO8601)
+            ]
+        ];
+        $this->client->addScenario("POST", $url, $body, $result, "201 Created");
+        $resource = $this->client->createResource([ "nested" => [ "date_time" => $dateTime ] ]);
+        $this->assertEquals($resource->getId(), "created");
+    }
+
     public function testFormatsDateTimeQueryParameters(): void
     {
         $beginTime = new DateTime("2020-01-01 00:00:00");


### PR DESCRIPTION
Automatically converts `DateTime` objects that are passed in as body or query string parameters to their ISO8601 string format.