### PR TITLE
Support items on subscriptions

### DIFF
--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -11,7 +11,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Stub', $subscription->account);
     $this->assertEquals($subscription->account->getHref(), 'https://api.recurly.com/v2/accounts/verena');
 
-    $this->assertCount(1, $subscription->subscription_add_ons);
+    $this->assertCount(2, $subscription->subscription_add_ons);
 
     $add_on = $subscription->subscription_add_ons[0];
     $this->assertInstanceOf('Recurly_SubscriptionAddOn', $add_on);
@@ -30,6 +30,11 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $this->assertEquals('Some Customer Notes', $subscription->customer_notes);
     $this->assertEquals('Some VAT Notes', $subscription->vat_reverse_charge_notes);
     $this->assertEquals('plan_free_trial', $subscription->no_billing_info_reason);
+
+    $item_add_on = $subscription->subscription_add_ons[1];
+    $this->assertInstanceOf('Recurly_SubscriptionAddOn', $item_add_on);
+    $this->assertEquals('item', $item_add_on->add_on_source);
+    $this->assertEquals(199, $item_add_on->unit_amount_in_cents);
 
     $this->assertInstanceOf('Recurly_CustomFieldList', $subscription->custom_fields);
     $this->assertCount(2, $subscription->custom_fields);
@@ -123,7 +128,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->shipping_address_id = 1234567890;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><subscription_add_ons><subscription_add_on><add_on_code>marketing_emails</add_on_code><unit_amount_in_cents>5</unit_amount_in_cents><quantity>1</quantity></subscription_add_on></subscription_add_ons><shipping_address_id>1234567890</shipping_address_id></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><subscription_add_ons><subscription_add_on><add_on_code>marketing_emails</add_on_code><unit_amount_in_cents>5</unit_amount_in_cents><quantity>1</quantity></subscription_add_on><subscription_add_on><item>&lt;Recurly_Stub[item] href=https://api.recurlyqa.com/v2/items/mockitem&gt;</item><external_sku>tester-sku</external_sku><add_on_code>mockitem</add_on_code><unit_amount_in_cents>199</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>never</revenue_schedule_type><tier_type>flat</tier_type><add_on_source>item</add_on_source></subscription_add_on></subscription_add_ons><shipping_address_id>1234567890</shipping_address_id></subscription>\n",
       $subscription->xml()
     );
   }
@@ -259,7 +264,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->quantity = 2;
 
     $this->assertEquals(
-      "<?xml version=\"1.0\"?>\n<subscription><quantity>2</quantity><subscription_add_ons><subscription_add_on><add_on_code>marketing_emails</add_on_code><unit_amount_in_cents>5</unit_amount_in_cents><quantity>1</quantity></subscription_add_on></subscription_add_ons></subscription>\n",
+      "<?xml version=\"1.0\"?>\n<subscription><quantity>2</quantity><subscription_add_ons><subscription_add_on><add_on_code>marketing_emails</add_on_code><unit_amount_in_cents>5</unit_amount_in_cents><quantity>1</quantity></subscription_add_on><subscription_add_on><item>&lt;Recurly_Stub[item] href=https://api.recurlyqa.com/v2/items/mockitem&gt;</item><external_sku>tester-sku</external_sku><add_on_code>mockitem</add_on_code><unit_amount_in_cents>199</unit_amount_in_cents><quantity>1</quantity><revenue_schedule_type>never</revenue_schedule_type><tier_type>flat</tier_type><add_on_source>item</add_on_source></subscription_add_on></subscription_add_ons></subscription>\n",
       $subscription->xml()
     );
   }

--- a/Tests/fixtures/subscriptions/show-200.xml
+++ b/Tests/fixtures/subscriptions/show-200.xml
@@ -45,6 +45,17 @@ Content-Type: application/xml; charset=utf-8
       <usage_type>price</usage_type>
       <usage_percentage nil="nil"/>
     </subscription_add_on>
