### PR TITLE
Implement Pager#take

### DIFF
--- a/lib/recurly/page.php
+++ b/lib/recurly/page.php
@@ -23,6 +23,16 @@ class Page extends \Recurly\RecurlyResource
     }
 
     /**
+     * Getter method for the Page results.
+     * 
+     * @return array
+     */
+    public function getData(): array
+    {
+        return $this->_data;
+    }
+
+    /**
      * Indicates whether there are more pages of results.
      * 
      * @return bool

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -64,7 +64,7 @@ class Pager implements \Iterator
      */
     public function getFirst(): ?\Recurly\RecurlyResource
     {
-        $params = array_merge([ 'limit' => 1 ], $this->_params);
+        $params = array_merge($this->_params, [ 'limit' => 1 ]);
         $page = $this->_client->nextPage($this->_path, $params);
         if ($page->valid()) {
             return $page->current();
@@ -80,7 +80,7 @@ class Pager implements \Iterator
      */
     public function take(int $n): ?array
     {
-        $params = array_merge([ 'limit' => $n ], $this->_params);
+        $params = array_merge($this->_params, [ 'limit' => $n ]);
         $page = $this->_client->nextPage($this->_path, $params);
         if ($page->valid()) {
             return $page->getData();

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -73,6 +73,22 @@ class Pager implements \Iterator
     }
 
     /**
+     * Performs a request with the pager `limit` set to `n` and only returns the
+     * first `n` results in the response. 
+     * 
+     * @return array
+     */
+    public function take(int $n): ?array
+    {
+        $params = array_merge([ 'limit' => $n ], $this->_params);
+        $page = $this->_client->nextPage($this->_path, $params);
+        if ($page->valid()) {
+            return $page->getData();
+        }
+        return null;
+    }
+
+    /**
      * Getter for the Recurly HTTP Response of the current Page
      * 
      * @return \Recurly\Response The Recurly HTTP Response

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -70,7 +70,7 @@ final class PagerTest extends RecurlyTestCase
         $result = '{"object":"list","has_more":true,"next":"page_two","data":[{"object":"test_resource","name":"resource one"}]}';
         $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
 
-        $pager = new \Recurly\Pager($this->client, '/resources', ['limit' => 5]);
+        $pager = new \Recurly\Pager($this->client, '/resources', [ 'limit' => 5 ]);
         $this->assertInstanceOf(
             \Recurly\Resources\TestResource::class,
             $pager->getFirst()
@@ -96,7 +96,7 @@ final class PagerTest extends RecurlyTestCase
         ]}';        
         $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
 
-        $pager = new \Recurly\Pager($this->client, '/resources', [ 'limit' => 200]);
+        $pager = new \Recurly\Pager($this->client, '/resources', [ 'limit' => 200 ]);
         $this->assertEquals(2, count($pager->take(2))
         );
     }

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -87,6 +87,20 @@ final class PagerTest extends RecurlyTestCase
         $this->assertNull($pager->getFirst());
     }
 
+    public function testTake(): void
+    {
+        $url = "https://v3.recurly.com/resources?limit=2";
+        $result = '{"object":"list","has_more":true,"next":"page_two","data":[
+          {"object":"test_resource","name":"resource one"},
+          {"object":"test_resource","name":"resource two"}
+        ]}';        
+        $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
+
+        $pager = new \Recurly\Pager($this->client, '/resources');
+        $this->assertEquals(2, count($pager->take(2))
+        );
+    }
+
     public function testGetCount(): void
     {
         $url = "https://v3.recurly.com/resources";

--- a/tests/Pager_Test.php
+++ b/tests/Pager_Test.php
@@ -70,7 +70,7 @@ final class PagerTest extends RecurlyTestCase
         $result = '{"object":"list","has_more":true,"next":"page_two","data":[{"object":"test_resource","name":"resource one"}]}';
         $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
 
-        $pager = new \Recurly\Pager($this->client, '/resources');
+        $pager = new \Recurly\Pager($this->client, '/resources', ['limit' => 5]);
         $this->assertInstanceOf(
             \Recurly\Resources\TestResource::class,
             $pager->getFirst()
@@ -96,7 +96,7 @@ final class PagerTest extends RecurlyTestCase
         ]}';        
         $this->client->addScenario("GET", $url, NULL, $result, "200 OK");
 
-        $pager = new \Recurly\Pager($this->client, '/resources');
+        $pager = new \Recurly\Pager($this->client, '/resources', [ 'limit' => 200]);
         $this->assertEquals(2, count($pager->take(2))
         );
     }


### PR DESCRIPTION
`take($n)` is similar to `getFirst()` except that it returns an array of `n` records. This allows users to fetch a determined number of records instead of all of them.

```php
$params = [
  'order' => 'asc',
];
// takes the first 12 accounts
$accounts = $client->listAccounts($params)->take(12);
foreach($accounts as $account) {
  echo 'Account code: ' . $account->getCode() . PHP_EOL;
}
```