### PR TITLE
Release 3.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.3.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "recurly/recurly-client",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "type": "library",
     "description": "The PHP client library for the Recurly API",
     "keywords": ["recurly", "payments", "pay"],

--- a/lib/recurly/version.php
+++ b/lib/recurly/version.php
@@ -4,5 +4,5 @@ namespace Recurly;
 
 class Version
 {
-    public const CURRENT = '3.2.0';
+    public const CURRENT = '3.3.0';
 }


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-php/compare/3.2.0...HEAD)

**Implemented enhancements:**

- Mon Jun 29 17:06:38 UTC 2020 Upgrade API version v2019-10-10 [\#510](https://github.com/recurly/recurly-client-php/pull/510) ([douglasmiller](https://github.com/douglasmiller))
- Convert DateTime objects to ISO8601 strings [\#504](https://github.com/recurly/recurly-client-php/pull/504) ([douglasmiller](https://github.com/douglasmiller))

**Fixed bugs:**

- Fix HTTP 411 error by including Content-Length header [\#509](https://github.com/recurly/recurly-client-php/pull/509) ([douglasmiller](https://github.com/douglasmiller))