+    <subscription_add_on>
+      <add_on_type>fixed</add_on_type>
+      <item href="https://api.recurlyqa.com/v2/items/mockitem"/>
+      <external_sku>tester-sku</external_sku>
+      <add_on_code>mockitem</add_on_code>
+      <unit_amount_in_cents type="integer">199</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <revenue_schedule_type>never</revenue_schedule_type>
+      <tier_type>flat</tier_type>
+      <add_on_source>item</add_on_source>
+    </subscription_add_on>
   </subscription_add_ons>
   <custom_fields type="array">
     <custom_field>

--- a/lib/recurly/plan.php
+++ b/lib/recurly/plan.php
@@ -32,6 +32,7 @@
  * @property string $usage_percentage If add_on_type = usage and usage_type = percentage, you must set a usage_percentage. Must be between 0.0000 and 100.0000.
  * @property boolean $trial_requires_billing_info Setting to determine if subscriptions to this plan will always require billing info or will only require it when either not in a trial or when money is due, defaults to true.
  * @property boolean $auto_renew Determines whether subscriptions to this plan should auto-renew term at the end of the current term or expire. Defaults to true.
+ * @property boolean $allow_any_item_on_subscriptions Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used.
  */
 class Recurly_Plan extends Recurly_Resource
 {
@@ -98,7 +99,7 @@ class Recurly_Plan extends Recurly_Resource
       'trial_interval_unit', 'unit_amount_in_cents', 'setup_fee_in_cents',
       'total_billing_cycles', 'accounting_code', 'setup_fee_accounting_code',
       'revenue_schedule_type', 'setup_fee_revenue_schedule_type',
-      'tax_exempt', 'tax_code', 'trial_requires_billing_info', 'auto_renew'
+      'tax_exempt', 'tax_code', 'trial_requires_billing_info', 'auto_renew', 'allow_any_item_on_subscriptions'
     );
   }
 }

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -7,6 +7,8 @@
  * @property int $quantity Optionally override the default quantity of 1.
  * @property float $usage_percentage If add_on_type = usage and usage_type = percentage, you can set a custom usage_percentage for the subscription add-on. Must be between 0.0000 and 100.0000.
  * @property string $revenue_schedule_type Optional field for setting a revenue schedule type. This will determine how revenue for the associated Subscription Add-On should be recognized. When creating a Subscription Add-On, available schedule types are: [never, evenly, at_range_start, at_range_end]. If no revenue_schedule_type is set, the Subscription Add-On will inherit the revenue_schedule_type from its Plan Add-On.
+ * @property string $add_on_source Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add-on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog.
+
  */
 class Recurly_SubscriptionAddOn extends Recurly_Resource
 {
@@ -24,6 +26,7 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource
       'usage_type',
       'usage_percentage',
       'revenue_schedule_type',
+      'add_on_source',
     );
   }
 


### PR DESCRIPTION
This PR adds support for items on subscriptions, where merchants may now associate a subscription add-on with an item in their catalog.

`allow_any_item_on_subscriptions` has been added to the `Plan` class. It is used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used.

`add_on_source`, added to the `SubscriptionAddOn` class, is used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add-on data will be pulled from the plan's add-ons. If the associated  `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog.

Code example:
```php
// create sub add-on from item
$addon1 = new Recurly_SubscriptionAddOn();
$addon1->add_on_code = $item->item_code;
$addon1->add_on_source = "item";
$addon1->unit_amount_in_cents = 299;

// create sub add-on from existing add-on
$addon2 = new Recurly_SubscriptionAddOn();
$addon2->add_on_code = $add_on_2->add_on_code;

// create subscription
$subscription = new Recurly_Subscription();
$subscription->plan_code = $plan->plan_code;
$subscription->currency = 'USD';
$subscription->account = $account;
$subscription->subscription_add_ons = array($addon1, $addon2);
$subscription->create();
```