### PR TITLE
Adding \Recurly\Logger class and the ability to configure a logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ $api_key = 'myApiKey';
 $client = new \Recurly\Client($api_key);
 ```
 
+#### Logging
+
+The client constructor optionally accepts a logger provided by the programmer. The logger you pass should implement the [PSR-3 Logger Interface](https://www.php-fig.org/psr/psr-3/). By default, the client creates an instance of the `\Recurly\Logger` which is a basic implementation that prints log messages to `php://stdout` with the `\Psr\Log\LogLevel::WARNING` level.
+
+```php
+// Create an instance of the Recurly\Logger
+$logger = new \Recurly\Logger('Recurly', \Psr\Log\LogLevel::INFO);
+
+$client = new \Recurly\Client($api_key, $logger);
+```
+
+> *SECURITY WARNING*: The log level should never be set to DEBUG in production. This could potentially result in sensitive data in your logging system.
+
 ### Operations
 
 The `\Recurly\Client` contains every operation you can perform on the site as a list of methods. Each method is documented explaining the types and descriptions for each input and return type. For example, to use the [get_plan](https://developers.recurly.com/api/latest/index.html#operation/get_plan) endpoint, call the `Client#getPlan()` method:

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -78,17 +78,15 @@ abstract class BaseClient
      */
     private function _getResponse(\Recurly\Request $request): \Recurly\Response
     {
-        $url = $this->_buildPath($path, $params);
-        $formattedBody = $this->_formatDateTimes($body);
         $this->_logger->info(
             'Request', [
-            'method' => $method,
-            'path' => $path
+            'method' => $request->getMethod(),
+            'path' => $request->getUrl()
             ]
         );
         $this->_logger->debug(
             'Request', [
-            'request_body' => $formattedBody,
+            'request_body' => $request->getBodyAsJson(),
             'request_headers' => $this->_headers()
             ]
         );

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -2,6 +2,9 @@
 
 namespace Recurly;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
 abstract class BaseClient
 {
     use RecurlyTraits;
@@ -9,16 +12,28 @@ abstract class BaseClient
     protected $baseUrl = 'https://v3.recurly.com';
     private $_api_key;
     protected $http;
+    private $_logger;
 
     /**
      * Constructor
      * 
      * @param string $api_key The API key to use when making requests
      */
-    public function __construct(string $api_key)
+    public function __construct(string $api_key, LoggerInterface $logger = null)
     {
         $this->_api_key = $api_key;
         $this->http = new HttpAdapter;
+        if (is_null($logger)) {
+            $logger = new \Recurly\Logger('Recurly', LogLevel::WARNING);
+        }
+        $this->_logger = $logger;
+
+        // Send Security Warning to logger debug
+        $msg = "The Recurly logger should not be initialized";
+        $msg .= "\nbeyond the level INFO. It is currently configured to emit";
+        $msg .= "\nheaders and request / response bodies. This has the potential to leak";
+        $msg .= "\nPII and other sensitive information and should never be used in production.";
+        $this->_logger->debug("SECURITY WARNING: {$msg}");
     }
 
     /**
@@ -63,10 +78,38 @@ abstract class BaseClient
      */
     private function _getResponse(\Recurly\Request $request): \Recurly\Response
     {
+        $url = $this->_buildPath($path, $params);
+        $formattedBody = $this->_formatDateTimes($body);
+        $this->_logger->info(
+            'Request', [
+            'method' => $method,
+            'path' => $path
+            ]
+        );
+        $this->_logger->debug(
+            'Request', [
+            'request_body' => $formattedBody,
+            'request_headers' => $this->_headers()
+            ]
+        );
+        $start = time();
         list($result, $response_header) = $this->http->execute($request->getMethod(), $request->getUrl(), $request->getBodyAsJson(), $this->_headers());
+        $end = time();
 
         $response = new \Recurly\Response($result, $request);
         $response->setHeaders($response_header);
+        $this->_logger->info(
+            'Response', [
+            'time_ms' => $end - $start,
+            'status' => $response->getStatusCode()
+            ]
+        );
+        $this->_logger->debug(
+            'Response', [
+            'response_body' => $response->getRawResponse(),
+            'response_headers' => $response->getHeaders()
+            ]
+        );
 
         return $response;
     }

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -92,15 +92,15 @@ abstract class BaseClient
             'request_headers' => $this->_headers()
             ]
         );
-        $start = time();
+        $start = microtime(true);
         list($result, $response_header) = $this->http->execute($request->getMethod(), $request->getUrl(), $request->getBodyAsJson(), $this->_headers());
-        $end = time();
+        $end = microtime(true);
 
         $response = new \Recurly\Response($result, $request);
         $response->setHeaders($response_header);
         $this->_logger->info(
             'Response', [
-            'time_ms' => $end - $start,
+            'time_ms' => intval(($end - $start) * 1000),
             'status' => $response->getStatusCode()
             ]
         );

--- a/lib/recurly/logger.php
+++ b/lib/recurly/logger.php
@@ -9,7 +9,7 @@ class Logger implements LoggerInterface
 {
     private $_name;
     private $_default_log_level;
-    const LEVEL_MAP = [
+    private const LEVEL_MAP = [
         LogLevel::EMERGENCY => 800,
         LogLevel::ALERT => 700,
         LogLevel::CRITICAL => 600,

--- a/lib/recurly/logger.php
+++ b/lib/recurly/logger.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Recurly;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class Logger implements LoggerInterface
+{
+    private $_name;
+    private $_default_log_level;
+    const LEVEL_MAP = [
+        LogLevel::EMERGENCY => 800,
+        LogLevel::ALERT => 700,
+        LogLevel::CRITICAL => 600,
+        LogLevel::ERROR => 500,
+        LogLevel::WARNING => 400,
+        LogLevel::NOTICE => 300,
+        LogLevel::INFO => 200,
+        LogLevel::DEBUG => 100
+    ];
+
+    /**
+     * Constructor
+     * 
+     * @param string $name              The name of the application
+     * @param string $default_log_level The minumum LogLevel to print messages for
+     */
+    public function __construct(string $name, string $default_log_level = LogLevel::INFO)
+    {
+        if (!array_key_exists($default_log_level, Logger::LEVEL_MAP)) {
+            throw new \InvalidArgumentException("Invalid default log level: {$default_log_level}");
+        }
+        $this->_name = $name;
+        $this->_default_log_level = $default_log_level;
+    }
+
+    /**
+     * Internal function that prints log messages to STDOUT
+     * Data passed into $context will be converted to JSON
+     * 
+     * @param string $level   The LogLevel of the message
+     * @param string $message The message to print
+     * @param array  $context Additional data to include in the output
+     *
+     * @return void
+     */
+    private function _print_log(string $level, string $message, array $context): void
+    {
+        if (Logger::LEVEL_MAP[$level] < Logger::LEVEL_MAP[$this->_default_log_level]) {
+            return;
+        }
+        $d = new \DateTime();
+        $jsonContext = json_encode($context);
+        print("[{$d->format(\DateTime::ISO8601)}] {$this->_name}.{$level}: {$message} {$jsonContext}" . PHP_EOL);
+    }
+
+    /**
+     * System is unusable.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function emergency($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function alert($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::ALERT, $message, $context);
+    }
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function critical($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function error($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::ERROR, $message, $context);
+    }
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function warning($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::WARNING, $message, $context);
+    }
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function notice($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::NOTICE, $message, $context);
+    }
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function info($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::INFO, $message, $context);
+    }
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     */
+    public function debug($message, array $context = array()): void
+    {
+        $this->_print_log(LogLevel::DEBUG, $message, $context);
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed   $level
+     * @param string  $message
+     * @param mixed[] $context
+     *
+     * @return void
+     *
+     * @throws \Psr\Log\InvalidArgumentException
+     */
+    public function log($level, $message, array $context = array()): void
+    {
+        if (!array_key_exists($level, Logger::LEVEL_MAP)) {
+            throw new \InvalidArgumentException("Invalid log level: {$level}");
+        }
+        $this->_print_log($level, $message, $context);
+    }
+}

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -100,6 +100,16 @@ class Response
     }
 
     /**
+     * Getter method for all of the HTTP headers included with the response.
+     * 
+     * @return array Associative array of response headers
+     */
+    public function getHeaders(): array
+    {
+        return $this->_headers;
+    }
+
+    /**
      * Getter method for the HTTP status code
      * 
      * @return int The HTTP status code

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
                 <file>lib/recurly.php</file>
                 <file>lib/recurly/version.php</file>
                 <file>lib/recurly/client.php</file>
+                <file>lib/recurly/http_adapter.php</file>
                 <directory suffix=".php">lib/recurly/resources</directory>
                 <directory suffix=".php">lib/recurly/errors</directory>
             </exclude>

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -12,8 +12,7 @@ final class BaseClientTest extends RecurlyTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $logger = new Logger('Recurly', LogLevel::EMERGENCY);
-        $this->client = new MockClient($logger);
+        $this->client = new MockClient();
     }
 
     public function tearDown(): void

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -12,7 +12,9 @@ final class BaseClientTest extends RecurlyTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->client = new MockClient();
+        // Using LogLevel::EMERGENCY to minimize output when running tests
+        $logger = new Logger('Recurly', LogLevel::EMERGENCY);
+        $this->client = new MockClient($logger);
     }
 
     public function tearDown(): void

--- a/tests/Logger_Test.php
+++ b/tests/Logger_Test.php
@@ -1,0 +1,101 @@
+<?php
+
+use Recurly\Logger;
+use Psr\Log\LogLevel;
+
+final class LoggerTest extends RecurlyTestCase
+{
+    const ISO8601_REGEX = "(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})[+-](\d{4})";
+
+    public function testConstructorInvalidLogLevelException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Logger('name', 'invalid-level');
+    }
+
+    public function testLogInvalidLogLevelException(): void
+    {
+        $logger = new Logger('name', LogLevel::INFO);
+        $this->expectException(InvalidArgumentException::class);
+        $logger->log('invalid-level', 'log-message');
+    }
+
+    public function testContextIntLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::INFO);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.info: info-log \[5\]\n$/");
+        $logger->info('info-log', [5]);
+    }
+
+    public function testContextObjectLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::INFO);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.info: info-log \[{\"test\":\"abc\"}\]\n$/");
+        $obj = new stdClass;
+        $obj->test = 'abc';
+        $logger->info('info-log', [$obj]);
+    }
+
+    public function testLogMethodLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::INFO);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.info: info-log \[.*\]\n$/");
+        $logger->log(LogLevel::INFO, 'info-log');
+    }
+
+    public function testEmergencyLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::EMERGENCY);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.emergency: emergency-log \[.*\]\n$/");
+        $logger->emergency('emergency-log');
+    }
+
+    public function testAlertLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::ALERT);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.alert: alert-log \[.*\]\n$/");
+        $logger->alert('alert-log');
+    }
+
+    public function testCriticalLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::CRITICAL);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.critical: critical-log \[.*\]\n$/");
+        $logger->critical('critical-log');
+    }
+
+    public function testErrorLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::ERROR);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.error: error-log \[.*\]\n$/");
+        $logger->error('error-log');
+    }
+
+    public function testWarningLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::WARNING);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.warning: warning-log \[.*\]\n$/");
+        $logger->warning('warning-log');
+    }
+
+    public function testNoticeLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::NOTICE);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.notice: notice-log \[.*\]\n$/");
+        $logger->notice('notice-log');
+    }
+
+    public function testInfoLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::INFO);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.info: info-log \[.*\]\n$/");
+        $logger->info('info-log');
+    }
+
+    public function testDebugLogging(): void
+    {
+        $logger = new Logger('Recurly', LogLevel::DEBUG);
+        $this->expectOutputRegex("/^\[" . self::ISO8601_REGEX . "\] Recurly.debug: debug-log \[.*\]\n$/");
+        $logger->debug('debug-log');
+    }
+}

--- a/tests/Logger_Test.php
+++ b/tests/Logger_Test.php
@@ -5,7 +5,7 @@ use Psr\Log\LogLevel;
 
 final class LoggerTest extends RecurlyTestCase
 {
-    const ISO8601_REGEX = "(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})[+-](\d{4})";
+    private const ISO8601_REGEX = "(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})[+-](\d{4})";
 
     public function testConstructorInvalidLogLevelException(): void
     {

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -1,13 +1,17 @@
 <?php
 
 use Recurly\Pager;
+use Recurly\Logger;
+use Psr\Log\LogLevel;
 
 final class PagerTest extends RecurlyTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        $this->client = new MockClient();
+        // Using LogLevel::EMERGENCY to minimize output when running tests
+        $logger = new Logger('Recurly', LogLevel::EMERGENCY);
+        $this->client = new MockClient($logger);
         $this->request = new \Recurly\Request('GET', 'https://v3.recurly.com/accounts', null, null, []);
 
         $this->count = 3;

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -1,16 +1,13 @@
 <?php
 
 use Recurly\Pager;
-use Recurly\Logger;
-use Psr\Log\LogLevel;
 
 final class PagerTest extends RecurlyTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        $logger = new Logger('Recurly', LogLevel::EMERGENCY);
-        $this->client = new MockClient($logger);
+        $this->client = new MockClient();
         $this->request = new \Recurly\Request('GET', 'https://v3.recurly.com/accounts', null, null, []);
 
         $this->count = 3;

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -1,13 +1,16 @@
 <?php
 
 use Recurly\Pager;
+use Recurly\Logger;
+use Psr\Log\LogLevel;
 
 final class PagerTest extends RecurlyTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        $this->client = new MockClient();
+        $logger = new Logger('Recurly', LogLevel::EMERGENCY);
+        $this->client = new MockClient($logger);
         $this->request = new \Recurly\Request('GET', 'https://v3.recurly.com/accounts', null, null, []);
 
         $this->count = 3;

--- a/tests/mock_client.php
+++ b/tests/mock_client.php
@@ -6,17 +6,13 @@ use Recurly\BaseClient;
 use Recurly\Utils;
 use PHPUnit\Framework\MockObject\Generator;
 use Recurly\HttpAdapter;
-use Recurly\Logger;
 
 class MockClient extends BaseClient
 {
     use Recurly\RecurlyTraits;
 
-    public function __construct($logger = null)
+    public function __construct($logger)
     {
-        if (!$logger) {
-            $logger = new Logger('Recurly');
-        }
         parent::__construct("apikey", $logger);
         $this->http = (new Generator())->getMock(HttpAdapter::class);
     }

--- a/tests/mock_client.php
+++ b/tests/mock_client.php
@@ -6,14 +6,17 @@ use Recurly\BaseClient;
 use Recurly\Utils;
 use PHPUnit\Framework\MockObject\Generator;
 use Recurly\HttpAdapter;
-use Psr\Log\LoggerInterface;
+use Recurly\Logger;
 
 class MockClient extends BaseClient
 {
     use Recurly\RecurlyTraits;
 
-    public function __construct($logger)
+    public function __construct($logger = null)
     {
+        if (!$logger) {
+            $logger = new Logger('Recurly');
+        }
         parent::__construct("apikey", $logger);
         $this->http = (new Generator())->getMock(HttpAdapter::class);
     }

--- a/tests/mock_client.php
+++ b/tests/mock_client.php
@@ -6,14 +6,15 @@ use Recurly\BaseClient;
 use Recurly\Utils;
 use PHPUnit\Framework\MockObject\Generator;
 use Recurly\HttpAdapter;
+use Psr\Log\LoggerInterface;
 
 class MockClient extends BaseClient
 {
     use Recurly\RecurlyTraits;
 
-    public function __construct()
+    public function __construct($logger)
     {
-        parent::__construct("apikey");
+        parent::__construct("apikey", $logger);
         $this->http = (new Generator())->getMock(HttpAdapter::class);
     }
 


### PR DESCRIPTION
Adds the ability to specify a custom logger that implements the `PSR-3 Logger Interface`.

By default, the PHP client will use it's own minimal implementation of the PSR-3 Logger that is configured to `\Psr\Log\LogLevel::INFO`. If a different log level is desired, we advise that you use a more fully featured 3rd party logger that also implements the PSR-3 interface. The logger instance can be passed as the 2nd argument when creating an instance of the `Client`.

Setting level `DEBUG` will log headers, request, and response bodies. This will produce a significant amount of logs of potentially sensitive information. The `DEBUG` level should not be used outside of a testing environment.

```shell
[2020-09-15T17:06:42+0000] Recurly.info: Request {"method":"POST","path":"\/accounts"}
[2020-09-15T17:06:43+0000] Recurly.info: Response {"time_ms":225,"status":201}
[2020-09-15T17:06:43+0000] Recurly.info: Request {"method":"DELETE","path":"\/accounts\/code-0d80167ed5be14f74321"}
[2020-09-15T17:06:43+0000] Recurly.info: Response {"time_ms":236,"status":200}
```