### PR TITLE
BECS support

### DIFF
--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -11,6 +11,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
       array('GET', '/accounts/bankaccount1234567890/billing_info', 'billing_info/show-bank-account-200.xml'),
       array('GET', '/accounts/sepa1234567890/billing_info', 'billing_info/show-sepa-200.xml'),
       array('GET', '/accounts/bacs1234567890/billing_info', 'billing_info/show-bacs-200.xml'),
+      array('GET', '/accounts/becs1234567890/billing_info', 'billing_info/show-becs-200.xml'),
       array('PUT', '/accounts/abcdef1234567890/billing_info', 'billing_info/show-200.xml'),
       array('DELETE', '/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
       array('DELETE', 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info', 'billing_info/destroy-204.xml'),
@@ -89,6 +90,13 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
     $this->assertEquals($billing_info->sort_code, '200000');
     $this->assertEquals($billing_info->name_on_account, 'BACS');
+  }
+
+  public function testGetBecsBillingInfo() {
+    $billing_info = Recurly_BillingInfo::get('becs1234567890', $this->client);
+    $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
+    $this->assertEquals($billing_info->bsb_code, '082-082');
+    $this->assertEquals($billing_info->name_on_account, 'BECS');
   }
 
   public function testDelete() {

--- a/Tests/fixtures/billing_info/show-becs-200.xml
+++ b/Tests/fixtures/billing_info/show-becs-200.xml
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<billing_info href="https://api.recurly.com/v2/accounts/becs1234567890/billing_info" type="becs">
+  <account href="https://api.recurly.com/v2/accounts/becs1234567890"/>
+  <company nil="nil"></company>
+  <address1>123 Fake St.</address1>
+  <address2 nil="nil"></address2>
+  <city>Adelaide</city>
+  <state></state>
+  <zip>123456</zip>
+  <country>AU</country>
+  <phone nil="nil"></phone>
+  <bsb_code>082-082</bsb_code>
+  <last_two>78</last_two>
+  <name_on_account>BECS</name_on_account>
+</billing_info>

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -39,8 +39,9 @@
  * @property string $card_type Visa, MasterCard, American Express, Discover, JCB, etc
  * @property-write string $three_d_secure_action_result_token_id An id returned by Recurly.js referencing the result of the 3DS authentication for PSD2
  * @property string $iban International bank account number developed to identify an overseas bank account
- * @property string $type The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+ * @property string $type The payment method type for a non-credit card based billing info. `bacs` and `becs` are the only accepted values
  * @property string $sort_code Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
+ * @property string $bsb_code Bank identifier code for AU based banks. Required for Becs based billing infos.
  */
 class Recurly_BillingInfo extends Recurly_Resource
 {
@@ -109,7 +110,7 @@ class Recurly_BillingInfo extends Recurly_Resource
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id', 'external_hpp_type', 'gateway_token', 'gateway_code',
       'braintree_payment_nonce', 'roku_billing_agreement_id',
-      'three_d_secure_action_result_token_id', 'transaction_type', 'iban', 'sort_code', 'type'
+      'three_d_secure_action_result_token_id', 'transaction_type', 'iban', 'sort_code', 'bsb_code', 'type'
     );
   }
 }


### PR DESCRIPTION
Completed:

- Added `bsb_code` field
- Included test

Affects the following endpoints:
- `PUT /v2/accounts/{account_id}/billing_info`
- `PUT /v2/accounts/{account_id}`
- `POST /v2/accounts`
- `POST /v2/purchases`
- `POST /v2/purchases/preview`
- `POST /v2/subscriptions`

To create billing_info with BECS:
```php
$billingInfo = new Recurly_BillingInfo();
$billingInfo->account_code       = $accountCode;
$billingInfo->address1           = '123 Paper Street';
$billingInfo->city               = 'Adelaide';
$billingInfo->zip                = 'W1K 6AH';
$billingInfo->country            = 'AU';
$billingInfo->phone              = '213-555-5555';
$billingInfo->name_on_account    = 'BECS account name';
$billingInfo->account_number     = '11223311';
$billingInfo->bsb_code           = '082-082';
$billingInfo->type               = 'becs';
$billingInfo->create();
```