### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: php
-php:
-  - 7
-  - 5.6
-  - 5.5
-  - 5.4
-  - 5.3
-  - hhvm
+jobs:
+  include:
+   - php: 7
+   - php: 5.6
+   - php: 5.5
+     dist: precise
+   - php: 5.4
+     dist: precise
+   - php: 5.3
+     dist: precise
+   - php: hhvm
 sudo: false
 install:
   - composer install --dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.5.4 (October 1, 2020)
+
+* Fixed issue with RFC 2616 compliance: headers should be treated as case-insensitive.
+
 ## Version 2.5.3 (July 5th, 2016)
 
 * Added support for setting `free_trial_amount` and `free_trial_unit` to `Recurly_Coupon` [#224](https://github.com/recurly/recurly-client-php/pull/224)

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -75,8 +75,10 @@ class Recurly_MockClient {
         break;
       }
       preg_match('/([^:]+): (.*)/', $fixture[$i], $matches);
-      if (sizeof($matches) > 2)
-        $headers[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $headers[$headerKey] = $matches[2];
+      }
     }
 
     if ($bodyLineNumber < sizeof($fixture))

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.5.3';
+  const API_CLIENT_VERSION = '2.5.4';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';
@@ -187,8 +187,10 @@ class Recurly_Client
     $returnHeaders = array();
     foreach ($headers as &$header) {
       preg_match('/([^:]+): (.*)/', $header, $matches);
-      if (sizeof($matches) > 2)
-        $returnHeaders[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $returnHeaders[$headerKey] = $matches[2];
+      }
     }
     return $returnHeaders;
   }

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -97,7 +97,7 @@ class Recurly_Coupon extends Recurly_Resource
     $response->assertValidResponse();
 
     $coupons = array();
-    foreach (new Recurly_UniqueCouponCodeList($response->headers['Location'], $this->_client) as $coupon) {
+    foreach (new Recurly_UniqueCouponCodeList($response->headers['location'], $this->_client) as $coupon) {
       $coupons[] = $coupon;
       if (count($coupons) == $number) break;
     }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -121,8 +121,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   private function _loadLinks($response) {
     $this->_links = array();
 
-    if (isset($response->headers['Link'])) {
-      $links = $response->headers['Link'];
+    if (isset($response->headers['link'])) {
+      $links = $response->headers['link'];
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {
@@ -137,8 +137,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
    */
   private function _loadRecordCount($response)
   {
-    if (isset($response->headers['X-Records'])) {
-      $this->_count = intval($response->headers['X-Records']);
+    if (isset($response->headers['x-records'])) {
+      $this->_count = intval($response->headers['x-records']);
     }
   }
 


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.