### PR TITLE
Fix HTTP 411 error by including Content-Length header

### DIFF
--- a/lib/recurly/http_adapter.php
+++ b/lib/recurly/http_adapter.php
@@ -33,6 +33,8 @@ class HttpAdapter
             'content' => $body,
             ]
         );
+        // The Content-Length header is required by Recurly API infrastructure
+        $headers['Content-Length'] = strlen($body);
         $headers_str = "";
         foreach ($headers as $k => $v) {
             $headers_str .= "$k: $v\r\n";


### PR DESCRIPTION
Recurly API requires that the `Content-Length` header be specified according to the HTTP specification.

A subset of requests were failing with a HTTP Status Code `411` error: `411. That’s an error. POST requests require a Content-length header. That’s all we know.`