### PR TITLE
Updating to be compliant with RFC 2616

### DIFF
--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -93,7 +93,7 @@ class Response
             } else {
                 $parts = explode(':', $header, 2);
                 if (count($parts) == 2) {
-                    $this->_headers[$parts[0]] = trim($parts[1]);
+                    $this->_headers[strtolower($parts[0])] = trim($parts[1]);
                 }
             }
         }
@@ -181,6 +181,7 @@ class Response
      */
     private function _getHeaderValue(string $key, $default = '')
     {
-        return key_exists($key, $this->_headers) ? $this->_headers[$key] : $default;
+        $lower_key = strtolower($key);
+        return key_exists($lower_key, $this->_headers) ? $this->_headers[$lower_key] : $default;
     }
 }


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

The PHP 3.x client libraries are not compliant with the RFC and are being updated to handle headers in a case-insensitive manner.