### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.1.5 (October 1, 2020)
+
+* Fixed issue with RFC 2616 compliance: headers should be treated as case-insensitive.
+
 ## Version 2.1.4 (February 19, 2013)
 
 * Fixed fatal error in Recurly_Invoice::getInvoicePdf().

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "lastcraft/simpletest": "1.1.*"
+        "simpletest/simpletest": "1.1.*"
     },
     "autoload": {
         "classmap": ["lib"]

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -29,7 +29,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.1.2';
+  const API_CLIENT_VERSION = '2.1.5';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';
@@ -160,8 +160,10 @@ class Recurly_Client
     $returnHeaders = array();
     foreach ($headers as &$header) {
       preg_match('/([^:]+): (.*)/', $header, $matches);
-      if (sizeof($matches) > 2)
-        $returnHeaders[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $returnHeaders[$headerKey] = $matches[2];
+      }
     }
     return $returnHeaders;
   }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -119,8 +119,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   private function _loadLinks($response) {
     $this->_links = array();
 
-    if (isset($response->headers['Link'])) {
-      $links = $response->headers['Link'];
+    if (isset($response->headers['link'])) {
+      $links = $response->headers['link'];
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {
@@ -135,8 +135,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
    */
   private function _loadRecordCount($response)
   {
-    if (empty($this->_count) && isset($response->headers['X-Records']))
-      $this->_count = intval($response->headers['X-Records']);
+    if (empty($this->_count) && isset($response->headers['x-records']))
+      $this->_count = intval($response->headers['x-records']);
   }
 
   /**

--- a/test/all_tests.php
+++ b/test/all_tests.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../vendor/autoload.php');
-require_once(__DIR__ . '/../vendor/lastcraft/simpletest/autorun.php');
+require_once(__DIR__ . '/../vendor/simpletest/simpletest/autorun.php');
 require_once(__DIR__ . '/test_helpers.php');
 
 

--- a/test/test_helpers.php
+++ b/test/test_helpers.php
@@ -19,8 +19,10 @@ function loadFixture($filename)
       break;
     }
     preg_match('/([^:]+): (.*)/', $fixture[$i], $matches);
-    if (sizeof($matches) > 2)
-      $headers[$matches[1]] = $matches[2];
+    if (sizeof($matches) > 2) {
+      $headerKey = strtolower($matches[1]);
+      $headers[$headerKey] = $matches[2];
+    }
   }
 
   if ($bodyLineNumber < sizeof($fixture))


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.