### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: php
-php:
-  - 7.1
-  - 7.0
-  - 5.6
-  - 5.5
-  - 5.4
-  - hhvm
+jobs:
+  include:
+   - php: 7.1
+   - php: 7.0
+   - php: 5.6
+   - php: 5.5
+     dist: precise
+   - php: 5.4
+     dist: precise
+   - php: hhvm
 sudo: false
 dist: trusty
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.9.1 (October 1, 2020)
+
+* Fixed issue with RFC 2616 compliance: headers should be treated as case-insensitive.
+
 ## Version 2.9.0 (October 6th, 2017)
 
 This release will upgrade us to API version 2.8.

--- a/Tests/Recurly/Pager_Test.php
+++ b/Tests/Recurly/Pager_Test.php
@@ -82,7 +82,8 @@ class Recurly_PagerTest extends Recurly_TestCase
     $relative_url = '/mocks';
     $this->client->addResponse('GET', $relative_url, 'pager/index-1-200.xml');
 
-    $pager = (new Recurly_Stub('mocks', $relative_url, $this->client))->get();
+    $stub = new Recurly_Stub('mocks', $relative_url, $this->client);
+    $pager = $stub->get();
     $this->assertInstanceOf('Mock_Pager', $pager);
 
     // Until we've fetched a second page with a next link we'll keep using the

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -77,8 +77,10 @@ class Recurly_MockClient {
         break;
       }
       preg_match('/([^:]+): (.*)/', $fixture[$i], $matches);
-      if (sizeof($matches) > 2)
-        $headers[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $headers[$headerKey] = $matches[2];
+      }
     }
 
     if ($bodyLineNumber < sizeof($fixture))

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -44,7 +44,7 @@ class Recurly_Client
    */
   private $_acceptLanguage = 'en-US';
 
-  const API_CLIENT_VERSION = '2.9.0';
+  const API_CLIENT_VERSION = '2.9.1';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';
@@ -193,8 +193,10 @@ class Recurly_Client
     $returnHeaders = array();
     foreach ($headers as &$header) {
       preg_match('/([^:]+): (.*)/', $header, $matches);
-      if (sizeof($matches) > 2)
-        $returnHeaders[$matches[1]] = $matches[2];
+      if (sizeof($matches) > 2) {
+        $headerKey = strtolower($matches[1]);
+        $returnHeaders[$headerKey] = $matches[2];
+      }
     }
     return $returnHeaders;
   }

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -109,7 +109,7 @@ class Recurly_Coupon extends Recurly_Resource
     $response->assertValidResponse();
 
     $coupons = array();
-    foreach (new Recurly_UniqueCouponCodeList($response->headers['Location'], $this->_client) as $coupon) {
+    foreach (new Recurly_UniqueCouponCodeList($response->headers['location'], $this->_client) as $coupon) {
       $coupons[] = $coupon;
       if (count($coupons) == $number) break;
     }

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -20,8 +20,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   public function count() {
     if (isset($this->_href)) {
       $headers = Recurly_Base::_head($this->_href, $this->_client);
-      if (isset($headers['X-Records'])) {
-        return intval($headers['X-Records']);
+      if (isset($headers['x-records'])) {
+        return intval($headers['x-records']);
       }
     } elseif (isset($this->_objects) && is_array($this->_objects)) {
       return count($this->_objects);
@@ -119,8 +119,8 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   private function _loadLinks($response) {
     $this->_links = array();
 
-    if (isset($response->headers['Link'])) {
-      $links = $response->headers['Link'];
+    if (isset($response->headers['link'])) {
+      $links = $response->headers['link'];
       preg_match_all('/\<([^>]+)\>; rel=\"([^"]+)\"/', $links, $matches);
       if (sizeof($matches) > 2) {
         for ($i = 0; $i < sizeof($matches[1]); $i++) {

--- a/lib/recurly/response.php
+++ b/lib/recurly/response.php
@@ -41,8 +41,8 @@ class Recurly_ClientResponse
 
   public function assertValidResponse()
   {
-    if (!empty($this->headers['Recurly-Deprecated'])) {
-      error_log("WARNING: API version {$this->headers['X-Api-Version']} is deprecated and will only be available until {$this->headers['Recurly-Sunset-Date']}. Please upgrade the Recurly PHP client.");
+    if (!empty($this->headers['recurly-deprecated'])) {
+      error_log("WARNING: API version {$this->headers['x-api-version']} is deprecated and will only be available until {$this->headers['recurly-sunset-date']}. Please upgrade the Recurly PHP client.");
     }
 
     // Successful response code


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.