### PR TITLE
Updating operations to accept generic request options instead of just query parameters

### DIFF
--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -10,7 +10,6 @@ abstract class BaseClient
     private $_api_key;
     protected $http;
     private const ALLOWED_OPTIONS = [
-        'body',
         'params',
         'headers'
     ];

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -72,7 +72,7 @@ abstract class BaseClient
         list($result, $response_header) = $this->http->execute($method, $url, $formattedBody, $headers);
 
         // TODO: The $request should be added to the $response
-        $response = new \Recurly\Response($result);
+        $response = new \Recurly\Response($result, $request);
         $response->setHeaders($response_header);
 
         return $response;

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -23,9 +23,11 @@ class Client extends BaseClient
     /**
      * List sites
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -36,14 +38,12 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'state' (string): Filter by state.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['state'] (string): Filter by state.
      *
      * @return \Recurly\Pager A list of sites.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_sites
@@ -58,22 +58,25 @@ class Client extends BaseClient
      * Fetch a site
      *
      * @param string $site_id Site ID or subdomain. For ID no prefix is used e.g. `e28zov4fw0v2`. For subdomain use prefix `subdomain-`, e.g. `subdomain-recurly`.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Site A site.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_site
      */
-    public function getSite(string $site_id): \Recurly\Resources\Site
+    public function getSite(string $site_id, array $options = []): \Recurly\Resources\Site
     {
         $path = $this->interpolatePath("/sites/{site_id}", ['site_id' => $site_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * List a site's accounts
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -84,21 +87,19 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'email' (string): Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-     * 'subscriber' (bool): Filter for accounts with or without a subscription in the `active`,
+     * - $options['params']['email'] (string): Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+     * - $options['params']['subscriber'] (bool): Filter for accounts with or without a subscription in the `active`,
      *        `canceled`, or `future` state.
-     * 'past_due' (string): Filter for accounts with an invoice in the `past_due` state.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['past_due'] (string): Filter for accounts with an invoice in the `past_due` state.
      *
      * @return \Recurly\Pager A list of the site's accounts.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_accounts
@@ -112,29 +113,31 @@ class Client extends BaseClient
     /**
      * Create an account
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Account An account.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_account
      */
-    public function createAccount(array $body): \Recurly\Resources\Account
+    public function createAccount(array $body, array $options = []): \Recurly\Resources\Account
     {
         $path = $this->interpolatePath("/accounts", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Fetch an account
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Account An account.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_account
      */
-    public function getAccount(string $account_id): \Recurly\Resources\Account
+    public function getAccount(string $account_id, array $options = []): \Recurly\Resources\Account
     {
         $path = $this->interpolatePath("/accounts/{account_id}", ['account_id' => $account_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -142,42 +145,45 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Account An account.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_account
      */
-    public function updateAccount(string $account_id, array $body): \Recurly\Resources\Account
+    public function updateAccount(string $account_id, array $body, array $options = []): \Recurly\Resources\Account
     {
         $path = $this->interpolatePath("/accounts/{account_id}", ['account_id' => $account_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Deactivate an account
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Account An account.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/deactivate_account
      */
-    public function deactivateAccount(string $account_id): \Recurly\Resources\Account
+    public function deactivateAccount(string $account_id, array $options = []): \Recurly\Resources\Account
     {
         $path = $this->interpolatePath("/accounts/{account_id}", ['account_id' => $account_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * Fetch an account's acquisition data
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\AccountAcquisition An account's acquisition data.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_account_acquisition
      */
-    public function getAccountAcquisition(string $account_id): \Recurly\Resources\AccountAcquisition
+    public function getAccountAcquisition(string $account_id, array $options = []): \Recurly\Resources\AccountAcquisition
     {
         $path = $this->interpolatePath("/accounts/{account_id}/acquisition", ['account_id' => $account_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -185,70 +191,75 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\AccountAcquisition An account's updated acquisition data.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_account_acquisition
      */
-    public function updateAccountAcquisition(string $account_id, array $body): \Recurly\Resources\AccountAcquisition
+    public function updateAccountAcquisition(string $account_id, array $body, array $options = []): \Recurly\Resources\AccountAcquisition
     {
         $path = $this->interpolatePath("/accounts/{account_id}/acquisition", ['account_id' => $account_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Remove an account's acquisition data
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\EmptyResource Acquisition data was succesfully deleted.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_account_acquisition
      */
-    public function removeAccountAcquisition(string $account_id): \Recurly\EmptyResource
+    public function removeAccountAcquisition(string $account_id, array $options = []): \Recurly\EmptyResource
     {
         $path = $this->interpolatePath("/accounts/{account_id}/acquisition", ['account_id' => $account_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * Reactivate an inactive account
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Account An account.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/reactivate_account
      */
-    public function reactivateAccount(string $account_id): \Recurly\Resources\Account
+    public function reactivateAccount(string $account_id, array $options = []): \Recurly\Resources\Account
     {
         $path = $this->interpolatePath("/accounts/{account_id}/reactivate", ['account_id' => $account_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * Fetch an account's balance and past due status
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\AccountBalance An account's balance.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_account_balance
      */
-    public function getAccountBalance(string $account_id): \Recurly\Resources\AccountBalance
+    public function getAccountBalance(string $account_id, array $options = []): \Recurly\Resources\AccountBalance
     {
         $path = $this->interpolatePath("/accounts/{account_id}/balance", ['account_id' => $account_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * Fetch an account's billing information
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\BillingInfo An account's billing information.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_billing_info
      */
-    public function getBillingInfo(string $account_id): \Recurly\Resources\BillingInfo
+    public function getBillingInfo(string $account_id, array $options = []): \Recurly\Resources\BillingInfo
     {
         $path = $this->interpolatePath("/accounts/{account_id}/billing_info", ['account_id' => $account_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -256,36 +267,41 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\BillingInfo Updated billing information.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_billing_info
      */
-    public function updateBillingInfo(string $account_id, array $body): \Recurly\Resources\BillingInfo
+    public function updateBillingInfo(string $account_id, array $body, array $options = []): \Recurly\Resources\BillingInfo
     {
         $path = $this->interpolatePath("/accounts/{account_id}/billing_info", ['account_id' => $account_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Remove an account's billing information
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\EmptyResource Billing information deleted
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_billing_info
      */
-    public function removeBillingInfo(string $account_id): \Recurly\EmptyResource
+    public function removeBillingInfo(string $account_id, array $options = []): \Recurly\EmptyResource
     {
         $path = $this->interpolatePath("/accounts/{account_id}/billing_info", ['account_id' => $account_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * Show the coupon redemptions for an account
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -296,16 +312,13 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the the coupon redemptions on an account.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_coupon_redemptions
@@ -320,14 +333,15 @@ class Client extends BaseClient
      * Show the coupon redemption that is active on an account
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\CouponRedemption An active coupon redemption on an account.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_active_coupon_redemption
      */
-    public function getActiveCouponRedemption(string $account_id): \Recurly\Resources\CouponRedemption
+    public function getActiveCouponRedemption(string $account_id, array $options = []): \Recurly\Resources\CouponRedemption
     {
         $path = $this->interpolatePath("/accounts/{account_id}/coupon_redemptions/active", ['account_id' => $account_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -335,47 +349,49 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\CouponRedemption Returns the new coupon redemption.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_coupon_redemption
      */
-    public function createCouponRedemption(string $account_id, array $body): \Recurly\Resources\CouponRedemption
+    public function createCouponRedemption(string $account_id, array $body, array $options = []): \Recurly\Resources\CouponRedemption
     {
         $path = $this->interpolatePath("/accounts/{account_id}/coupon_redemptions/active", ['account_id' => $account_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Delete the active coupon redemption from an account
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\CouponRedemption Coupon redemption deleted.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_coupon_redemption
      */
-    public function removeCouponRedemption(string $account_id): \Recurly\Resources\CouponRedemption
+    public function removeCouponRedemption(string $account_id, array $options = []): \Recurly\Resources\CouponRedemption
     {
         $path = $this->interpolatePath("/accounts/{account_id}/coupon_redemptions/active", ['account_id' => $account_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * List an account's credit payments
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the account's credit payments.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_credit_payments
@@ -389,9 +405,12 @@ class Client extends BaseClient
     /**
      * List an account's invoices
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -402,23 +421,20 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'type' (string): Filter by type when:
+     * - $options['params']['type'] (string): Filter by type when:
      *        - `type=charge`, only charge invoices will be returned.
      *        - `type=credit`, only credit invoices will be returned.
      *        - `type=non-legacy`, only charge and credit invoices will be returned.
      *        - `type=legacy`, only legacy invoices will be returned.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the account's invoices.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_invoices
@@ -434,14 +450,15 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\InvoiceCollection Returns the new invoices.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_invoice
      */
-    public function createInvoice(string $account_id, array $body): \Recurly\Resources\InvoiceCollection
+    public function createInvoice(string $account_id, array $body, array $options = []): \Recurly\Resources\InvoiceCollection
     {
         $path = $this->interpolatePath("/accounts/{account_id}/invoices", ['account_id' => $account_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
@@ -449,22 +466,26 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\InvoiceCollection Returns the invoice previews.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/preview_invoice
      */
-    public function previewInvoice(string $account_id, array $body): \Recurly\Resources\InvoiceCollection
+    public function previewInvoice(string $account_id, array $body, array $options = []): \Recurly\Resources\InvoiceCollection
     {
         $path = $this->interpolatePath("/accounts/{account_id}/invoices/preview", ['account_id' => $account_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * List an account's line items
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -475,21 +496,18 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'original' (string): Filter by original field.
-     * 'state' (string): Filter by state field.
-     * 'type' (string): Filter by type field.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
+     * - $options['params']['original'] (string): Filter by original field.
+     * - $options['params']['state'] (string): Filter by state field.
+     * - $options['params']['type'] (string): Filter by type field.
      *
      * @return \Recurly\Pager A list of the account's line items.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_line_items
@@ -505,22 +523,26 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\LineItem Returns the new line item.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_line_item
      */
-    public function createLineItem(string $account_id, array $body): \Recurly\Resources\LineItem
+    public function createLineItem(string $account_id, array $body, array $options = []): \Recurly\Resources\LineItem
     {
         $path = $this->interpolatePath("/accounts/{account_id}/line_items", ['account_id' => $account_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Fetch a list of an account's notes
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -531,9 +553,6 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of an account's notes.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_notes
@@ -549,22 +568,26 @@ class Client extends BaseClient
      *
      * @param string $account_id      Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param string $account_note_id Account Note ID.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\AccountNote An account note.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_account_note
      */
-    public function getAccountNote(string $account_id, string $account_note_id): \Recurly\Resources\AccountNote
+    public function getAccountNote(string $account_id, string $account_note_id, array $options = []): \Recurly\Resources\AccountNote
     {
         $path = $this->interpolatePath("/accounts/{account_id}/notes/{account_note_id}", ['account_id' => $account_id, 'account_note_id' => $account_note_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * Fetch a list of an account's shipping addresses
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -575,18 +598,15 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of an account's shipping addresses.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_shipping_addresses
@@ -602,14 +622,15 @@ class Client extends BaseClient
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\ShippingAddress Returns the new shipping address.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_shipping_address
      */
-    public function createShippingAddress(string $account_id, array $body): \Recurly\Resources\ShippingAddress
+    public function createShippingAddress(string $account_id, array $body, array $options = []): \Recurly\Resources\ShippingAddress
     {
         $path = $this->interpolatePath("/accounts/{account_id}/shipping_addresses", ['account_id' => $account_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
@@ -617,14 +638,15 @@ class Client extends BaseClient
      *
      * @param string $account_id          Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param string $shipping_address_id Shipping Address ID.
+     * @param array  $options             Associative array of optional parameters
      *
      * @return \Recurly\Resources\ShippingAddress A shipping address.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_shipping_address
      */
-    public function getShippingAddress(string $account_id, string $shipping_address_id): \Recurly\Resources\ShippingAddress
+    public function getShippingAddress(string $account_id, string $shipping_address_id, array $options = []): \Recurly\Resources\ShippingAddress
     {
         $path = $this->interpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", ['account_id' => $account_id, 'shipping_address_id' => $shipping_address_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -633,14 +655,15 @@ class Client extends BaseClient
      * @param string $account_id          Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param string $shipping_address_id Shipping Address ID.
      * @param array  $body                The body of the request.
+     * @param array  $options             Associative array of optional parameters
      *
      * @return \Recurly\Resources\ShippingAddress The updated shipping address.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_shipping_address
      */
-    public function updateShippingAddress(string $account_id, string $shipping_address_id, array $body): \Recurly\Resources\ShippingAddress
+    public function updateShippingAddress(string $account_id, string $shipping_address_id, array $body, array $options = []): \Recurly\Resources\ShippingAddress
     {
         $path = $this->interpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", ['account_id' => $account_id, 'shipping_address_id' => $shipping_address_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
@@ -648,22 +671,26 @@ class Client extends BaseClient
      *
      * @param string $account_id          Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
      * @param string $shipping_address_id Shipping Address ID.
+     * @param array  $options             Associative array of optional parameters
      *
      * @return \Recurly\EmptyResource Shipping address deleted.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_shipping_address
      */
-    public function removeShippingAddress(string $account_id, string $shipping_address_id): \Recurly\EmptyResource
+    public function removeShippingAddress(string $account_id, string $shipping_address_id, array $options = []): \Recurly\EmptyResource
     {
         $path = $this->interpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", ['account_id' => $account_id, 'shipping_address_id' => $shipping_address_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * List an account's subscriptions
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -674,23 +701,20 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'state' (string): Filter by state.
+     * - $options['params']['state'] (string): Filter by state.
      *        
      *        - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
      *        - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
      *        - When `state=live`, only subscriptions that are in an active, canceled, or future state or are in trial will be returned.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the account's subscriptions.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_subscriptions
@@ -704,9 +728,12 @@ class Client extends BaseClient
     /**
      * List an account's transactions
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -717,20 +744,17 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'type' (string): Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-     * 'success' (string): Filter by success field.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
+     * - $options['params']['type'] (string): Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+     * - $options['params']['success'] (string): Filter by success field.
      *
      * @return \Recurly\Pager A list of the account's transactions.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_transactions
@@ -744,9 +768,12 @@ class Client extends BaseClient
     /**
      * List an account's child accounts
      *
-     * Supported optional parameters:
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -757,22 +784,19 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'email' (string): Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-     * 'subscriber' (bool): Filter for accounts with or without a subscription in the `active`,
+     * - $options['params']['email'] (string): Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+     * - $options['params']['subscriber'] (bool): Filter for accounts with or without a subscription in the `active`,
      *        `canceled`, or `future` state.
-     * 'past_due' (string): Filter for accounts with an invoice in the `past_due` state.
-     *
-     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-     * @param array  $options    Associative array of optional parameters:
+     * - $options['params']['past_due'] (string): Filter for accounts with an invoice in the `past_due` state.
      *
      * @return \Recurly\Pager A list of an account's child accounts.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_child_accounts
@@ -786,9 +810,11 @@ class Client extends BaseClient
     /**
      * List a site's account acquisition data
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -799,17 +825,15 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param array $options Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the site's account acquisition data.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_account_acquisition
@@ -823,9 +847,11 @@ class Client extends BaseClient
     /**
      * List a site's coupons
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -836,17 +862,15 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param array $options Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the site's coupons.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_coupons
@@ -860,29 +884,31 @@ class Client extends BaseClient
     /**
      * Create a new coupon
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Coupon A new coupon.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_coupon
      */
-    public function createCoupon(array $body): \Recurly\Resources\Coupon
+    public function createCoupon(array $body, array $options = []): \Recurly\Resources\Coupon
     {
         $path = $this->interpolatePath("/coupons", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Fetch a coupon
      *
      * @param string $coupon_id Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+     * @param array  $options   Associative array of optional parameters
      *
      * @return \Recurly\Resources\Coupon A coupon.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_coupon
      */
-    public function getCoupon(string $coupon_id): \Recurly\Resources\Coupon
+    public function getCoupon(string $coupon_id, array $options = []): \Recurly\Resources\Coupon
     {
         $path = $this->interpolatePath("/coupons/{coupon_id}", ['coupon_id' => $coupon_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -890,36 +916,41 @@ class Client extends BaseClient
      *
      * @param string $coupon_id Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
      * @param array  $body      The body of the request.
+     * @param array  $options   Associative array of optional parameters
      *
      * @return \Recurly\Resources\Coupon The updated coupon.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_coupon
      */
-    public function updateCoupon(string $coupon_id, array $body): \Recurly\Resources\Coupon
+    public function updateCoupon(string $coupon_id, array $body, array $options = []): \Recurly\Resources\Coupon
     {
         $path = $this->interpolatePath("/coupons/{coupon_id}", ['coupon_id' => $coupon_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Expire a coupon
      *
      * @param string $coupon_id Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+     * @param array  $options   Associative array of optional parameters
      *
      * @return \Recurly\Resources\Coupon The expired Coupon
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/deactivate_coupon
      */
-    public function deactivateCoupon(string $coupon_id): \Recurly\Resources\Coupon
+    public function deactivateCoupon(string $coupon_id, array $options = []): \Recurly\Resources\Coupon
     {
         $path = $this->interpolatePath("/coupons/{coupon_id}", ['coupon_id' => $coupon_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * List unique coupon codes associated with a bulk coupon
      *
-     * Supported optional parameters:
+     * @param string $coupon_id Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+     * @param array  $options   Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -930,18 +961,15 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param string $coupon_id Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-     * @param array  $options   Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of unique coupon codes that were generated
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_unique_coupon_codes
@@ -955,19 +983,19 @@ class Client extends BaseClient
     /**
      * List a site's credit payments
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param array $options Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the site's credit payments.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_credit_payments
@@ -982,22 +1010,25 @@ class Client extends BaseClient
      * Fetch a credit payment
      *
      * @param string $credit_payment_id Credit Payment ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options           Associative array of optional parameters
      *
      * @return \Recurly\Resources\CreditPayment A credit payment.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_credit_payment
      */
-    public function getCreditPayment(string $credit_payment_id): \Recurly\Resources\CreditPayment
+    public function getCreditPayment(string $credit_payment_id, array $options = []): \Recurly\Resources\CreditPayment
     {
         $path = $this->interpolatePath("/credit_payments/{credit_payment_id}", ['credit_payment_id' => $credit_payment_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * List a site's custom field definitions
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1008,18 +1039,16 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'related_type' (string): Filter by related type.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['related_type'] (string): Filter by related type.
      *
      * @return \Recurly\Pager A list of the site's custom field definitions.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_custom_field_definitions
@@ -1034,22 +1063,25 @@ class Client extends BaseClient
      * Fetch an custom field definition
      *
      * @param string $custom_field_definition_id Custom Field Definition ID
+     * @param array  $options                    Associative array of optional parameters
      *
      * @return \Recurly\Resources\CustomFieldDefinition An custom field definition.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_custom_field_definition
      */
-    public function getCustomFieldDefinition(string $custom_field_definition_id): \Recurly\Resources\CustomFieldDefinition
+    public function getCustomFieldDefinition(string $custom_field_definition_id, array $options = []): \Recurly\Resources\CustomFieldDefinition
     {
         $path = $this->interpolatePath("/custom_field_definitions/{custom_field_definition_id}", ['custom_field_definition_id' => $custom_field_definition_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * List a site's items
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1060,18 +1092,16 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'state' (string): Filter by state.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['state'] (string): Filter by state.
      *
      * @return \Recurly\Pager A list of the site's items.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_items
@@ -1085,29 +1115,31 @@ class Client extends BaseClient
     /**
      * Create a new item
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Item A new item.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_item
      */
-    public function createItem(array $body): \Recurly\Resources\Item
+    public function createItem(array $body, array $options = []): \Recurly\Resources\Item
     {
         $path = $this->interpolatePath("/items", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Fetch an item
      *
      * @param string $item_id Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Item An item.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_item
      */
-    public function getItem(string $item_id): \Recurly\Resources\Item
+    public function getItem(string $item_id, array $options = []): \Recurly\Resources\Item
     {
         $path = $this->interpolatePath("/items/{item_id}", ['item_id' => $item_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -1115,50 +1147,55 @@ class Client extends BaseClient
      *
      * @param string $item_id Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
      * @param array  $body    The body of the request.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Item The updated item.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_item
      */
-    public function updateItem(string $item_id, array $body): \Recurly\Resources\Item
+    public function updateItem(string $item_id, array $body, array $options = []): \Recurly\Resources\Item
     {
         $path = $this->interpolatePath("/items/{item_id}", ['item_id' => $item_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Deactivate an item
      *
      * @param string $item_id Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Item An item.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/deactivate_item
      */
-    public function deactivateItem(string $item_id): \Recurly\Resources\Item
+    public function deactivateItem(string $item_id, array $options = []): \Recurly\Resources\Item
     {
         $path = $this->interpolatePath("/items/{item_id}", ['item_id' => $item_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * Reactivate an inactive item
      *
      * @param string $item_id Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Item An item.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/reactivate_item
      */
-    public function reactivateItem(string $item_id): \Recurly\Resources\Item
+    public function reactivateItem(string $item_id, array $options = []): \Recurly\Resources\Item
     {
         $path = $this->interpolatePath("/items/{item_id}/reactivate", ['item_id' => $item_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * List a site's invoices
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1169,22 +1206,20 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'type' (string): Filter by type when:
+     * - $options['params']['type'] (string): Filter by type when:
      *        - `type=charge`, only charge invoices will be returned.
      *        - `type=credit`, only credit invoices will be returned.
      *        - `type=non-legacy`, only charge and credit invoices will be returned.
      *        - `type=legacy`, only legacy invoices will be returned.
-     *
-     * @param array $options Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the site's invoices.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_invoices
@@ -1199,14 +1234,15 @@ class Client extends BaseClient
      * Fetch an invoice
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice An invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_invoice
      */
-    public function getInvoice(string $invoice_id): \Recurly\Resources\Invoice
+    public function getInvoice(string $invoice_id, array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -1214,28 +1250,30 @@ class Client extends BaseClient
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice An invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/put_invoice
      */
-    public function putInvoice(string $invoice_id, array $body): \Recurly\Resources\Invoice
+    public function putInvoice(string $invoice_id, array $body, array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Fetch an invoice as a PDF
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\BinaryFile An invoice as a PDF.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_invoice_pdf
      */
-    public function getInvoicePdf(string $invoice_id): \Recurly\Resources\BinaryFile
+    public function getInvoicePdf(string $invoice_id, array $options = []): \Recurly\Resources\BinaryFile
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}.pdf", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -1243,70 +1281,75 @@ class Client extends BaseClient
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice The updated invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/collect_invoice
      */
-    public function collectInvoice(string $invoice_id, array $body = []): \Recurly\Resources\Invoice
+    public function collectInvoice(string $invoice_id, array $body = [], array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/collect", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Mark an open invoice as failed
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice The updated invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/fail_invoice
      */
-    public function failInvoice(string $invoice_id): \Recurly\Resources\Invoice
+    public function failInvoice(string $invoice_id, array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/mark_failed", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * Mark an open invoice as successful
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice The updated invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/mark_invoice_successful
      */
-    public function markInvoiceSuccessful(string $invoice_id): \Recurly\Resources\Invoice
+    public function markInvoiceSuccessful(string $invoice_id, array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/mark_successful", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * Reopen a closed, manual invoice
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice The updated invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/reopen_invoice
      */
-    public function reopenInvoice(string $invoice_id): \Recurly\Resources\Invoice
+    public function reopenInvoice(string $invoice_id, array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/reopen", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * Void a credit invoice.
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice The updated invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/void_invoice
      */
-    public function voidInvoice(string $invoice_id): \Recurly\Resources\Invoice
+    public function voidInvoice(string $invoice_id, array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/void", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
@@ -1314,22 +1357,26 @@ class Client extends BaseClient
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Transaction The recorded transaction.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/record_external_transaction
      */
-    public function recordExternalTransaction(string $invoice_id, array $body): \Recurly\Resources\Transaction
+    public function recordExternalTransaction(string $invoice_id, array $body, array $options = []): \Recurly\Resources\Transaction
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/transactions", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * List an invoice's line items
      *
-     * Supported optional parameters:
+     * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1340,21 +1387,18 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'original' (string): Filter by original field.
-     * 'state' (string): Filter by state field.
-     * 'type' (string): Filter by type field.
-     *
-     * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-     * @param array  $options    Associative array of optional parameters:
+     * - $options['params']['original'] (string): Filter by original field.
+     * - $options['params']['state'] (string): Filter by state field.
+     * - $options['params']['type'] (string): Filter by type field.
      *
      * @return \Recurly\Pager A list of the invoice's line items.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_invoice_line_items
@@ -1368,9 +1412,12 @@ class Client extends BaseClient
     /**
      * Show the coupon redemptions applied to an invoice
      *
-     * Supported optional parameters:
+     * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1381,16 +1428,13 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-     * @param array  $options    Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the the coupon redemptions associated with the invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_invoice_coupon_redemptions
@@ -1405,14 +1449,15 @@ class Client extends BaseClient
      * List an invoice's related credit or charge invoices
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Pager A list of the credit or charge invoices associated with the invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_related_invoices
      */
-    public function listRelatedInvoices(string $invoice_id): \Recurly\Pager
+    public function listRelatedInvoices(string $invoice_id, array $options = []): \Recurly\Pager
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/related_invoices", ['invoice_id' => $invoice_id]);
-        return new \Recurly\Pager($this, $path, null);
+        return new \Recurly\Pager($this, $path, $options);
     }
   
     /**
@@ -1420,22 +1465,25 @@ class Client extends BaseClient
      *
      * @param string $invoice_id Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
      * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
      *
      * @return \Recurly\Resources\Invoice Returns the new credit invoice.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/refund_invoice
      */
-    public function refundInvoice(string $invoice_id, array $body): \Recurly\Resources\Invoice
+    public function refundInvoice(string $invoice_id, array $body, array $options = []): \Recurly\Resources\Invoice
     {
         $path = $this->interpolatePath("/invoices/{invoice_id}/refund", ['invoice_id' => $invoice_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * List a site's line items
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1446,20 +1494,18 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'original' (string): Filter by original field.
-     * 'state' (string): Filter by state field.
-     * 'type' (string): Filter by type field.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['original'] (string): Filter by original field.
+     * - $options['params']['state'] (string): Filter by state field.
+     * - $options['params']['type'] (string): Filter by type field.
      *
      * @return \Recurly\Pager A list of the site's line items.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_line_items
@@ -1474,36 +1520,40 @@ class Client extends BaseClient
      * Fetch a line item
      *
      * @param string $line_item_id Line Item ID.
+     * @param array  $options      Associative array of optional parameters
      *
      * @return \Recurly\Resources\LineItem A line item.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_line_item
      */
-    public function getLineItem(string $line_item_id): \Recurly\Resources\LineItem
+    public function getLineItem(string $line_item_id, array $options = []): \Recurly\Resources\LineItem
     {
         $path = $this->interpolatePath("/line_items/{line_item_id}", ['line_item_id' => $line_item_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * Delete an uninvoiced line item
      *
      * @param string $line_item_id Line Item ID.
+     * @param array  $options      Associative array of optional parameters
      *
      * @return \Recurly\EmptyResource Line item deleted.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_line_item
      */
-    public function removeLineItem(string $line_item_id): \Recurly\EmptyResource
+    public function removeLineItem(string $line_item_id, array $options = []): \Recurly\EmptyResource
     {
         $path = $this->interpolatePath("/line_items/{line_item_id}", ['line_item_id' => $line_item_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * List a site's plans
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1514,18 +1564,16 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'state' (string): Filter by state.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['state'] (string): Filter by state.
      *
      * @return \Recurly\Pager A list of plans.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_plans
@@ -1539,29 +1587,31 @@ class Client extends BaseClient
     /**
      * Create a plan
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Plan A plan.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_plan
      */
-    public function createPlan(array $body): \Recurly\Resources\Plan
+    public function createPlan(array $body, array $options = []): \Recurly\Resources\Plan
     {
         $path = $this->interpolatePath("/plans", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Fetch a plan
      *
      * @param string $plan_id Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Plan A plan.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_plan
      */
-    public function getPlan(string $plan_id): \Recurly\Resources\Plan
+    public function getPlan(string $plan_id, array $options = []): \Recurly\Resources\Plan
     {
         $path = $this->interpolatePath("/plans/{plan_id}", ['plan_id' => $plan_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -1569,36 +1619,41 @@ class Client extends BaseClient
      *
      * @param string $plan_id Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
      * @param array  $body    The body of the request.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Plan A plan.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_plan
      */
-    public function updatePlan(string $plan_id, array $body): \Recurly\Resources\Plan
+    public function updatePlan(string $plan_id, array $body, array $options = []): \Recurly\Resources\Plan
     {
         $path = $this->interpolatePath("/plans/{plan_id}", ['plan_id' => $plan_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Remove a plan
      *
      * @param string $plan_id Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Plan Plan deleted
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_plan
      */
-    public function removePlan(string $plan_id): \Recurly\Resources\Plan
+    public function removePlan(string $plan_id, array $options = []): \Recurly\Resources\Plan
     {
         $path = $this->interpolatePath("/plans/{plan_id}", ['plan_id' => $plan_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * List a plan's add-ons
      *
-     * Supported optional parameters:
+     * @param string $plan_id Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+     * @param array  $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1609,19 +1664,16 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'state' (string): Filter by state.
-     *
-     * @param string $plan_id Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-     * @param array  $options Associative array of optional parameters:
+     * - $options['params']['state'] (string): Filter by state.
      *
      * @return \Recurly\Pager A list of add-ons.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_plan_add_ons
@@ -1637,14 +1689,15 @@ class Client extends BaseClient
      *
      * @param string $plan_id Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
      * @param array  $body    The body of the request.
+     * @param array  $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\AddOn An add-on.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_plan_add_on
      */
-    public function createPlanAddOn(string $plan_id, array $body): \Recurly\Resources\AddOn
+    public function createPlanAddOn(string $plan_id, array $body, array $options = []): \Recurly\Resources\AddOn
     {
         $path = $this->interpolatePath("/plans/{plan_id}/add_ons", ['plan_id' => $plan_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
@@ -1652,14 +1705,15 @@ class Client extends BaseClient
      *
      * @param string $plan_id   Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
      * @param string $add_on_id Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+     * @param array  $options   Associative array of optional parameters
      *
      * @return \Recurly\Resources\AddOn An add-on.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_plan_add_on
      */
-    public function getPlanAddOn(string $plan_id, string $add_on_id): \Recurly\Resources\AddOn
+    public function getPlanAddOn(string $plan_id, string $add_on_id, array $options = []): \Recurly\Resources\AddOn
     {
         $path = $this->interpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", ['plan_id' => $plan_id, 'add_on_id' => $add_on_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -1668,14 +1722,15 @@ class Client extends BaseClient
      * @param string $plan_id   Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
      * @param string $add_on_id Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
      * @param array  $body      The body of the request.
+     * @param array  $options   Associative array of optional parameters
      *
      * @return \Recurly\Resources\AddOn An add-on.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_plan_add_on
      */
-    public function updatePlanAddOn(string $plan_id, string $add_on_id, array $body): \Recurly\Resources\AddOn
+    public function updatePlanAddOn(string $plan_id, string $add_on_id, array $body, array $options = []): \Recurly\Resources\AddOn
     {
         $path = $this->interpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", ['plan_id' => $plan_id, 'add_on_id' => $add_on_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
@@ -1683,22 +1738,25 @@ class Client extends BaseClient
      *
      * @param string $plan_id   Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
      * @param string $add_on_id Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+     * @param array  $options   Associative array of optional parameters
      *
      * @return \Recurly\Resources\AddOn Add-on deleted
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_plan_add_on
      */
-    public function removePlanAddOn(string $plan_id, string $add_on_id): \Recurly\Resources\AddOn
+    public function removePlanAddOn(string $plan_id, string $add_on_id, array $options = []): \Recurly\Resources\AddOn
     {
         $path = $this->interpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", ['plan_id' => $plan_id, 'add_on_id' => $add_on_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * List a site's add-ons
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1709,18 +1767,16 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'state' (string): Filter by state.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['state'] (string): Filter by state.
      *
      * @return \Recurly\Pager A list of add-ons.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_add_ons
@@ -1735,22 +1791,25 @@ class Client extends BaseClient
      * Fetch an add-on
      *
      * @param string $add_on_id Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+     * @param array  $options   Associative array of optional parameters
      *
      * @return \Recurly\Resources\AddOn An add-on.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_add_on
      */
-    public function getAddOn(string $add_on_id): \Recurly\Resources\AddOn
+    public function getAddOn(string $add_on_id, array $options = []): \Recurly\Resources\AddOn
     {
         $path = $this->interpolatePath("/add_ons/{add_on_id}", ['add_on_id' => $add_on_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * List a site's shipping methods
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1761,17 +1820,15 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param array $options Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the site's shipping methods.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_shipping_methods
@@ -1785,29 +1842,31 @@ class Client extends BaseClient
     /**
      * Create a new shipping method
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\ShippingMethod A new shipping method.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_shipping_method
      */
-    public function createShippingMethod(array $body): \Recurly\Resources\ShippingMethod
+    public function createShippingMethod(array $body, array $options = []): \Recurly\Resources\ShippingMethod
     {
         $path = $this->interpolatePath("/shipping_methods", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Fetch a shipping method
      *
      * @param string $shipping_method_id Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
+     * @param array  $options            Associative array of optional parameters
      *
      * @return \Recurly\Resources\ShippingMethod A shipping method.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_shipping_method
      */
-    public function getShippingMethod(string $shipping_method_id): \Recurly\Resources\ShippingMethod
+    public function getShippingMethod(string $shipping_method_id, array $options = []): \Recurly\Resources\ShippingMethod
     {
         $path = $this->interpolatePath("/shipping_methods/{shipping_method_id}", ['shipping_method_id' => $shipping_method_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -1815,36 +1874,40 @@ class Client extends BaseClient
      *
      * @param string $shipping_method_id Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
      * @param array  $body               The body of the request.
+     * @param array  $options            Associative array of optional parameters
      *
      * @return \Recurly\Resources\ShippingMethod The updated shipping method.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/update_shipping_method
      */
-    public function updateShippingMethod(string $shipping_method_id, array $body): \Recurly\Resources\ShippingMethod
+    public function updateShippingMethod(string $shipping_method_id, array $body, array $options = []): \Recurly\Resources\ShippingMethod
     {
         $path = $this->interpolatePath("/shipping_methods/{shipping_method_id}", ['shipping_method_id' => $shipping_method_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Deactivate a shipping method
      *
      * @param string $shipping_method_id Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
+     * @param array  $options            Associative array of optional parameters
      *
      * @return \Recurly\Resources\ShippingMethod A shipping method.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/deactivate_shipping_method
      */
-    public function deactivateShippingMethod(string $shipping_method_id): \Recurly\Resources\ShippingMethod
+    public function deactivateShippingMethod(string $shipping_method_id, array $options = []): \Recurly\Resources\ShippingMethod
     {
         $path = $this->interpolatePath("/shipping_methods/{shipping_method_id}", ['shipping_method_id' => $shipping_method_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * List a site's subscriptions
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -1855,22 +1918,20 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'state' (string): Filter by state.
+     * - $options['params']['state'] (string): Filter by state.
      *        
      *        - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
      *        - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
      *        - When `state=live`, only subscriptions that are in an active, canceled, or future state or are in trial will be returned.
-     *
-     * @param array $options Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the site's subscriptions.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_subscriptions
@@ -1884,29 +1945,31 @@ class Client extends BaseClient
     /**
      * Create a new subscription
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription A subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_subscription
      */
-    public function createSubscription(array $body): \Recurly\Resources\Subscription
+    public function createSubscription(array $body, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Fetch a subscription
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription A subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_subscription
      */
-    public function getSubscription(string $subscription_id): \Recurly\Resources\Subscription
+    public function getSubscription(string $subscription_id, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -1914,22 +1977,26 @@ class Client extends BaseClient
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
      * @param array  $body            The body of the request.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription A subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/modify_subscription
      */
-    public function modifySubscription(string $subscription_id, array $body): \Recurly\Resources\Subscription
+    public function modifySubscription(string $subscription_id, array $body, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Terminate a subscription
      *
-     * Supported optional parameters:
+     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
-     * 'refund' (string): The type of refund to perform:
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['refund'] (string): The type of refund to perform:
      *        
      *        * `full` - Performs a full refund of the last invoice for the current subscription term.
      *        * `partial` - Prorates a refund based on the amount of time remaining in the current bill cycle.
@@ -1939,16 +2006,13 @@ class Client extends BaseClient
      *        
      *        You may also terminate a subscription with no refund and then manually refund specific invoices.
      *
-     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-     * @param array  $options         Associative array of optional parameters:
-     *
      * @return \Recurly\Resources\Subscription An expired subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/terminate_subscription
      */
     public function terminateSubscription(string $subscription_id, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('DELETE', $path, null, $options);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
@@ -1956,28 +2020,30 @@ class Client extends BaseClient
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
      * @param array  $body            The body of the request.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription A canceled or failed subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/cancel_subscription
      */
-    public function cancelSubscription(string $subscription_id, array $body = []): \Recurly\Resources\Subscription
+    public function cancelSubscription(string $subscription_id, array $body = [], array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/cancel", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Reactivate a canceled subscription
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription An active subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/reactivate_subscription
      */
-    public function reactivateSubscription(string $subscription_id): \Recurly\Resources\Subscription
+    public function reactivateSubscription(string $subscription_id, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/reactivate", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
@@ -1985,56 +2051,60 @@ class Client extends BaseClient
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
      * @param array  $body            The body of the request.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription A subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/pause_subscription
      */
-    public function pauseSubscription(string $subscription_id, array $body): \Recurly\Resources\Subscription
+    public function pauseSubscription(string $subscription_id, array $body, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/pause", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
   
     /**
      * Resume subscription
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription A subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/resume_subscription
      */
-    public function resumeSubscription(string $subscription_id): \Recurly\Resources\Subscription
+    public function resumeSubscription(string $subscription_id, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/resume", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * Convert trial subscription
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\Subscription A subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/convert_trial
      */
-    public function convertTrial(string $subscription_id): \Recurly\Resources\Subscription
+    public function convertTrial(string $subscription_id, array $options = []): \Recurly\Resources\Subscription
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/convert_trial", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * Fetch a subscription's pending change
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\SubscriptionChange A subscription's pending change.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_subscription_change
      */
-    public function getSubscriptionChange(string $subscription_id): \Recurly\Resources\SubscriptionChange
+    public function getSubscriptionChange(string $subscription_id, array $options = []): \Recurly\Resources\SubscriptionChange
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/change", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
@@ -2042,28 +2112,30 @@ class Client extends BaseClient
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
      * @param array  $body            The body of the request.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\SubscriptionChange A subscription change.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_subscription_change
      */
-    public function createSubscriptionChange(string $subscription_id, array $body): \Recurly\Resources\SubscriptionChange
+    public function createSubscriptionChange(string $subscription_id, array $body, array $options = []): \Recurly\Resources\SubscriptionChange
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/change", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Delete the pending subscription change
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\EmptyResource Subscription change was deleted.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/remove_subscription_change
      */
-    public function removeSubscriptionChange(string $subscription_id): \Recurly\EmptyResource
+    public function removeSubscriptionChange(string $subscription_id, array $options = []): \Recurly\EmptyResource
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/change", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
@@ -2071,22 +2143,26 @@ class Client extends BaseClient
      *
      * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
      * @param array  $body            The body of the request.
+     * @param array  $options         Associative array of optional parameters
      *
      * @return \Recurly\Resources\SubscriptionChangePreview A subscription change.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/preview_subscription_change
      */
-    public function previewSubscriptionChange(string $subscription_id, array $body): \Recurly\Resources\SubscriptionChangePreview
+    public function previewSubscriptionChange(string $subscription_id, array $body, array $options = []): \Recurly\Resources\SubscriptionChangePreview
     {
         $path = $this->interpolatePath("/subscriptions/{subscription_id}/change/preview", ['subscription_id' => $subscription_id]);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * List a subscription's invoices
      *
-     * Supported optional parameters:
+     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -2097,23 +2173,20 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'type' (string): Filter by type when:
+     * - $options['params']['type'] (string): Filter by type when:
      *        - `type=charge`, only charge invoices will be returned.
      *        - `type=credit`, only credit invoices will be returned.
      *        - `type=non-legacy`, only charge and credit invoices will be returned.
      *        - `type=legacy`, only legacy invoices will be returned.
-     *
-     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-     * @param array  $options         Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the subscription's invoices.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_invoices
@@ -2127,9 +2200,12 @@ class Client extends BaseClient
     /**
      * List a subscription's line items
      *
-     * Supported optional parameters:
+     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -2140,21 +2216,18 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'original' (string): Filter by original field.
-     * 'state' (string): Filter by state field.
-     * 'type' (string): Filter by type field.
-     *
-     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-     * @param array  $options         Associative array of optional parameters:
+     * - $options['params']['original'] (string): Filter by original field.
+     * - $options['params']['state'] (string): Filter by state field.
+     * - $options['params']['type'] (string): Filter by type field.
      *
      * @return \Recurly\Pager A list of the subscription's line items.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_line_items
@@ -2168,9 +2241,12 @@ class Client extends BaseClient
     /**
      * Show the coupon redemptions for a subscription
      *
-     * Supported optional parameters:
+     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options         Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -2181,16 +2257,13 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     *
-     * @param string $subscription_id Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-     * @param array  $options         Associative array of optional parameters:
      *
      * @return \Recurly\Pager A list of the the coupon redemptions on a subscription.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_coupon_redemptions
@@ -2204,9 +2277,11 @@ class Client extends BaseClient
     /**
      * List a site's transactions
      *
-     * Supported optional parameters:
+     * @param array $options Associative array of optional parameters
      *
-     * 'ids' (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
      *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
      *        
      *        **Important notes:**
@@ -2217,19 +2292,17 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
-     * 'limit' (int): Limit number of records 1-200.
-     * 'order' (string): Sort order.
-     * 'sort' (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
      *        order. In descending order updated records will move behind the cursor and could
      *        prevent some records from being returned.
-     * 'begin_time' (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'end_time' (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-     * 'type' (string): Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-     * 'success' (string): Filter by success field.
-     *
-     * @param array $options Associative array of optional parameters:
+     * - $options['params']['type'] (string): Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+     * - $options['params']['success'] (string): Filter by success field.
      *
      * @return \Recurly\Pager A list of the site's transactions.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/list_transactions
@@ -2244,84 +2317,90 @@ class Client extends BaseClient
      * Fetch a transaction
      *
      * @param string $transaction_id Transaction ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+     * @param array  $options        Associative array of optional parameters
      *
      * @return \Recurly\Resources\Transaction A transaction.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_transaction
      */
-    public function getTransaction(string $transaction_id): \Recurly\Resources\Transaction
+    public function getTransaction(string $transaction_id, array $options = []): \Recurly\Resources\Transaction
     {
         $path = $this->interpolatePath("/transactions/{transaction_id}", ['transaction_id' => $transaction_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * Fetch a unique coupon code
      *
      * @param string $unique_coupon_code_id Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
+     * @param array  $options               Associative array of optional parameters
      *
      * @return \Recurly\Resources\UniqueCouponCode A unique coupon code.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/get_unique_coupon_code
      */
-    public function getUniqueCouponCode(string $unique_coupon_code_id): \Recurly\Resources\UniqueCouponCode
+    public function getUniqueCouponCode(string $unique_coupon_code_id, array $options = []): \Recurly\Resources\UniqueCouponCode
     {
         $path = $this->interpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", ['unique_coupon_code_id' => $unique_coupon_code_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
   
     /**
      * Deactivate a unique coupon code
      *
      * @param string $unique_coupon_code_id Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
+     * @param array  $options               Associative array of optional parameters
      *
      * @return \Recurly\Resources\UniqueCouponCode A unique coupon code.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/deactivate_unique_coupon_code
      */
-    public function deactivateUniqueCouponCode(string $unique_coupon_code_id): \Recurly\Resources\UniqueCouponCode
+    public function deactivateUniqueCouponCode(string $unique_coupon_code_id, array $options = []): \Recurly\Resources\UniqueCouponCode
     {
         $path = $this->interpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", ['unique_coupon_code_id' => $unique_coupon_code_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
   
     /**
      * Restore a unique coupon code
      *
      * @param string $unique_coupon_code_id Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
+     * @param array  $options               Associative array of optional parameters
      *
      * @return \Recurly\Resources\UniqueCouponCode A unique coupon code.
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/reactivate_unique_coupon_code
      */
-    public function reactivateUniqueCouponCode(string $unique_coupon_code_id): \Recurly\Resources\UniqueCouponCode
+    public function reactivateUniqueCouponCode(string $unique_coupon_code_id, array $options = []): \Recurly\Resources\UniqueCouponCode
     {
         $path = $this->interpolatePath("/unique_coupon_codes/{unique_coupon_code_id}/restore", ['unique_coupon_code_id' => $unique_coupon_code_id]);
-        return $this->makeRequest('PUT', $path, null, null);
+        return $this->makeRequest('PUT', $path, [], $options);
     }
   
     /**
      * Create a new purchase
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\InvoiceCollection Returns the new invoices
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/create_purchase
      */
-    public function createPurchase(array $body): \Recurly\Resources\InvoiceCollection
+    public function createPurchase(array $body, array $options = []): \Recurly\Resources\InvoiceCollection
     {
         $path = $this->interpolatePath("/purchases", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
     /**
      * Preview a new purchase
      *
-     * @param array $body The body of the request.
+     * @param array $body    The body of the request.
+     * @param array $options Associative array of optional parameters
      *
      * @return \Recurly\Resources\InvoiceCollection Returns preview of the new invoices
      * @link   https://developers.recurly.com/api/v2020-01-01#operation/preview_purchase
      */
-    public function previewPurchase(array $body): \Recurly\Resources\InvoiceCollection
+    public function previewPurchase(array $body, array $options = []): \Recurly\Resources\InvoiceCollection
     {
         $path = $this->interpolatePath("/purchases/preview", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
   
 }

--- a/lib/recurly/request.php
+++ b/lib/recurly/request.php
@@ -7,22 +7,23 @@ class Request
     private $_method;
     private $_path;
     private $_body;
-    private $_params;
+    private $_options;
 
     /**
      * Constructor
      * 
-     * @param string $method HTTP method to use
-     * @param string $path   Tokenized path to request
-     * @param array  $body   The request body
-     * @param array  $params Query string parameters
+     * @param string $method  HTTP method to use
+     * @param string $path    Tokenized path to request
+     * @param array  $body    The request body
+     * @param array  $params  Query string parameters
+     * @param array  $options Additional request parameters (including query parameters)
      */
-    public function __construct(string $method, string $path, ?array $body, ?array $params)
+    public function __construct(string $method, string $path, array $body, array $options)
     {
         $this->_method = $method;
         $this->_path = $path;
         $this->_body = $body;
-        $this->_params = $params;
+        $this->_options = $options;
     }
 
     /**
@@ -60,8 +61,28 @@ class Request
      * 
      * @return array The query string parameters
      */
-    public function getParams(): ?array
+    public function getParams(): array
     {
-        return $this->_params;
+        return array_key_exists('params', $this->_options) ? $this->_options['params'] : [];
+    }
+
+    /**
+     * Returns the request headers
+     * 
+     * @return array The custom request headers
+     */
+    public function getCustomHeaders(): array
+    {
+        return array_key_exists('headers', $this->_options) ? $this->_options['headers'] : [];
+    }
+
+    /**
+     * Returns the request options
+     * 
+     * @return array The options included in the request
+     */
+    public function getOptions(): array
+    {
+        return $this->_options;
     }
 }

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -5,6 +5,7 @@ namespace Recurly;
 class Response
 {
     private $_response;
+    private $_request;
     private $_status_code;
     private $_headers = [];
     private const BINARY_TYPES = [
@@ -16,9 +17,10 @@ class Response
      * 
      * @param string $response The raw HTTP response string
      */
-    public function __construct(string $response)
+    public function __construct(string $response, \Recurly\Request $request)
     {
         $this->_response = $response;
+        $this->_request = $request;
     }
 
     /**
@@ -39,6 +41,16 @@ class Response
     public function getJsonResponse(): ?object
     {
         return json_decode($this->_response);
+    }
+
+    /**
+     * The \Recurly\Request object
+     * 
+     * @return \Recurly\Request
+     */
+    public function getRequest(): \Recurly\Request
+    {
+        return $this->_request;
     }
 
     /**

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -28,7 +28,7 @@ final class BaseClientTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources/iexist";
         $result = '{"id": "iexist", "object": "test_resource"}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
         $resource = $this->client->getResource("iexist");
         $this->assertEquals($resource->getId(), "iexist");
@@ -38,7 +38,7 @@ final class BaseClientTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources/idontexist";
         $result = "{\"error\":{\"type\":\"not_found\",\"message\":\"Couldn't find Resource with id = idontexist\",\"params\":[{\"param\":\"resource_id\"}]}}";
-        $this->client->addScenario("GET", $url, NULL, $result, "404 Not Found");
+        $this->client->addScenario("GET", $url, [], $result, "404 Not Found");
 
         $this->expectException(\Recurly\Errors\NotFound::class);
         $this->client->getResource("idontexist");
@@ -69,7 +69,7 @@ final class BaseClientTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources/iexist";
         $result = "";
-        $this->client->addScenario("DELETE", $url, NULL, $result, "204 No Content");
+        $this->client->addScenario("DELETE", $url, [], $result, "204 No Content");
         $empty = $this->client->deleteResource("iexist");
         $this->assertInstanceOf(\Recurly\EmptyResource::class, $empty);
     }
@@ -89,7 +89,7 @@ final class BaseClientTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources";
         $result = '{ "object": "list", "has_more": false, "next": null, "data": [{"id": "iexist", "object": "test_resource", "name": "newname"}]}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
         $resources = $this->client->listResources();
         $count = 0;
@@ -104,9 +104,9 @@ final class BaseClientTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources?limit=1";
         $result = '{ "object": "list", "has_more": false, "next": null, "data": [{"id": "iexist", "object": "test_resource", "name": "newname"}]}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
-        $resources = $this->client->listResources([ "limit" => 1 ]);
+        $resources = $this->client->listResources([ 'params' => [ 'limit' => 1 ] ]);
         $count = 0;
         foreach($resources as $resource) {
             $count = $count + 1;
@@ -148,9 +148,9 @@ final class BaseClientTest extends RecurlyTestCase
         $beginTime = new DateTime("2020-01-01 00:00:00");
         $url = "https://v3.recurly.com/resources?begin_time=" . urlencode($beginTime->format(\DateTime::ISO8601));
         $result = '{ "object": "list", "has_more": false, "next": null, "data": [{"id": "iexist", "object": "test_resource", "name": "newname"}]}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
-        $resources = $this->client->listResources([ "begin_time" => $beginTime ]);
+        $resources = $this->client->listResources([ 'params' => [ 'begin_time' => $beginTime ] ]);
         $count = 0;
         foreach($resources as $resource) {
             $count = $count + 1;

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -158,4 +158,38 @@ final class BaseClientTest extends RecurlyTestCase
         }
         $this->assertEquals($count, 1);
     }
+
+    public function testValidOptions(): void
+    {
+        $url = "https://v3.recurly.com/resources/iexist?param-1=Param+1";
+        $result = '{"id": "iexist", "object": "test_resource"}';
+        $headers = [
+            'Accept-Language' => 'fr'
+        ];
+        $this->client->addScenario("GET", $url, [], $result, "200 OK", [], $headers);
+
+        $options = [
+            'params' => [
+                'param-1' => 'Param 1'
+            ],
+            'headers' => $headers
+        ];
+
+        $resource = $this->client->getResource("iexist", $options);
+        $this->assertEquals($resource->getId(), "iexist");
+    }
+
+    public function testInvalidOptions(): void
+    {
+        $url = "https://v3.recurly.com/resources/iexist?param-1=Param+1";
+        $result = '{"id": "iexist", "object": "test_resource"}';
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
+
+        $options = [
+            'param-1' => 'Param 1'
+        ];
+
+        $this->expectException(\Recurly\RecurlyError::class);
+        $resource = $this->client->getResource("iexist", $options);
+    }
 }

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -7,6 +7,7 @@ final class PagerTest extends RecurlyTestCase
     public function setUp(): void
     {
         parent::setUp();
+        $this->setUpRequest();
         $this->client = new MockClient();
 
         $this->count = 3;
@@ -16,7 +17,7 @@ final class PagerTest extends RecurlyTestCase
                 $name = 'page_limit_1';
             }
             $json_string = $this->fixtures->loadJsonFixture($name, ['type' => 'string']);
-            $response = new \Recurly\Response($json_string);
+            $response = new \Recurly\Response($json_string, $this->request);
             $response->setHeaders(array(
                 'HTTP/1.1 200 OK',
                 "Recurly-Total-Records: {$this->count}"
@@ -24,7 +25,7 @@ final class PagerTest extends RecurlyTestCase
             return $response->toResource();
         }));
         $client_stub->method('pagerCount')->will($this->returnCallback(function($name, $params) {
-            $response = new \Recurly\Response('');
+            $response = new \Recurly\Response('', $this->request);
             $response->setHeaders(array(
                 'HTTP/1.1 200 OK',
                 "Recurly-Total-Records: {$this->count}"

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -41,9 +41,9 @@ final class PagerTest extends RecurlyTestCase
         $idsCsv = join('%2C', $ids);
         $url = "https://v3.recurly.com/resources?ids=$idsCsv";
         $result = '{"object":"list","has_more":true,"next":"page_two","data":[{"object":"test_resource","name":"resource one"}]}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
-        $pager = new \Recurly\Pager($this->client, '/resources', ['ids' => $ids]);
+        $pager = new \Recurly\Pager($this->client, '/resources', [ 'params' => [ 'ids' => $ids ] ]);
         $pager->rewind();
         $this->assertInstanceOf(\Recurly\Response::class, $pager->getResponse());
     }
@@ -52,7 +52,7 @@ final class PagerTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources";
         $result = '{"object":"list","has_more":false,"next":null,"data":[{"object":"test_resource","name":"resource one"}]}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
         $pager = new \Recurly\Pager($this->client, '/resources');
         $pager->rewind();
@@ -63,7 +63,7 @@ final class PagerTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources?limit=1";
         $result = '{"object":"list","has_more":true,"next":"page_two","data":[{"object":"test_resource","name":"resource one"}]}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
         $pager = new \Recurly\Pager($this->client, '/resources');
         $this->assertInstanceOf(
@@ -76,7 +76,7 @@ final class PagerTest extends RecurlyTestCase
     {
         $url = "https://v3.recurly.com/resources?limit=1";
         $result = '{"object":"list","has_more":false,"next":null,"data":[]}';
-        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+        $this->client->addScenario("GET", $url, [], $result, "200 OK");
 
         $pager = new \Recurly\Pager($this->client, '/resources');
         $this->assertNull($pager->getFirst());
@@ -85,7 +85,7 @@ final class PagerTest extends RecurlyTestCase
     public function testGetCount(): void
     {
         $url = "https://v3.recurly.com/resources";
-        $this->client->addScenario("HEAD", $url, NULL, '', "200 OK", ['Recurly-Total-Records' => 3]);
+        $this->client->addScenario("HEAD", $url, [], '', "200 OK", ['Recurly-Total-Records' => 3]);
 
         $pager = new \Recurly\Pager($this->client, '/resources');
 

--- a/tests/RecurlyError_Test.php
+++ b/tests/RecurlyError_Test.php
@@ -2,6 +2,12 @@
 
 final class RecurlyErrorTest extends RecurlyTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRequest();
+    }
+
     public function testFromResponseGenericJsonServerError(): void
     {
         $data = array(
@@ -12,7 +18,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             )
         );
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(array(
             'HTTP/1.1 500 Internal Server Error',
             'Content-Type: application/json',
@@ -34,7 +40,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             )
         );
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(array(
             'HTTP/1.1 404 Not Found',
             'Content-Type: application/json',
@@ -56,7 +62,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             )
         );
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(array(
             'HTTP/1.1 100 Continue',
             'Content-Type: application/json',
@@ -70,7 +76,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
 
     public function testFromResponseForbiddenError(): void
     {
-        $response = new \Recurly\Response('forbidden error');
+        $response = new \Recurly\Response('forbidden error', $this->request);
         $response->setHeaders(array(
             'HTTP/1.1 403 Forbidden',
         ));
@@ -83,7 +89,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
 
     public function testFromResponseUnknownError(): void
     {
-        $response = new \Recurly\Response('what is this???');
+        $response = new \Recurly\Response('what is this???', $this->request);
         $response->setHeaders(array(
             'HTTP/1.1 100 Continue',
         ));
@@ -104,7 +110,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             )
         );
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(array(
             'HTTP/1.1 500 Internal Server Error',
             'Content-Type: application/json'

--- a/tests/RecurlyResource_Test.php
+++ b/tests/RecurlyResource_Test.php
@@ -4,6 +4,12 @@ use Recurly\RecurlyResource;
 
 final class RecurlyResourceTest extends RecurlyTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRequest();
+    }
+
     public function testUnknownPropertyError(): void
     {
         $resource = new \Recurly\Resources\TestResource();
@@ -30,7 +36,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
             ]
         );
 
-        $response = new \Recurly\Response(json_encode($test_resource));
+        $response = new \Recurly\Response(json_encode($test_resource), $this->request);
         $response->setHeaders(array('HTTP/1.1 200 OK'));
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
@@ -46,7 +52,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
             "unknown_key" => "unknown-key"
         );
 
-        $response = new \Recurly\Response(json_encode($test_resource));
+        $response = new \Recurly\Response(json_encode($test_resource), $this->request);
         $response->setHeaders(array('HTTP/1.1 200 OK'));
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
@@ -102,7 +108,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
             'object' => 'list'
         );
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(array('HTTP/1.1 200 OK'));
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Page::class, $result);
@@ -112,7 +118,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
     {
         $data = 'binary file data';
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(array('HTTP/1.1 200 OK'));
         $result = RecurlyResource::fromBinary($data, $response);
         $this->assertInstanceOf(\Recurly\Resources\BinaryFile::class, $result);
@@ -121,7 +127,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
 
     public function testFromEmpty(): void
     {
-        $response = new \Recurly\Response('');
+        $response = new \Recurly\Response('', $this->request);
         $response->setHeaders(array('HTTP/1.1 200 OK'));
         $result = RecurlyResource::fromEmpty($response);
         $this->assertInstanceOf(\Recurly\EmptyResource::class, $result);

--- a/tests/Request_Test.php
+++ b/tests/Request_Test.php
@@ -11,12 +11,21 @@ final class RequestTest extends RecurlyTestCase
         $this->method = 'GET';
         $this->path = '/accounts';
         $this->body = $account_create;
-        $this->params = [];
+        $this->options = [
+            'params' => [
+                'param-1' => 1,
+                'param-2' => 'Param 2',
+            ],
+            'headers' => [
+                'header-1' => 'Header 1',
+                'header-2' => 'Header 2',
+            ]
+        ];
         $this->request = new Request(
             $this->method,
             $this->path,
             $this->body,
-            $this->params
+            $this->options
         );
     }
 
@@ -47,8 +56,24 @@ final class RequestTest extends RecurlyTestCase
     public function testGetParams()
     {
         $this->assertEquals(
-            $this->params,
+            $this->options['params'],
             $this->request->getParams()
+        );
+    }
+
+    public function testGetCustomHeaders()
+    {
+        $this->assertEquals(
+            $this->options['headers'],
+            $this->request->getCustomHeaders()
+        );
+    }
+
+    public function testGetOptions()
+    {
+        $this->assertEquals(
+            $this->options,
+            $this->request->getOptions()
         );
     }
 

--- a/tests/Request_Test.php
+++ b/tests/Request_Test.php
@@ -7,26 +7,7 @@ final class RequestTest extends RecurlyTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $account_create = $this->fixtures->loadJsonFixture('account_create', ['type' => 'array']);
-        $this->method = 'GET';
-        $this->path = '/accounts';
-        $this->body = $account_create;
-        $this->options = [
-            'params' => [
-                'param-1' => 1,
-                'param-2' => 'Param 2',
-            ],
-            'headers' => [
-                'header-1' => 'Header 1',
-                'header-2' => 'Header 2',
-            ]
-        ];
-        $this->request = new Request(
-            $this->method,
-            $this->path,
-            $this->body,
-            $this->options
-        );
+        $this->setUpRequest();
     }
 
     public function testGetMethod()

--- a/tests/Response_Test.php
+++ b/tests/Response_Test.php
@@ -3,11 +3,17 @@
 use PHPUnit\Framework\TestCase;
 use Recurly\Response;
 
-final class ResponseTest extends TestCase
+final class ResponseTest extends RecurlyTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRequest();
+    }
+
     public function testNullHeaders(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders(null);
         $this->assertEquals(
             400,
@@ -17,7 +23,7 @@ final class ResponseTest extends TestCase
 
     public function testStatusCode(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $status_code = 201;
         $status = "HTTP/1.1 {$status_code} Created";
         $response->setHeaders(array(
@@ -32,7 +38,7 @@ final class ResponseTest extends TestCase
 
     public function testRequestIdHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $request_id = bin2hex(random_bytes(10));
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
@@ -46,7 +52,7 @@ final class ResponseTest extends TestCase
 
     public function testRateLimitHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $rate_limit = "2000";
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
@@ -60,7 +66,7 @@ final class ResponseTest extends TestCase
 
     public function testRateLimitRemainingHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $rate_limit_remaining = "300";
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
@@ -74,7 +80,7 @@ final class ResponseTest extends TestCase
 
     public function testRateLimitResetHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $rate_limit_reset = "1576791240";
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
@@ -88,7 +94,7 @@ final class ResponseTest extends TestCase
 
     public function testContentTypeHeaderSimple(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $content_type = "application/json";
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
@@ -102,7 +108,7 @@ final class ResponseTest extends TestCase
 
     public function testContentTypeHeaderMultiPart(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $content_type = "application/json";
         $charset = "charset=utf-8";
         $response->setHeaders(array(
@@ -118,7 +124,7 @@ final class ResponseTest extends TestCase
     public function testRecordCountHeader(): void
     {
         $count = 325;
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
             "Recurly-Total-Records: $count"
@@ -133,7 +139,7 @@ final class ResponseTest extends TestCase
     {
         $data = 'binary file data';
 
-        $response = new Response($data);
+        $response = new Response($data, $this->request);
         $content_type = "application/pdf";
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
@@ -151,7 +157,7 @@ final class ResponseTest extends TestCase
             'last_name' => 'DuMonde'
         );
 
-        $response = new Response(json_encode($account));
+        $response = new Response(json_encode($account), $this->request);
         $content_type = "application/json";
         $response->setHeaders(array(
             'HTTP/1.1 200 OK',
@@ -163,7 +169,7 @@ final class ResponseTest extends TestCase
 
     public function testToResourceEmpty(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders(array('HTTP/1.1 200 OK'));
         $result = $response->toResource();
         $this->assertInstanceOf(\Recurly\EmptyResource::class, $result);
@@ -172,7 +178,7 @@ final class ResponseTest extends TestCase
     public function testToResourceError(): void
     {
         $this->expectException(\Recurly\RecurlyError::class);
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders(array('HTTP/1.1 403 Forbidden'));
         $result = $response->toResource();
     }
@@ -180,10 +186,19 @@ final class ResponseTest extends TestCase
     public function testGetRawResponse(): void
     {
         $raw_response = 'raw-response';
-        $response = new Response($raw_response);
+        $response = new Response($raw_response, $this->request);
         $this->assertEquals(
             $raw_response,
             $response->getRawResponse()
+        );
+    }
+
+    public function testGetRequest(): void
+    {
+        $response = new Response('', $this->request);
+        $this->assertEquals(
+            $this->request,
+            $response->getRequest()
         );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,30 @@ abstract class RecurlyTestCase extends TestCase
     {
         $this->fixtures = new FixtureLoader();
     }
+
+    protected function setUpRequest()
+    {
+        $account_create = $this->fixtures->loadJsonFixture('account_create', ['type' => 'array']);
+        $this->method = 'GET';
+        $this->path = '/accounts';
+        $this->body = $account_create;
+        $this->options = [
+            'params' => [
+                'param-1' => 1,
+                'param-2' => 'Param 2',
+            ],
+            'headers' => [
+                'header-1' => 'Header 1',
+                'header-2' => 'Header 2',
+            ]
+        ];
+        $this->request = new \Recurly\Request(
+            $this->method,
+            $this->path,
+            $this->body,
+            $this->options
+        );
+    }
 }
 
 class FixtureLoader

--- a/tests/mock_client.php
+++ b/tests/mock_client.php
@@ -28,28 +28,28 @@ class MockClient extends BaseClient
         return new \Recurly\Pager($this, $path, $options);
     }
 
-    public function getResource(string $resource_id): TestResource
+    public function getResource(string $resource_id, array $options = []): TestResource
     {
         $path = $this->interpolatePath("/resources/{resource_id}", ['resource_id' => $resource_id]);
-        return $this->makeRequest('GET', $path, null, null);
+        return $this->makeRequest('GET', $path, [], $options);
     }
 
-    public function createResource(array $body): TestResource
+    public function createResource(array $body, array $options = []): TestResource
     {
         $path = $this->interpolatePath("/resources/", []);
-        return $this->makeRequest('POST', $path, $body, null);
+        return $this->makeRequest('POST', $path, $body, $options);
     }
 
-    public function updateResource(string $resource_id, array $body): TestResource
+    public function updateResource(string $resource_id, array $body, array $options = []): TestResource
     {
         $path = $this->interpolatePath("/resources/{resource_id}", ['resource_id' => $resource_id]);
-        return $this->makeRequest('PUT', $path, $body, null);
+        return $this->makeRequest('PUT', $path, $body, $options);
     }
 
-    public function deleteResource(string $resource_id): \Recurly\EmptyResource
+    public function deleteResource(string $resource_id, array $options = []): \Recurly\EmptyResource
     {
         $path = $this->interpolatePath("/resources/{resource_id}", ['resource_id' => $resource_id]);
-        return $this->makeRequest('DELETE', $path, null, null);
+        return $this->makeRequest('DELETE', $path, [], $options);
     }
 
     public function addScenario($method, $url, $body, $result, $status, $additional_headers = []): void

--- a/tests/mock_client.php
+++ b/tests/mock_client.php
@@ -52,14 +52,14 @@ class MockClient extends BaseClient
         return $this->makeRequest('DELETE', $path, [], $options);
     }
 
-    public function addScenario($method, $url, $body, $result, $status, $additional_headers = []): void
+    public function addScenario($method, $url, $body, $result, $status, $responseHeaders = [], $requestHeaders = []): void
     {
-        $resp_header = self::_generateRespHeader($status, $additional_headers);
+        $resp_header = self::_generateRespHeader($status, $responseHeaders);
         $this->http->method('execute')->with(
             $method,
             $url,
             $body,
-            self::_expectedHeaders()
+            self::_expectedHeaders($requestHeaders)
             )->willReturn(array($result, $resp_header));
     }
 
@@ -68,7 +68,7 @@ class MockClient extends BaseClient
         $this->http = (new Generator())->getMock(HttpAdapter::class);
     }
 
-    private static function _generateRespHeader($status, $additional_headers): array
+    private static function _generateRespHeader($status, $responseHeaders): array
     {
         $header_map = array_merge([
             "Date" => "Wed, 19 Feb 2020 17:52:05 GMT",
@@ -80,7 +80,7 @@ class MockClient extends BaseClient
             "X-Request-Id" => "567a17af7875e3ba-ATL",
             "Server" => "cloudflare",
             "CF-RAY" => "567a17af7875e3ba-ATL"
-        ], $additional_headers);
+        ], $responseHeaders);
 
         $headers = ["HTTP/1.1 $status"];
         foreach ($header_map as $k => $v) {
@@ -89,16 +89,16 @@ class MockClient extends BaseClient
         return $headers;
     }
 
-    private static function _expectedHeaders(): array
+    private static function _expectedHeaders($requestHeaders): array
     {
         $auth_token = self::encodeApiKey("apikey");
         $agent = self::getUserAgent();
-        return [
+        return array_merge([
             "User-Agent" => $agent,
             "Authorization" => "Basic {$auth_token}",
             "Accept" => "application/vnd.recurly.v2999-01-01",
             "Content-Type" => "application/json",
             "Accept-Encoding" => "gzip",
-        ];
+        ], $requestHeaders);
     }
 }


### PR DESCRIPTION
This is an update to the `4.x` version of the client.

Operations now require that query string parameters be specified under the `params` key of the `$options` parameter. This will allow for additional options to be specified in requests. Currently, this only includes custom headers, but may be expanded in the future.

This pull request also adds the `getRequest()` method to the `\Recurly\Response` class for debugging purposes.

In the `3.x` version of the client, query string parameters would be specified directly on the `$options` parameter of the operation:
```php
$options = [
  'limit' => 200
];
$accounts = $client->listAccounts($options);
```

With this update, the `params` key must be added to the `$options`. Additionally, a `headers` key may be added:
```php
$options = [
  'params' => [
    'limit' => 200
  ],
  'headers' => [
    'Accept-Language' => 'fr'
  ]
];
$accounts = $client->listAccounts($options);
```

