### PR TITLE
Improvements for PHPUnit fistures and array syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ sudo: false
 dist: trusty
 install:
   - composer install --dev
-script: vendor/phpunit/phpunit/phpunit tests
+script: vendor/bin/phpunit tests

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -191,12 +191,12 @@ abstract class BaseClient
     {
         $auth_token = self::encodeApiKey($this->_api_key);
         $agent = self::getUserAgent();
-        return array(
+        return [
             "User-Agent" => $agent,
             "Authorization" => "Basic {$auth_token}",
             "Accept" => "application/vnd.recurly.{$this->apiVersion()}",
             "Content-Type" => "application/json",
             "Accept-Encoding" => "gzip",
-        );
+        ];
     }
 }

--- a/lib/recurly/error_traits.php
+++ b/lib/recurly/error_traits.php
@@ -19,7 +19,7 @@ trait ErrorTraits
      */
     protected static function errorFromStatus(int $status_code): string
     {
-        $error_map = array(
+        $error_map = [
             500 => 'internal_server_error',
             502 => 'bad_gateway',
             503 => 'service_unavailable',
@@ -33,7 +33,7 @@ trait ErrorTraits
             412 => 'precondition_failed',
             422 => 'unprocessable_entity',
             429 => 'too_many_requests',
-        );
+        ];
 
         if (array_key_exists($status_code, $error_map)) {
             return $error_map[$status_code];

--- a/lib/recurly/http_adapter.php
+++ b/lib/recurly/http_adapter.php
@@ -50,6 +50,6 @@ class HttpAdapter
                 }
             }
         }
-        return array($result, $http_response_header);
+        return [$result, $http_response_header];
     }
 }

--- a/lib/recurly/resources/account.php
+++ b/lib/recurly/resources/account.php
@@ -43,10 +43,10 @@ class Account extends RecurlyResource
     private $_username;
     private $_vat_number;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCustomFields' => '\Recurly\Resources\CustomField',
         'setShippingAddresses' => '\Recurly\Resources\ShippingAddress',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/account_acquisition.php
+++ b/lib/recurly/resources/account_acquisition.php
@@ -22,8 +22,8 @@ class AccountAcquisition extends RecurlyResource
     private $_subchannel;
     private $_updated_at;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/account_acquisition_cost.php
+++ b/lib/recurly/resources/account_acquisition_cost.php
@@ -15,8 +15,8 @@ class AccountAcquisitionCost extends RecurlyResource
     private $_amount;
     private $_currency;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/account_balance.php
+++ b/lib/recurly/resources/account_balance.php
@@ -17,9 +17,9 @@ class AccountBalance extends RecurlyResource
     private $_object;
     private $_past_due;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setBalances' => '\Recurly\Resources\AccountBalanceAmount',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/account_balance_amount.php
+++ b/lib/recurly/resources/account_balance_amount.php
@@ -15,8 +15,8 @@ class AccountBalanceAmount extends RecurlyResource
     private $_amount;
     private $_currency;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/account_mini.php
+++ b/lib/recurly/resources/account_mini.php
@@ -22,8 +22,8 @@ class AccountMini extends RecurlyResource
     private $_object;
     private $_parent_account_id;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/account_note.php
+++ b/lib/recurly/resources/account_note.php
@@ -19,8 +19,8 @@ class AccountNote extends RecurlyResource
     private $_object;
     private $_user;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/add_on.php
+++ b/lib/recurly/resources/add_on.php
@@ -33,10 +33,10 @@ class AddOn extends RecurlyResource
     private $_tiers;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCurrencies' => '\Recurly\Resources\AddOnPricing',
         'setTiers' => '\Recurly\Resources\Tier',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/add_on_mini.php
+++ b/lib/recurly/resources/add_on_mini.php
@@ -20,8 +20,8 @@ class AddOnMini extends RecurlyResource
     private $_name;
     private $_object;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/add_on_pricing.php
+++ b/lib/recurly/resources/add_on_pricing.php
@@ -15,8 +15,8 @@ class AddOnPricing extends RecurlyResource
     private $_currency;
     private $_unit_amount;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/address.php
