### PR TITLE
Adding \Recurly\Request to \Recurly\Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ try {
 }
 ```
 
+### HTTP Metadata
+
 Sometimes you might want to get some additional information about the underlying HTTP request and response. Instead of returning this information directly and forcing the programmer to unwrap it, we inject this metadata into the top level resource that was returned. You can access the response by calling `getResponse()` on any Resource.
 
 > **Warning**:
@@ -173,6 +175,19 @@ $account = $client->getAccount("code-douglas");
 $response = $account->getResponse();
 echo "Request ID:" . $response->getRequestId() . PHP_EOL;
 echo "Rate limit remaining:" . $response->getRateLimitRemaining() . PHP_EOL;
+```
+
+Information about the request is also included in the `\Recurly\Response` class and can be accessed using the `getRequest()` method on the Response.
+
+```php
+$account = $client->getAccount("code-douglas");
+$response = $account->getResponse();
+$request = $response->getRequest();
+echo "Request URL:" . $request->getUrl() . PHP_EOL;
+echo "Request body as JSON:" . $request->getJSON() . PHP_EOL;
+foreach($request->getHeaders() as $k => $v) {
+    echo "Request header: $k => $v" . PHP_EOL;
+}
 ```
 
 This also works on `Empty` resources (for when there is no return body):

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ $account = $client->getAccount("code-douglas");
 $response = $account->getResponse();
 $request = $response->getRequest();
 echo "Request URL:" . $request->getUrl() . PHP_EOL;
