### PR TITLE
Null checking variable before calling property_exists to prevent Warning

### DIFF
--- a/lib/recurly/recurly_resource.php
+++ b/lib/recurly/recurly_resource.php
@@ -110,6 +110,8 @@ abstract class RecurlyResource
                     $klass->$setter(
                         array_map(
                             function ($item) use ($setter) {
+                                if (\is_null($item))
+                                    return;
                                 if (property_exists($item, 'object')) {
                                     $item_class = static::resourceClass($item->object);
                                 } else {


### PR DESCRIPTION
This update adds a null check to the `cast` method when casting arrays. There are scenarios where the values of an array can be `null` which was causing the below warning to be thrown. 

```
PHP Warning:  First parameter must either be an object or the name of an existing class in /app/clients/php/lib/recurly/recurly_resource.php on line 113
PHP Stack trace:
PHP   1. {main}() /app/scripts/v2019-10-10/php/sandbox/preview_purchase.php:0
PHP   2. TestClient->previewPurchase() /app/scripts/v2019-10-10/php/sandbox/preview_purchase.php:37
PHP   3. TestClient->makeRequest() /app/clients/php/lib/recurly/client.php:2324
PHP   4. Recurly\Response->toResource() /app/clients/php/lib/recurly/base_client.php:44
PHP   5. Recurly\RecurlyResource::fromResponse() /app/clients/php/lib/recurly/response.php:57
PHP   6. Recurly\RecurlyResource::cast() /app/clients/php/lib/recurly/recurly_resource.php:86
PHP   7. Recurly\RecurlyResource::cast() /app/clients/php/lib/recurly/recurly_resource.php:130
PHP   8. array_map() /app/clients/php/lib/recurly/recurly_resource.php:112
PHP   9. Recurly\RecurlyResource::Recurly\{closure:/app/clients/php/lib/recurly/recurly_resource.php:112-123}() /app/clients/php/lib/recurly/recurly_resource.php:112
PHP  10. property_exists() /app/clients/php/lib/recurly/recurly_resource.php:113
```

Resolves https://github.com/recurly/recurly-client-php/issues/524