+++ b/lib/recurly/resources/address.php
@@ -22,8 +22,8 @@ class Address extends RecurlyResource
     private $_street1;
     private $_street2;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/billing_info.php
+++ b/lib/recurly/resources/billing_info.php
@@ -27,8 +27,8 @@ class BillingInfo extends RecurlyResource
     private $_valid;
     private $_vat_number;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/billing_info_updated_by.php
+++ b/lib/recurly/resources/billing_info_updated_by.php
@@ -15,8 +15,8 @@ class BillingInfoUpdatedBy extends RecurlyResource
     private $_country;
     private $_ip;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/binary_file.php
+++ b/lib/recurly/resources/binary_file.php
@@ -14,8 +14,8 @@ class BinaryFile extends RecurlyResource
 {
     private $_data;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/coupon.php
+++ b/lib/recurly/resources/coupon.php
@@ -41,10 +41,10 @@ class Coupon extends RecurlyResource
     private $_unique_coupon_codes_count;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setPlans' => '\Recurly\Resources\PlanMini',
         'setPlansNames' => 'string',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/coupon_discount.php
+++ b/lib/recurly/resources/coupon_discount.php
@@ -17,9 +17,9 @@ class CouponDiscount extends RecurlyResource
     private $_trial;
     private $_type;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCurrencies' => '\Recurly\Resources\CouponDiscountPricing',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/coupon_discount_pricing.php
+++ b/lib/recurly/resources/coupon_discount_pricing.php
@@ -15,8 +15,8 @@ class CouponDiscountPricing extends RecurlyResource
     private $_amount;
     private $_currency;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/coupon_discount_trial.php
+++ b/lib/recurly/resources/coupon_discount_trial.php
@@ -15,8 +15,8 @@ class CouponDiscountTrial extends RecurlyResource
     private $_length;
     private $_unit;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/coupon_mini.php
+++ b/lib/recurly/resources/coupon_mini.php
@@ -21,8 +21,8 @@ class CouponMini extends RecurlyResource
     private $_object;
     private $_state;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/coupon_redemption.php
+++ b/lib/recurly/resources/coupon_redemption.php
@@ -23,8 +23,8 @@ class CouponRedemption extends RecurlyResource
     private $_state;
     private $_updated_at;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/coupon_redemption_mini.php
+++ b/lib/recurly/resources/coupon_redemption_mini.php
@@ -19,8 +19,8 @@ class CouponRedemptionMini extends RecurlyResource
     private $_object;
     private $_state;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/credit_payment.php
+++ b/lib/recurly/resources/credit_payment.php
@@ -27,8 +27,8 @@ class CreditPayment extends RecurlyResource
     private $_uuid;
     private $_voided_at;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/custom_field.php
+++ b/lib/recurly/resources/custom_field.php
@@ -15,8 +15,8 @@ class CustomField extends RecurlyResource
     private $_name;
     private $_value;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/custom_field_definition.php
+++ b/lib/recurly/resources/custom_field_definition.php
@@ -23,8 +23,8 @@ class CustomFieldDefinition extends RecurlyResource
     private $_updated_at;
     private $_user_access;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/error.php
+++ b/lib/recurly/resources/error.php
@@ -16,9 +16,9 @@ class Error extends RecurlyResource
     private $_params;
     private $_type;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setParams' => 'object',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/error_may_have_transaction.php
+++ b/lib/recurly/resources/error_may_have_transaction.php
@@ -17,9 +17,9 @@ class ErrorMayHaveTransaction extends RecurlyResource
     private $_transaction_error;
     private $_type;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setParams' => 'object',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/fraud_info.php
+++ b/lib/recurly/resources/fraud_info.php
@@ -16,8 +16,8 @@ class FraudInfo extends RecurlyResource
     private $_risk_rules_triggered;
     private $_score;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -47,11 +47,11 @@ class Invoice extends RecurlyResource
     private $_vat_number;
     private $_vat_reverse_charge_notes;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCreditPayments' => '\Recurly\Resources\CreditPayment',
         'setSubscriptionIds' => 'string',
         'setTransactions' => '\Recurly\Resources\Transaction',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/invoice_address.php
+++ b/lib/recurly/resources/invoice_address.php
@@ -24,8 +24,8 @@ class InvoiceAddress extends RecurlyResource
     private $_street1;
     private $_street2;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/invoice_collection.php
+++ b/lib/recurly/resources/invoice_collection.php
@@ -16,9 +16,9 @@ class InvoiceCollection extends RecurlyResource
     private $_credit_invoices;
     private $_object;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCreditInvoices' => '\Recurly\Resources\Invoice',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/invoice_mini.php
+++ b/lib/recurly/resources/invoice_mini.php
@@ -18,8 +18,8 @@ class InvoiceMini extends RecurlyResource
     private $_state;
     private $_type;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/item.php
+++ b/lib/recurly/resources/item.php
@@ -29,10 +29,10 @@ class Item extends RecurlyResource
     private $_tax_exempt;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCurrencies' => '\Recurly\Resources\Pricing',
         'setCustomFields' => '\Recurly\Resources\CustomField',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/item_mini.php
+++ b/lib/recurly/resources/item_mini.php
@@ -19,8 +19,8 @@ class ItemMini extends RecurlyResource
     private $_object;
     private $_state;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -58,8 +58,8 @@ class LineItem extends RecurlyResource
     private $_updated_at;
     private $_uuid;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/line_item_list.php
+++ b/lib/recurly/resources/line_item_list.php
@@ -17,9 +17,9 @@ class LineItemList extends RecurlyResource
     private $_next;
     private $_object;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setData' => '\Recurly\Resources\LineItem',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/payment_method.php
+++ b/lib/recurly/resources/payment_method.php
@@ -27,8 +27,8 @@ class PaymentMethod extends RecurlyResource
     private $_routing_number;
     private $_routing_number_bank;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/plan.php
+++ b/lib/recurly/resources/plan.php
@@ -38,9 +38,9 @@ class Plan extends RecurlyResource
     private $_trial_unit;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCurrencies' => '\Recurly\Resources\PlanPricing',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/plan_hosted_pages.php
+++ b/lib/recurly/resources/plan_hosted_pages.php
@@ -17,8 +17,8 @@ class PlanHostedPages extends RecurlyResource
     private $_display_quantity;
     private $_success_url;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/plan_mini.php
+++ b/lib/recurly/resources/plan_mini.php
@@ -17,8 +17,8 @@ class PlanMini extends RecurlyResource
     private $_name;
     private $_object;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/plan_pricing.php
+++ b/lib/recurly/resources/plan_pricing.php
@@ -16,8 +16,8 @@ class PlanPricing extends RecurlyResource
     private $_setup_fee;
     private $_unit_amount;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/pricing.php
+++ b/lib/recurly/resources/pricing.php
@@ -15,8 +15,8 @@ class Pricing extends RecurlyResource
     private $_currency;
     private $_unit_amount;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/settings.php
+++ b/lib/recurly/resources/settings.php
@@ -16,9 +16,9 @@ class Settings extends RecurlyResource
     private $_billing_address_requirement;
     private $_default_currency;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setAcceptedCurrencies' => 'string',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/shipping_address.php
+++ b/lib/recurly/resources/shipping_address.php
@@ -31,8 +31,8 @@ class ShippingAddress extends RecurlyResource
     private $_updated_at;
     private $_vat_number;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/shipping_method.php
+++ b/lib/recurly/resources/shipping_method.php
@@ -22,8 +22,8 @@ class ShippingMethod extends RecurlyResource
     private $_tax_code;
     private $_updated_at;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/shipping_method_mini.php
+++ b/lib/recurly/resources/shipping_method_mini.php
@@ -17,8 +17,8 @@ class ShippingMethodMini extends RecurlyResource
     private $_name;
     private $_object;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/site.php
+++ b/lib/recurly/resources/site.php
@@ -24,9 +24,9 @@ class Site extends RecurlyResource
     private $_subdomain;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setFeatures' => 'string',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -54,11 +54,11 @@ class Subscription extends RecurlyResource
     private $_updated_at;
     private $_uuid;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setAddOns' => '\Recurly\Resources\SubscriptionAddOn',
         'setCouponRedemptions' => '\Recurly\Resources\CouponRedemptionMini',
         'setCustomFields' => '\Recurly\Resources\CustomField',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/subscription_add_on.php
+++ b/lib/recurly/resources/subscription_add_on.php
@@ -26,9 +26,9 @@ class SubscriptionAddOn extends RecurlyResource
     private $_unit_amount;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setTiers' => '\Recurly\Resources\SubscriptionAddOnTier',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/subscription_add_on_tier.php
+++ b/lib/recurly/resources/subscription_add_on_tier.php
@@ -15,8 +15,8 @@ class SubscriptionAddOnTier extends RecurlyResource
     private $_ending_quantity;
     private $_unit_amount;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/subscription_change.php
+++ b/lib/recurly/resources/subscription_change.php
@@ -28,9 +28,9 @@ class SubscriptionChange extends RecurlyResource
     private $_unit_amount;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setAddOns' => '\Recurly\Resources\SubscriptionAddOn',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/subscription_change_preview.php
+++ b/lib/recurly/resources/subscription_change_preview.php
@@ -29,9 +29,9 @@ class SubscriptionChangePreview extends RecurlyResource
     private $_unit_amount;
     private $_updated_at;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setAddOns' => '\Recurly\Resources\SubscriptionAddOn',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/subscription_shipping.php
+++ b/lib/recurly/resources/subscription_shipping.php
@@ -17,8 +17,8 @@ class SubscriptionShipping extends RecurlyResource
     private $_method;
     private $_object;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/tax_info.php
+++ b/lib/recurly/resources/tax_info.php
@@ -16,8 +16,8 @@ class TaxInfo extends RecurlyResource
     private $_region;
     private $_type;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/tier.php
+++ b/lib/recurly/resources/tier.php
@@ -15,9 +15,9 @@ class Tier extends RecurlyResource
     private $_currencies;
     private $_ending_quantity;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setCurrencies' => '\Recurly\Resources\Pricing',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/transaction.php
+++ b/lib/recurly/resources/transaction.php
@@ -50,9 +50,9 @@ class Transaction extends RecurlyResource
     private $_voided_at;
     private $_voided_by_invoice;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setSubscriptionIds' => 'string',
-    );
+    ];
 
     
     /**

--- a/lib/recurly/resources/transaction_error.php
+++ b/lib/recurly/resources/transaction_error.php
@@ -20,8 +20,8 @@ class TransactionError extends RecurlyResource
     private $_three_d_secure_action_token_id;
     private $_transaction_id;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/transaction_payment_gateway.php
+++ b/lib/recurly/resources/transaction_payment_gateway.php
@@ -17,8 +17,8 @@ class TransactionPaymentGateway extends RecurlyResource
     private $_object;
     private $_type;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/unique_coupon_code.php
+++ b/lib/recurly/resources/unique_coupon_code.php
@@ -21,8 +21,8 @@ class UniqueCouponCode extends RecurlyResource
     private $_state;
     private $_updated_at;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/resources/user.php
+++ b/lib/recurly/resources/user.php
@@ -21,8 +21,8 @@ class User extends RecurlyResource
     private $_object;
     private $_time_zone;
 
-    protected static $array_hints = array(
-    );
+    protected static $array_hints = [
+    ];
 
     
     /**

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -72,7 +72,7 @@ class Response
     public function setHeaders(?array $headers): void
     {
         if (empty($headers)) {
-            $headers = array('HTTP/1.1 400 Bad request');
+            $headers = ['HTTP/1.1 400 Bad request'];
         }
 
         foreach ($headers as $header) {

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -7,13 +7,13 @@ use Recurly\Utils;
 
 final class BaseClientTest extends RecurlyTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new MockClient();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->client->clearScenarios();
     }

--- a/tests/Page_Test.php
+++ b/tests/Page_Test.php
@@ -5,7 +5,7 @@ use Recurly\Resources\TestResource;
 
 final class PageTest extends RecurlyTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -4,7 +4,7 @@ use Recurly\Pager;
 
 final class PagerTest extends RecurlyTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new MockClient();
@@ -17,18 +17,18 @@ final class PagerTest extends RecurlyTestCase
             }
             $json_string = $this->fixtures->loadJsonFixture($name, ['type' => 'string']);
             $response = new \Recurly\Response($json_string);
-            $response->setHeaders(array(
+            $response->setHeaders([
                 'HTTP/1.1 200 OK',
                 "Recurly-Total-Records: {$this->count}"
-            ));
+            ]);
             return $response->toResource();
         }));
         $client_stub->method('pagerCount')->will($this->returnCallback(function($name, $params) {
             $response = new \Recurly\Response('');
-            $response->setHeaders(array(
+            $response->setHeaders([
                 'HTTP/1.1 200 OK',
                 "Recurly-Total-Records: {$this->count}"
-            ));
+            ]);
             return $response;
         }));
 

--- a/tests/RecurlyError_Test.php
+++ b/tests/RecurlyError_Test.php
@@ -4,19 +4,19 @@ final class RecurlyErrorTest extends RecurlyTestCase
 {
     public function testFromResponseGenericJsonServerError(): void
     {
-        $data = array(
-            "error" => array(
+        $data = [
+            "error" => [
                 "object" => "error",
                 "type" => "unknown_type",
                 "message" => "The error message"
-            )
-        );
+            ]
+        ];
 
         $response = new \Recurly\Response(json_encode($data));
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 500 Internal Server Error',
             'Content-Type: application/json',
-        ));
+        ]);
         $result = \Recurly\RecurlyError::fromResponse($response);
         $this->assertEquals(
             \Recurly\Errors\ServerError::class,
@@ -26,19 +26,19 @@ final class RecurlyErrorTest extends RecurlyTestCase
 
     public function testFromResponseGenericJsonClientError(): void
     {
-        $data = array(
-            "error" => array(
+        $data = [
+            "error" => [
                 "object" => "error",
                 "type" => "unknown_type",
                 "message" => "The error message"
-            )
-        );
+            ]
+        ];
 
         $response = new \Recurly\Response(json_encode($data));
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 404 Not Found',
             'Content-Type: application/json',
-        ));
+        ]);
         $result = \Recurly\RecurlyError::fromResponse($response);
         $this->assertEquals(
             \Recurly\Errors\ClientError::class,
@@ -48,19 +48,19 @@ final class RecurlyErrorTest extends RecurlyTestCase
 
     public function testFromResponseGenericJsonError(): void
     {
-        $data = array(
-            "error" => array(
+        $data = [
+            "error" => [
                 "object" => "error",
                 "type" => "unknown_type",
                 "message" => "The error message"
-            )
-        );
+            ]
+        ];
 
         $response = new \Recurly\Response(json_encode($data));
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 100 Continue',
             'Content-Type: application/json',
-        ));
+        ]);
         $result = \Recurly\RecurlyError::fromResponse($response);
         $this->assertEquals(
             \Recurly\RecurlyError::class,
@@ -71,9 +71,9 @@ final class RecurlyErrorTest extends RecurlyTestCase
     public function testFromResponseForbiddenError(): void
     {
         $response = new \Recurly\Response('forbidden error');
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 403 Forbidden',
-        ));
+        ]);
         $result = \Recurly\RecurlyError::fromResponse($response);
         $this->assertEquals(
             \Recurly\Errors\Forbidden::class,
@@ -84,9 +84,9 @@ final class RecurlyErrorTest extends RecurlyTestCase
     public function testFromResponseUnknownError(): void
     {
         $response = new \Recurly\Response('what is this???');
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 100 Continue',
-        ));
+        ]);
         $result = \Recurly\RecurlyError::fromResponse($response);
         $this->assertEquals(
             \Recurly\RecurlyError::class,
@@ -96,19 +96,19 @@ final class RecurlyErrorTest extends RecurlyTestCase
 
     public function testApiErrorClass(): void
     {
-        $data = array(
-            "error" => array(
+        $data = [
+            "error" => [
                 "object" => "error",
                 "type" => "test_error",
                 "message" => "The error message"
-            )
-        );
+            ]
+        ];
 
         $response = new \Recurly\Response(json_encode($data));
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 500 Internal Server Error',
             'Content-Type: application/json'
-        ));
+        ]);
         $result = \Recurly\RecurlyError::fromResponse($response);
         $this->assertInstanceOf(
             \Recurly\Resources\ErrorMayHaveTransaction::class,

--- a/tests/RecurlyResource_Test.php
+++ b/tests/RecurlyResource_Test.php
@@ -15,23 +15,23 @@ final class RecurlyResourceTest extends RecurlyTestCase
 
     public function testFromJsonValidResource(): void
     {
-        $test_resource = (object)array(
+        $test_resource = (object)[
             "object" => "test_resource",
             "name" => "test-resource",
-            "single_child" => (object)array(
+            "single_child" => (object)[
                 "name" => "child-test-resource"
-            ),
+            ],
             "resource_array" => [
-                (object)array( "name" => "child-test-resource" )
+                (object)[ "name" => "child-test-resource" ]
             ],
             "string_array" => [
                 "string-one",
                 "string-two",
             ]
-        );
+        ];
 
         $response = new \Recurly\Response(json_encode($test_resource));
-        $response->setHeaders(array('HTTP/1.1 200 OK'));
+        $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
         $this->assertEquals($response, $result->getResponse());
@@ -40,14 +40,14 @@ final class RecurlyResourceTest extends RecurlyTestCase
 
     public function testFromJsonUnknownKeys(): void
     {
-        $test_resource = (object)array(
+        $test_resource = (object)[
             "object" => "test_resource",
             "name" => "test-resource",
             "unknown_key" => "unknown-key"
-        );
+        ];
 
         $response = new \Recurly\Response(json_encode($test_resource));
-        $response->setHeaders(array('HTTP/1.1 200 OK'));
+        $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
     }
@@ -98,12 +98,12 @@ final class RecurlyResourceTest extends RecurlyTestCase
 
     public function testFromJsonList(): void
     {
-        $data = (object)array(
+        $data = (object)[
             'object' => 'list'
-        );
+        ];
 
         $response = new \Recurly\Response(json_encode($data));
-        $response->setHeaders(array('HTTP/1.1 200 OK'));
+        $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Page::class, $result);
     }
@@ -113,7 +113,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
         $data = 'binary file data';
 
         $response = new \Recurly\Response(json_encode($data));
-        $response->setHeaders(array('HTTP/1.1 200 OK'));
+        $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromBinary($data, $response);
         $this->assertInstanceOf(\Recurly\Resources\BinaryFile::class, $result);
         $this->assertEquals($response, $result->getResponse());
@@ -122,7 +122,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
     public function testFromEmpty(): void
     {
         $response = new \Recurly\Response('');
-        $response->setHeaders(array('HTTP/1.1 200 OK'));
+        $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromEmpty($response);
         $this->assertInstanceOf(\Recurly\EmptyResource::class, $result);
         $this->assertEquals($response, $result->getResponse());

--- a/tests/Request_Test.php
+++ b/tests/Request_Test.php
@@ -4,7 +4,7 @@ use Recurly\Request;
 
 final class RequestTest extends RecurlyTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $account_create = $this->fixtures->loadJsonFixture('account_create', ['type' => 'array']);

--- a/tests/Response_Test.php
+++ b/tests/Response_Test.php
@@ -20,10 +20,10 @@ final class ResponseTest extends TestCase
         $response = new Response('');
         $status_code = 201;
         $status = "HTTP/1.1 {$status_code} Created";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             $status
-        ));
+        ]);
         $this->assertEquals(
             $status_code,
             $response->getStatusCode()
@@ -34,10 +34,10 @@ final class ResponseTest extends TestCase
     {
         $response = new Response('');
         $request_id = bin2hex(random_bytes(10));
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "X-Request-Id: {$request_id}"
-        ));
+        ]);
         $this->assertEquals(
             $request_id,
             $response->getRequestId()
@@ -48,10 +48,10 @@ final class ResponseTest extends TestCase
     {
         $response = new Response('');
         $rate_limit = "2000";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "X-RateLimit-Limit: {$rate_limit}"
-        ));
+        ]);
         $this->assertEquals(
             $rate_limit,
             $response->getRateLimit()
@@ -62,10 +62,10 @@ final class ResponseTest extends TestCase
     {
         $response = new Response('');
         $rate_limit_remaining = "300";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "X-RateLimit-Remaining: {$rate_limit_remaining}"
-        ));
+        ]);
         $this->assertEquals(
             $rate_limit_remaining,
             $response->getRateLimitRemaining()
@@ -76,10 +76,10 @@ final class ResponseTest extends TestCase
     {
         $response = new Response('');
         $rate_limit_reset = "1576791240";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "X-RateLimit-Reset: {$rate_limit_reset}"
-        ));
+        ]);
         $this->assertEquals(
             $rate_limit_reset,
             $response->getRateLimitReset()
@@ -90,10 +90,10 @@ final class ResponseTest extends TestCase
     {
         $response = new Response('');
         $content_type = "application/json";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "Content-Type: {$content_type}"
-        ));
+        ]);
         $this->assertEquals(
             $content_type,
             $response->getContentType()
@@ -105,10 +105,10 @@ final class ResponseTest extends TestCase
         $response = new Response('');
         $content_type = "application/json";
         $charset = "charset=utf-8";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "Content-Type: {$content_type}; {$charset}"
-        ));
+        ]);
         $this->assertEquals(
             $content_type,
             $response->getContentType()
@@ -119,10 +119,10 @@ final class ResponseTest extends TestCase
     {
         $count = 325;
         $response = new Response('');
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "Recurly-Total-Records: $count"
-        ));
+        ]);
         $this->assertEquals(
             $count,
             $response->getRecordCount()
@@ -135,28 +135,28 @@ final class ResponseTest extends TestCase
 
         $response = new Response($data);
         $content_type = "application/pdf";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "Content-Type: {$content_type}"
-        ));
+        ]);
         $result = $response->toResource();
         $this->assertInstanceOf(\Recurly\Resources\BinaryFile::class, $result);
     }
 
     public function testToResourceJson(): void
     {
-        $account = (object)array(
+        $account = (object)[
             'object' => 'account',
             'first_name' => 'Douglas',
             'last_name' => 'DuMonde'
-        );
+        ];
 
         $response = new Response(json_encode($account));
         $content_type = "application/json";
-        $response->setHeaders(array(
+        $response->setHeaders([
             'HTTP/1.1 200 OK',
             "Content-Type: {$content_type}"
-        ));
+        ]);
         $result = $response->toResource();
         $this->assertInstanceOf(\Recurly\Resources\Account::class, $result);
     }
@@ -164,7 +164,7 @@ final class ResponseTest extends TestCase
     public function testToResourceEmpty(): void
     {
         $response = new Response('');
-        $response->setHeaders(array('HTTP/1.1 200 OK'));
+        $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = $response->toResource();
         $this->assertInstanceOf(\Recurly\EmptyResource::class, $result);
     }
@@ -173,7 +173,7 @@ final class ResponseTest extends TestCase
     {
         $this->expectException(\Recurly\RecurlyError::class);
         $response = new Response('');
-        $response->setHeaders(array('HTTP/1.1 403 Forbidden'));
+        $response->setHeaders(['HTTP/1.1 403 Forbidden']);
         $result = $response->toResource();
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,9 +12,9 @@ abstract class RecurlyTestCase extends TestCase
 
 class FixtureLoader
 {
-    const DEFAULT_OPTIONS = array(
+    const DEFAULT_OPTIONS = [
         'type' => 'object'
-    );
+    ];
 
     public function loadJsonFixture(string $filename, array $options = [])
     {

--- a/tests/mock_client.php
+++ b/tests/mock_client.php
@@ -60,7 +60,7 @@ class MockClient extends BaseClient
             $url,
             $body,
             self::_expectedHeaders()
-            )->willReturn(array($result, $resp_header));
+            )->willReturn([$result, $resp_header]);
     }
 
     public function clearScenarios(): void

--- a/tests/recurly/resources/test_resource.php
+++ b/tests/recurly/resources/test_resource.php
@@ -11,10 +11,10 @@ class TestResource extends \Recurly\RecurlyResource
     private $_resource_array;
     private $_string_array;
 
-    protected static $array_hints = array(
+    protected static $array_hints = [
         'setResourceArray' => '\Recurly\Resources\TestResource',
         'setStringArray' => 'string',
-    );
+    ];
 
     public function getId(): string
     {


### PR DESCRIPTION
# Changed log
- According to [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` and `protected tearDown(): void` methods.
- Sine this package requires PHP `7.2+` versions at least, it's time to replace `array`  syntax with short array syntax now :).