### PR TITLE
Fixing casting for list types that are not in pagers

### DIFF
--- a/lib/recurly/recurly_resource.php
+++ b/lib/recurly/recurly_resource.php
@@ -116,9 +116,8 @@ abstract class RecurlyResource
                                 if (property_exists($item, 'object')) {
                                     $item_class = static::resourceClass($item->object);
                                 } else {
-                                    // TODO: Ensure that there is a hintArrayType method
                                     $item_class = static::hintArrayType($setter);
-                                    if (!preg_match('/^Recurly/', $item_class)) {
+                                    if (!preg_match('/^\\\Recurly/', $item_class)) {
                                         return $item;
                                     }
                                 }

--- a/tests/RecurlyResource_Test.php
+++ b/tests/RecurlyResource_Test.php
@@ -36,6 +36,10 @@ final class RecurlyResourceTest extends RecurlyTestCase
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
         $this->assertEquals($response, $result->getResponse());
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result->getSingleChild());
+        foreach ($result->getResourceArray() as $resource)
+        {
+            $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $resource);
+        }
     }
 
     public function testFromJsonUnknownKeys(): void


### PR DESCRIPTION
Fixes a bug with casting responses with array values that do not contain the `object` key. This functionality has not been encountered previously as all current arrays have contained resources with the `object` key.