### PR TITLE
Release 2.12.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.16 (August 20, 2020)
+
+This brings us up to API version 2.29. There are no breaking changes
+
+* Add tax identifier fields to billing info [PR](https://github.com/recurly/recurly-client-php/pull/530)
+
 ## Version 2.12.15 (July 22, 2020)
 
 This brings us up to API version 2.28. There are no breaking changes

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -42,6 +42,8 @@
  * @property string $type The payment method type for a non-credit card based billing info. `bacs` and `becs` are the only accepted values
  * @property string $sort_code Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
  * @property string $bsb_code Bank identifier code for AU based banks. Required for Becs based billing infos.
+ * @property string $tax_identifier Tax identifier is required if adding a billing info that is a consumer card in Brazil. This would be the customer's CPF, a Brazilian tax identifier for all tax paying residents.
+ * @property string $tax_identifier_type This field and a value of 'cpf' are required if adding a billing info that is an elo or hipercard type in Brazil.
  */
 class Recurly_BillingInfo extends Recurly_Resource
 {
@@ -110,7 +112,8 @@ class Recurly_BillingInfo extends Recurly_Resource
       'paypal_billing_agreement_id', 'amazon_billing_agreement_id', 'currency',
       'token_id', 'external_hpp_type', 'gateway_token', 'gateway_code',
       'braintree_payment_nonce', 'roku_billing_agreement_id',
-      'three_d_secure_action_result_token_id', 'transaction_type', 'iban', 'sort_code', 'bsb_code', 'type'
+      'three_d_secure_action_result_token_id', 'transaction_type', 'iban', 'sort_code', 'bsb_code', 'type',
+      'tax_identifier', 'tax_identifier_type'
     );
   }
 }

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -24,7 +24,7 @@ class Recurly_Client
   /**
    * API Version
    */
-  public static $apiVersion = '2.28';
+  public static $apiVersion = '2.29';
 
   /**
    * The path to your CA certs. Use only if needed (if you can't fix libcurl/php).
@@ -51,8 +51,7 @@ class Recurly_Client
    */
   private static $apiUrl = 'https://%s.recurly.com/v2';
 
-
-  const API_CLIENT_VERSION = '2.12.15';
+  const API_CLIENT_VERSION = '2.12.16';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
This PR merges v2.29 features into v2 branch for release and bumps the client library version to 2.12.16.

---

This brings us up to API version 2.29. There are no breaking changes

* Add tax identifier fields to billing info https://github.com/recurly/recurly-client-php/pull/530