### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: php
-php:
-  - 7
-  - 5.6
-  - 5.5
-  - 5.4
-  - 5.3
-  - hhvm
+jobs:
+  include:
+   - php: 7
+   - php: 5.6
+   - php: 5.5
+     dist: precise
+   - php: 5.4
+     dist: precise
+   - php: 5.3
+     dist: precise
+   - php: hhvm
 sudo: false
 install:
   - composer install --dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.6.1 (October 1, 2020)
+
+* Fixed issue with RFC 2616 compliance: headers should be treated as case-insensitive.
+
 ## Version 2.6.0 (August 9th, 2016)
 
 * Upgraded to API V2.3: https://dev.recurly.com/v2.3/docs

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -75,8 +75,10 @@ class Recurly_MockClient {
         break;
       }
       preg_match('/([^:]+): (.*)/', $fixture[$i], $matches);
-      if (sizeof($matches) > 2)
-        $headers[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $headers[$headerKey] = $matches[2];
+      }
     }
 
     if ($bodyLineNumber < sizeof($fixture))

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.6.0';
+  const API_CLIENT_VERSION = '2.6.1';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';
@@ -188,8 +188,10 @@ class Recurly_Client
     $returnHeaders = array();
     foreach ($headers as &$header) {
       preg_match('/([^:]+): (.*)/', $header, $matches);
-      if (sizeof($matches) > 2)
-        $returnHeaders[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $returnHeaders[$headerKey] = $matches[2];
+      }
     }
     return $returnHeaders;
   }

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -97,7 +97,7 @@ class Recurly_Coupon extends Recurly_Resource
     $response->assertValidResponse();
 
     $coupons = array();
-    foreach (new Recurly_UniqueCouponCodeList($response->headers['Location'], $this->_client) as $coupon) {
+    foreach (new Recurly_UniqueCouponCodeList($response->headers['location'], $this->_client) as $coupon) {
       $coupons[] = $coupon;
       if (count($coupons) == $number) break;
     }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -120,8 +120,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
   private function _loadLinks($response) {
     $this->_links = array();
 
-    if (isset($response->headers['Link'])) {
-      $links = $response->headers['Link'];
+    if (isset($response->headers['link'])) {
+      $links = $response->headers['link'];
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {
@@ -136,8 +136,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator
    */
   private function _loadRecordCount($response)
   {
-    if (isset($response->headers['X-Records'])) {
-      $this->_count = intval($response->headers['X-Records']);
+    if (isset($response->headers['x-records'])) {
+      $this->_count = intval($response->headers['x-records']);
     }
   }
 

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -33,8 +33,8 @@ class Recurly_ClientResponse
 
   public function assertValidResponse()
   {
-    if (!empty($this->headers['Recurly-Deprecated'])) {
-      error_log("WARNING: API version {$this->headers['X-Api-Version']} is deprecated and will only be available until {$this->headers['Recurly-Sunset-Date']}. Please upgrade the Recurly PHP client.");
+    if (!empty($this->headers['recurly-deprecated'])) {
+      error_log("WARNING: API version {$this->headers['x-api-version']} is deprecated and will only be available until {$this->headers['recurly-sunset-date']}. Please upgrade the Recurly PHP client.");
     }
 
     // Successful response code


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.