### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.0.9 (October 1, 2020)
+
+* Fixed issue with RFC 2616 compliance: headers should be treated as case-insensitive.
+
+## Version 2.0.8 (February 7, 2012)
 
 * Better parsing of transaction errors on one-time transaction requests.
 * Parse an array of plan_codes as strings in the coupon response.

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -29,7 +29,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.0.7';
+  const API_CLIENT_VERSION = '2.0.9';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';
@@ -160,8 +160,10 @@ class Recurly_Client
     $returnHeaders = array();
     foreach ($headers as &$header) {
       preg_match('/([^:]+): (.*)/', $header, $matches);
-      if (sizeof($matches) > 2)
-        $returnHeaders[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $returnHeaders[$headerKey] = $matches[2];
+      }
     }
     return $returnHeaders;
   }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -119,8 +119,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   private function _loadLinks($response) {
     $this->_links = array();
 
-    if (isset($response->headers['Link'])) {
-      $links = $response->headers['Link'];
+    if (isset($response->headers['link'])) {
+      $links = $response->headers['link'];
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {
@@ -135,8 +135,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
    */
   private function _loadRecordCount($response)
   {
-    if (empty($this->_count) && isset($response->headers['X-Records']))
-      $this->_count = intval($response->headers['X-Records']);
+    if (empty($this->_count) && isset($response->headers['x-records']))
+      $this->_count = intval($response->headers['x-records']);
   }
 
   /**

--- a/test/fixtures/transactions/show-200-error.xml
+++ b/test/fixtures/transactions/show-200-error.xml
@@ -1,0 +1,54 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890">
+  <account href="https://api.recurly.com/v2/accounts/verena"/>
+  <uuid>abcdef1234567890</uuid>
+  <action>purchase</action>
+  <amount_in_cents type="integer">30000</amount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <currency>USD</currency>
+  <status>declined</status>
+  <reference nil="nil"></reference>
+  <test type="boolean">true</test>
+  <voidable type="boolean">true</voidable>
+  <refundable type="boolean">true</refundable>
+  <transaction_error>
+    <error_code>invalid_card_number</error_code>
+    <error_category>hard</error_category>
+    <merchant_message>The credit card number is not valid. The customer needs to try a different number.</merchant_message>
+    <customer_message>Your card number is not valid. Please update your card number.</customer_message>
+  </transaction_error>
+  <cvv_result code=""></cvv_result>
+  <avs_result code=""></avs_result>
+  <avs_result_street nil="nil"></avs_result_street>
+  <avs_result_postal nil="nil"></avs_result_postal>
+  <created_at type="datetime">2011-04-30T12:00:00Z</created_at>
+  <details>
+    <account>
+      <account_code>gob</account_code>
+      <first_name>George Oscar</first_name>
+      <last_name>Bluth</last_name>
+      <company nil="nil"></company>
+      <email>gobias@bluth-company.com</email>
+      <billing_info type="credit_card">
+        <first_name nil="nil"></first_name>
+        <last_name nil="nil"></last_name>
+        <address1 nil="nil"></address1>
+        <address2 nil="nil"></address2>
+        <city nil="nil"></city>
+        <state nil="nil"></state>
+        <zip nil="nil"></zip>
+        <country nil="nil"></country>
+        <phone nil="nil"></phone>
+        <vat_number nil="nil"></vat_number>
+        <cc_type>visa</cc_type>
+        <year type="integer">2011</year>
+        <month type="integer">12</month>
+        <first_six>411111</first_six>
+        <last_four>1111</last_four>
+      </billing_info>
+    </account>
+  </details>
+</transaction>

--- a/test/recurly/recurlyjs_test.php
+++ b/test/recurly/recurlyjs_test.php
@@ -7,7 +7,7 @@ class Recurly_jsMock extends Recurly_js {
   }
 
   // Expose a protected static method for testing
-  function testGenerateSignature($claim, $values, $timestamp = null) {
+  static function testGenerateSignature($claim, $values, $timestamp = null) {
     return Recurly_js::_generateSignature($claim, $values, $timestamp);
   }
 }

--- a/test/test_helpers.php
+++ b/test/test_helpers.php
@@ -19,8 +19,10 @@ function loadFixture($filename)
       break;
     }
     preg_match('/([^:]+): (.*)/', $fixture[$i], $matches);
-    if (sizeof($matches) > 2)
-      $headers[$matches[1]] = $matches[2];
+    if (sizeof($matches) > 2) {
+      $headerKey = strtolower($matches[1]);
+      $headers[$headerKey] = $matches[2];
+    }
   }
 
   if ($bodyLineNumber < sizeof($fixture))


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.