-echo "Request body as JSON:" . $request->getJSON() . PHP_EOL;
+echo "Request body as JSON:" . $request->getBodyAsJson() . PHP_EOL;
 foreach($request->getHeaders() as $k => $v) {
     echo "Request header: $k => $v" . PHP_EOL;
 }

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -63,9 +63,8 @@ abstract class BaseClient
      */
     private function _getResponse(\Recurly\Request $request): \Recurly\Response
     {
-        list($result, $response_header) = $this->http->execute($request->getMethod(), $request->getUrl(), $request->getJson(), $this->_headers());
+        list($result, $response_header) = $this->http->execute($request->getMethod(), $request->getUrl(), $request->getBodyAsJson(), $this->_headers());
 
-        // TODO: The $request should be added to the $response
         $response = new \Recurly\Response($result, $request);
         $response->setHeaders($response_header);
 

--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -40,7 +40,12 @@ abstract class BaseClient
      */
     protected function makeRequest(string $method, string $path, ?array $body = [], ?array $params = []): \Recurly\RecurlyResource
     {
-        $response = $this->_getResponse($method, $path, $body, $params);
+        $url = $this->_buildPath($path, $params);
+        $formattedBody = $this->_formatDateTimes($body);
+
+        $request = new \Recurly\Request($method, $url, $formattedBody, $params, $this->_headers());
+
+        $response = $this->_getResponse($request);
         $resource = $response->toResource();
         return $resource;
     }
@@ -56,16 +61,12 @@ abstract class BaseClient
      * 
      * @return \Recurly\Response A Recurly Response object
      */
-    private function _getResponse(string $method, string $path, ?array $body = [], ?array $params = []): \Recurly\Response
+    private function _getResponse(\Recurly\Request $request): \Recurly\Response
     {
-        $request = new \Recurly\Request($method, $path, $body, $params);
-
-        $url = $this->_buildPath($path, $params);
-        $formattedBody = $this->_formatDateTimes($body);
-        list($result, $response_header) = $this->http->execute($method, $url, $formattedBody, $this->_headers());
+        list($result, $response_header) = $this->http->execute($request->getMethod(), $request->getUrl(), $request->getJson(), $this->_headers());
 
         // TODO: The $request should be added to the $response
-        $response = new \Recurly\Response($result);
+        $response = new \Recurly\Response($result, $request);
         $response->setHeaders($response_header);
 
         return $response;
@@ -96,7 +97,9 @@ abstract class BaseClient
      */
     public function pagerCount(string $path, ?array $params = []): \Recurly\Response
     {
-        return $this->_getResponse('HEAD', $path, null, $params);
+        $url = $this->_buildPath($path, $params);
+        $request = new \Recurly\Request('HEAD', $url, null, $params, $this->_headers());
+        return $this->_getResponse($request);
     }
 
     /**

--- a/lib/recurly/http_adapter.php
+++ b/lib/recurly/http_adapter.php
@@ -8,6 +8,9 @@
 
 namespace Recurly;
 
+/**
+ * @codeCoverageIgnore
+ */
 class HttpAdapter
 {
     private static $_default_options = [
@@ -26,7 +29,6 @@ class HttpAdapter
      */
     public function execute($method, $url, $body, $headers): array
     {
-        $body = empty($body) ? null : json_encode($body);
         $options = array_replace(
             self::$_default_options, [
             'method' => $method,

--- a/lib/recurly/request.php
+++ b/lib/recurly/request.php
@@ -62,7 +62,7 @@ class Request
      * 
      * @return array The request body
      */
-    public function getJson(): ?string
+    public function getBodyAsJson(): ?string
     {
         return empty($this->_body) ? null : json_encode($this->_body);
     }

--- a/lib/recurly/request.php
+++ b/lib/recurly/request.php
@@ -5,24 +5,26 @@ namespace Recurly;
 class Request
 {
     private $_method;
-    private $_path;
+    private $_url;
     private $_body;
     private $_params;
+    private $_headers;
 
     /**
      * Constructor
      * 
      * @param string $method HTTP method to use
-     * @param string $path   Tokenized path to request
+     * @param string $url    URL for the request.
      * @param array  $body   The request body
      * @param array  $params Query string parameters
      */
-    public function __construct(string $method, string $path, ?array $body, ?array $params)
+    public function __construct(string $method, string $url, ?array $body, ?array $params, array $headers)
     {
         $this->_method = $method;
-        $this->_path = $path;
+        $this->_url = $url;
         $this->_body = $body;
         $this->_params = $params;
+        $this->_headers = $headers;
     }
 
     /**
@@ -36,13 +38,13 @@ class Request
     }
 
     /**
-     * Returns the path that the HTTP request was made to
+     * Returns the URL that the HTTP request was made to
      * 
-     * @return string The path
+     * @return string The URL
      */
-    public function getPath(): string
+    public function getUrl(): string
     {
-        return $this->_path;
+        return $this->_url;
     }
 
     /**
@@ -56,6 +58,16 @@ class Request
     }
 
     /**
+     * Returns the JSON body included in the request
+     * 
+     * @return array The request body
+     */
+    public function getJson(): ?string
+    {
+        return empty($this->_body) ? null : json_encode($this->_body);
+    }
+
+    /**
      * Returns the request query string parameters
      * 
      * @return array The query string parameters
@@ -63,5 +75,16 @@ class Request
     public function getParams(): ?array
     {
         return $this->_params;
+    }
+
+    /**
+     * Returns the request headers.
+     * Note: The `Content-Length` header is not included here as it is calculated just prior to the request being sent.
+     * 
+     * @return array Associative array of headers
+     */
+    public function getHeaders(): ?array
+    {
+        return $this->_headers;
     }
 }

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -5,6 +5,7 @@ namespace Recurly;
 class Response
 {
     private $_response;
+    private $_request;
     private $_status_code;
     private $_headers = [];
     private const BINARY_TYPES = [
@@ -16,9 +17,20 @@ class Response
      * 
      * @param string $response The raw HTTP response string
      */
-    public function __construct(string $response)
+    public function __construct(string $response, \Recurly\Request $request)
     {
         $this->_response = $response;
+        $this->_request = $request;
+    }
+
+    /**
+     * The \Recurly\Request that generated this resposne.
+     * 
+     * @return \Recurly\Request
+     */
+    public function getRequest(): \Recurly\Request
+    {
+        return $this->_request;
     }
 
     /**

--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -49,7 +49,7 @@ final class BaseClientTest extends RecurlyTestCase
         $url = "https://v3.recurly.com/resources/";
         $result = '{"id": "created", "object": "test_resource", "name": "valid"}';
         $body = [ "name" => "valid" ];
-        $this->client->addScenario("POST", $url, $body, $result, "201 Created");
+        $this->client->addScenario("POST", $url, json_encode($body), $result, "201 Created");
         $resource = $this->client->createResource([ "name" => "valid" ]);
         $this->assertEquals($resource->getId(), "created");
     }
@@ -59,7 +59,7 @@ final class BaseClientTest extends RecurlyTestCase
         $url = "https://v3.recurly.com/resources/";
         $result = "{\"error\":{\"type\":\"validation\",\"message\":\"Name is invalid\",\"params\":[{\"param\":\"name\",\"message\":\"is invalid\"}]}}";
         $body = [ "name" => "invalid" ];
-        $this->client->addScenario("POST", $url, $body, $result, "422 Unprocessable Entity");
+        $this->client->addScenario("POST", $url, json_encode($body), $result, "422 Unprocessable Entity");
 
         $this->expectException(\Recurly\Errors\Validation::class);
         $resource = $this->client->createResource([ "name" => "invalid" ]);
@@ -79,7 +79,7 @@ final class BaseClientTest extends RecurlyTestCase
         $url = "https://v3.recurly.com/resources/iexist";
         $result = '{"id": "iexist", "object": "test_resource", "name": "newname"}';
         $body = [ "name" => "newname" ];
-        $this->client->addScenario("PUT", $url, $body, $result, "200 OK");
+        $this->client->addScenario("PUT", $url, json_encode($body), $result, "200 OK");
 
         $resource = $this->client->updateResource("iexist", $body);
         $this->assertEquals($resource->getName(), "newname");
@@ -122,7 +122,7 @@ final class BaseClientTest extends RecurlyTestCase
         $url = "https://v3.recurly.com/resources/";
         $result = '{"id": "created", "object": "test_resource", "name": "valid"}';
         $body = [ "date_time" => $dateTime->format(\DateTime::ISO8601) ];
-        $this->client->addScenario("POST", $url, $body, $result, "201 Created");
+        $this->client->addScenario("POST", $url, json_encode($body), $result, "201 Created");
         $resource = $this->client->createResource([ "date_time" => $dateTime ]);
         $this->assertEquals($resource->getId(), "created");
     }
@@ -138,7 +138,7 @@ final class BaseClientTest extends RecurlyTestCase
                 "date_time" => $dateTime->format(\DateTime::ISO8601)
             ]
         ];
-        $this->client->addScenario("POST", $url, $body, $result, "201 Created");
+        $this->client->addScenario("POST", $url, json_encode($body), $result, "201 Created");
         $resource = $this->client->createResource([ "nested" => [ "date_time" => $dateTime ] ]);
         $this->assertEquals($resource->getId(), "created");
     }

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -8,6 +8,7 @@ final class PagerTest extends RecurlyTestCase
     {
         parent::setUp();
         $this->client = new MockClient();
+        $this->request = new \Recurly\Request('GET', 'https://v3.recurly.com/accounts', null, null, []);
 
         $this->count = 3;
         $client_stub = $this->createMock(\Recurly\BaseClient::class);
@@ -16,7 +17,7 @@ final class PagerTest extends RecurlyTestCase
                 $name = 'page_limit_1';
             }
             $json_string = $this->fixtures->loadJsonFixture($name, ['type' => 'string']);
-            $response = new \Recurly\Response($json_string);
+            $response = new \Recurly\Response($json_string, $this->request);
             $response->setHeaders([
                 'HTTP/1.1 200 OK',
                 "Recurly-Total-Records: {$this->count}"

--- a/tests/RecurlyError_Test.php
+++ b/tests/RecurlyError_Test.php
@@ -2,6 +2,11 @@
 
 final class RecurlyErrorTest extends RecurlyTestCase
 {
+    protected function setUp(): void
+    {
+        $this->request = new \Recurly\Request('GET', 'https://v3.recurly.com/accounts', null, null, []);
+    }
+
     public function testFromResponseGenericJsonServerError(): void
     {
         $data = [
@@ -12,7 +17,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             ]
         ];
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders([
             'HTTP/1.1 500 Internal Server Error',
             'Content-Type: application/json',
@@ -34,7 +39,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             ]
         ];
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders([
             'HTTP/1.1 404 Not Found',
             'Content-Type: application/json',
@@ -56,7 +61,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             ]
         ];
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders([
             'HTTP/1.1 100 Continue',
             'Content-Type: application/json',
@@ -70,7 +75,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
 
     public function testFromResponseForbiddenError(): void
     {
-        $response = new \Recurly\Response('forbidden error');
+        $response = new \Recurly\Response('forbidden error', $this->request);
         $response->setHeaders([
             'HTTP/1.1 403 Forbidden',
         ]);
@@ -83,7 +88,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
 
     public function testFromResponseUnknownError(): void
     {
-        $response = new \Recurly\Response('what is this???');
+        $response = new \Recurly\Response('what is this???', $this->request);
         $response->setHeaders([
             'HTTP/1.1 100 Continue',
         ]);
@@ -104,7 +109,7 @@ final class RecurlyErrorTest extends RecurlyTestCase
             ]
         ];
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders([
             'HTTP/1.1 500 Internal Server Error',
             'Content-Type: application/json'

--- a/tests/RecurlyResource_Test.php
+++ b/tests/RecurlyResource_Test.php
@@ -4,6 +4,11 @@ use Recurly\RecurlyResource;
 
 final class RecurlyResourceTest extends RecurlyTestCase
 {
+    protected function setUp(): void
+    {
+        $this->request = new \Recurly\Request('GET', 'https://v3.recurly.com/accounts', null, null, []);
+    }
+
     public function testUnknownPropertyError(): void
     {
         $resource = new \Recurly\Resources\TestResource();
@@ -30,7 +35,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
             ]
         ];
 
-        $response = new \Recurly\Response(json_encode($test_resource));
+        $response = new \Recurly\Response(json_encode($test_resource), $this->request);
         $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
@@ -42,6 +47,22 @@ final class RecurlyResourceTest extends RecurlyTestCase
         }
     }
 
+    public function testFromJsonNullArray(): void
+    {
+        $test_resource = (object)[
+            "object" => "test_resource",
+            "resource_array" => [
+                null
+            ]
+        ];
+
+        $response = new \Recurly\Response(json_encode($test_resource), $this->request);
+        $response->setHeaders(['HTTP/1.1 200 OK']);
+        $result = RecurlyResource::fromResponse($response);
+        $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
+        $this->assertEquals($response, $result->getResponse());
+    }
+
     public function testFromJsonUnknownKeys(): void
     {
         $test_resource = (object)[
@@ -50,7 +71,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
             "unknown_key" => "unknown-key"
         ];
 
-        $response = new \Recurly\Response(json_encode($test_resource));
+        $response = new \Recurly\Response(json_encode($test_resource), $this->request);
         $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
@@ -106,7 +127,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
             'object' => 'list'
         ];
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromResponse($response);
         $this->assertInstanceOf(\Recurly\Page::class, $result);
@@ -116,7 +137,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
     {
         $data = 'binary file data';
 
-        $response = new \Recurly\Response(json_encode($data));
+        $response = new \Recurly\Response(json_encode($data), $this->request);
         $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromBinary($data, $response);
         $this->assertInstanceOf(\Recurly\Resources\BinaryFile::class, $result);
@@ -125,7 +146,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
 
     public function testFromEmpty(): void
     {
-        $response = new \Recurly\Response('');
+        $response = new \Recurly\Response('', $this->request);
         $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = RecurlyResource::fromEmpty($response);
         $this->assertInstanceOf(\Recurly\EmptyResource::class, $result);

--- a/tests/Request_Test.php
+++ b/tests/Request_Test.php
@@ -9,14 +9,20 @@ final class RequestTest extends RecurlyTestCase
         parent::setUp();
         $account_create = $this->fixtures->loadJsonFixture('account_create', ['type' => 'array']);
         $this->method = 'GET';
-        $this->path = '/accounts';
+        $this->url = 'https://v3.recurly.com/accounts';
         $this->body = $account_create;
-        $this->params = [];
+        $this->params = [
+            'param-1' => 'param-1-value'
+        ];
+        $this->headers = [
+            'header-1' => 'header-1-value'
+        ];
         $this->request = new Request(
             $this->method,
-            $this->path,
+            $this->url,
             $this->body,
-            $this->params
+            $this->params,
+            $this->headers
         );
     }
 
@@ -31,8 +37,8 @@ final class RequestTest extends RecurlyTestCase
     public function testGetPath()
     {
         $this->assertEquals(
-            $this->path,
-            $this->request->getPath()
+            $this->url,
+            $this->request->getUrl()
         );
     }
 
@@ -49,6 +55,14 @@ final class RequestTest extends RecurlyTestCase
         $this->assertEquals(
             $this->params,
             $this->request->getParams()
+        );
+    }
+
+    public function testGetHeaders()
+    {
+        $this->assertEquals(
+            $this->headers,
+            $this->request->getHeaders()
         );
     }
 

--- a/tests/Response_Test.php
+++ b/tests/Response_Test.php
@@ -5,9 +5,14 @@ use Recurly\Response;
 
 final class ResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->request = new \Recurly\Request('GET', 'https://v3.recurly.com/accounts', null, null, []);
+    }
+
     public function testNullHeaders(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders(null);
         $this->assertEquals(
             400,
@@ -17,7 +22,7 @@ final class ResponseTest extends TestCase
 
     public function testStatusCode(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $status_code = 201;
         $status = "HTTP/1.1 {$status_code} Created";
         $response->setHeaders([
@@ -32,7 +37,7 @@ final class ResponseTest extends TestCase
 
     public function testRequestIdHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $request_id = bin2hex(random_bytes(10));
         $response->setHeaders([
             'HTTP/1.1 200 OK',
@@ -46,7 +51,7 @@ final class ResponseTest extends TestCase
 
     public function testRateLimitHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $rate_limit = "2000";
         $response->setHeaders([
             'HTTP/1.1 200 OK',
@@ -60,7 +65,7 @@ final class ResponseTest extends TestCase
 
     public function testRateLimitRemainingHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $rate_limit_remaining = "300";
         $response->setHeaders([
             'HTTP/1.1 200 OK',
@@ -74,7 +79,7 @@ final class ResponseTest extends TestCase
 
     public function testRateLimitResetHeader(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $rate_limit_reset = "1576791240";
         $response->setHeaders([
             'HTTP/1.1 200 OK',
@@ -88,7 +93,7 @@ final class ResponseTest extends TestCase
 
     public function testContentTypeHeaderSimple(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $content_type = "application/json";
         $response->setHeaders([
             'HTTP/1.1 200 OK',
@@ -102,7 +107,7 @@ final class ResponseTest extends TestCase
 
     public function testContentTypeHeaderMultiPart(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $content_type = "application/json";
         $charset = "charset=utf-8";
         $response->setHeaders([
@@ -118,7 +123,7 @@ final class ResponseTest extends TestCase
     public function testRecordCountHeader(): void
     {
         $count = 325;
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders([
             'HTTP/1.1 200 OK',
             "Recurly-Total-Records: $count"
@@ -133,7 +138,7 @@ final class ResponseTest extends TestCase
     {
         $data = 'binary file data';
 
-        $response = new Response($data);
+        $response = new Response($data, $this->request);
         $content_type = "application/pdf";
         $response->setHeaders([
             'HTTP/1.1 200 OK',
@@ -151,7 +156,7 @@ final class ResponseTest extends TestCase
             'last_name' => 'DuMonde'
         ];
 
-        $response = new Response(json_encode($account));
+        $response = new Response(json_encode($account), $this->request);
         $content_type = "application/json";
         $response->setHeaders([
             'HTTP/1.1 200 OK',
@@ -163,7 +168,7 @@ final class ResponseTest extends TestCase
 
     public function testToResourceEmpty(): void
     {
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders(['HTTP/1.1 200 OK']);
         $result = $response->toResource();
         $this->assertInstanceOf(\Recurly\EmptyResource::class, $result);
@@ -172,7 +177,7 @@ final class ResponseTest extends TestCase
     public function testToResourceError(): void
     {
         $this->expectException(\Recurly\RecurlyError::class);
-        $response = new Response('');
+        $response = new Response('', $this->request);
         $response->setHeaders(['HTTP/1.1 403 Forbidden']);
         $result = $response->toResource();
     }
@@ -180,10 +185,19 @@ final class ResponseTest extends TestCase
     public function testGetRawResponse(): void
     {
         $raw_response = 'raw-response';
-        $response = new Response($raw_response);
+        $response = new Response($raw_response, $this->request);
         $this->assertEquals(
             $raw_response,
             $response->getRawResponse()
+        );
+    }
+
+    public function testGetRequest(): void
+    {
+        $response = new Response('', $this->request);
+        $this->assertEquals(
+            $this->request,
+            $response->getRequest()
         );
     }
 }


### PR DESCRIPTION
Adds the `\Recurly\Request` to the `\Recurly\Response` to enable developers to inspect the request that was sent as well as the response.

```php
$account = $client->getAccount("code-douglas");
$response = $account->getResponse();
$request = $response->getRequest();
echo "Request URL:" . $request->getUrl() . PHP_EOL;
echo "Request body as JSON:" . $request->getBodyAsJson() . PHP_EOL;
foreach($request->getHeaders() as $k => $v) {
    echo "Request header: $k => $v" . PHP_EOL;
}
```

As a reminder, the request can contain sensitive information. This enhancement should only be utilized for internal development purposes.