### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: php
-php:
-  - 5.5
-  - 5.4
-  - 5.3
+jobs:
+  include:
+   - php: 5.5
+     dist: precise
+   - php: 5.4
+     dist: precise
+   - php: 5.3
+     dist: precise
 before_script:
   - composer install --dev
 script: phpunit Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.2.7 (October 1, 2020)
+
+* Fixed issue with RFC 2616 compliance: headers should be treated as case-insensitive.
+
 ## Version 2.2.6 (May 9th, 2014)
 
 * Added support for `Recurly_Account` field `balance_in_cents_invoiced` [#64]

--- a/Tests/test_helpers.php
+++ b/Tests/test_helpers.php
@@ -76,8 +76,10 @@ class Recurly_MockClient {
         break;
       }
       preg_match('/([^:]+): (.*)/', $fixture[$i], $matches);
-      if (sizeof($matches) > 2)
-        $headers[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $headers[$headerKey] = $matches[2];
+      }
     }
 
     if ($bodyLineNumber < sizeof($fixture))

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -34,7 +34,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.2.6';
+  const API_CLIENT_VERSION = '2.2.7';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';
@@ -175,8 +175,10 @@ class Recurly_Client
     $returnHeaders = array();
     foreach ($headers as &$header) {
       preg_match('/([^:]+): (.*)/', $header, $matches);
-      if (sizeof($matches) > 2)
-        $returnHeaders[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $returnHeaders[$headerKey] = $matches[2];
+      }
     }
     return $returnHeaders;
   }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -119,8 +119,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   private function _loadLinks($response) {
     $this->_links = array();
 
-    if (isset($response->headers['Link'])) {
-      $links = $response->headers['Link'];
+    if (isset($response->headers['link'])) {
+      $links = $response->headers['link'];
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {
@@ -135,8 +135,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
    */
   private function _loadRecordCount($response)
   {
-    if (empty($this->_count) && isset($response->headers['X-Records']))
-      $this->_count = intval($response->headers['X-Records']);
+    if (empty($this->_count) && isset($response->headers['x-records']))
+      $this->_count = intval($response->headers['x-records']);
   }
 
   /**


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.