### PR TITLE
BACS support

### DIFF
--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -10,6 +10,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
       array('GET', '/accounts/amazon1234567890/billing_info', 'billing_info/show-amazon-200.xml'),
       array('GET', '/accounts/bankaccount1234567890/billing_info', 'billing_info/show-bank-account-200.xml'),
       array('GET', '/accounts/sepa1234567890/billing_info', 'billing_info/show-sepa-200.xml'),
+      array('GET', '/accounts/bacs1234567890/billing_info', 'billing_info/show-bacs-200.xml'),
       array('PUT', '/accounts/abcdef1234567890/billing_info', 'billing_info/show-200.xml'),
       array('DELETE', '/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
       array('DELETE', 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
@@ -81,6 +82,13 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
     $this->assertEquals($billing_info->iban, 'US1234567890');
     $this->assertEquals($billing_info->name_on_account, 'Account Name');
+  }
+
+  public function testGetBacsBillingInfo() {
+    $billing_info = Recurly_BillingInfo::get('bacs1234567890', $this->client);
+    $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
+    $this->assertEquals($billing_info->sort_code, '200000');
+    $this->assertEquals($billing_info->name_on_account, 'BACS');
   }
 
   public function testDelete() {

--- a/Tests/fixtures/billing_info/show-bacs-200.xml
+++ b/Tests/fixtures/billing_info/show-bacs-200.xml
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<billing_info href="https://api.recurly.com/v2/accounts/bacs1234567890/billing_info" type="bacs">
+  <account href="https://api.recurly.com/v2/accounts/bacs1234567890"/>
+  <company nil="nil"></company>
+  <address1>123 Fake St.</address1>
+  <address2 nil="nil"></address2>
+  <city>London</city>
+  <state></state>
+  <zip>W1K 6AH</zip>
+  <country>GB</country>
+  <phone nil="nil"></phone>
+  <sort_code>200000</sort_code>
+  <last_two>78</last_two>
+  <name_on_account>BACS</name_on_account>
+</billing_info>
+

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -39,6 +39,8 @@
  * @property string $card_type Visa, MasterCard, American Express, Discover, JCB, etc
  * @property-write string $three_d_secure_action_result_token_id An id returned by Recurly.js referencing the result of the 3DS authentication for PSD2
  * @property string $iban International bank account number developed to identify an overseas bank account
+ * @property string $type The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+ * @property string $sort_code Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
  */
 class Recurly_BillingInfo extends Recurly_Resource
 {
@@ -107,7 +109,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id', 'external_hpp_type', 'gateway_token', 'gateway_code',
       'braintree_payment_nonce', 'roku_billing_agreement_id',
-      'three_d_secure_action_result_token_id', 'transaction_type', 'iban'
+      'three_d_secure_action_result_token_id', 'transaction_type', 'iban', 'sort_code', 'type'
     );
   }
 }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -24,7 +24,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.26';
+  public static $apiVersion = '2.27';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).


### PR DESCRIPTION
Added `sort_code` and `type` fields to support BACS payment type.