### PR TITLE
Support item-specific coupons

### DIFF
--- a/Tests/Recurly/Coupon_Test.php
+++ b/Tests/Recurly/Coupon_Test.php
@@ -90,7 +90,7 @@ class Recurly_CouponTest extends Recurly_TestCase
     $coupon = Recurly_Coupon::get('special', $this->client);
 
     $this->assertInstanceOf('Recurly_Coupon', $coupon);
-    $this->assertTrue($coupon->applies_to_all_plans);
+    $this->assertFalse($coupon->applies_to_all_plans);
     $this->assertEquals(array('plan_one', 'plan_two'), $coupon->plan_codes);
   }
 

--- a/Tests/Recurly/Coupon_Test.php
+++ b/Tests/Recurly/Coupon_Test.php
@@ -94,6 +94,16 @@ class Recurly_CouponTest extends Recurly_TestCase
     $this->assertEquals(array('plan_one', 'plan_two'), $coupon->plan_codes);
   }
 
+  public function testItemCodesXml() {
+    $this->client->addResponse('GET', '/coupons/special', 'coupons/show-200-3.xml');
+
+    $coupon = Recurly_Coupon::get('special', $this->client);
+
+    $this->assertInstanceOf('Recurly_Coupon', $coupon);
+    $this->assertFalse($coupon->applies_to_all_items);
+    $this->assertEquals(array('item_one', 'item_two', 'item_three'), $coupon->item_codes);
+  }
+
   public function testXml() {
     $coupon = new Recurly_Coupon();
     $coupon->coupon_code = 'fifteen-off';
@@ -123,6 +133,21 @@ class Recurly_CouponTest extends Recurly_TestCase
     );
   }
 
+  public function testXmlWithItems() {
+    $coupon = new Recurly_Coupon();
+    $coupon->coupon_code = 'twenty-off';
+    $coupon->name = '$20 Off';
+    $coupon->discount_type = 'dollar';
+    $coupon->discount_in_cents->addCurrency('USD', 2000);
+    $coupon->item_codes = array('item_one', 'item_two', 'item_three');
+    $coupon->invoice_description = 'Invoice description';
+
+    $this->assertEquals(
+      "<?xml version=\"1.0\"?>\n<coupon><coupon_code>twenty-off</coupon_code><name>$20 Off</name><discount_type>dollar</discount_type><discount_in_cents><USD>2000</USD></discount_in_cents><item_codes><item_code>item_one</item_code><item_code>item_two</item_code><item_code>item_three</item_code></item_codes><invoice_description>Invoice description</invoice_description></coupon>\n",
+      $coupon->xml()
+    );
+  }
+
   public function testCreateUpdateXML() {
     $coupon = new Recurly_Coupon();
 
@@ -131,6 +156,7 @@ class Recurly_CouponTest extends Recurly_TestCase
     $coupon->discount_type = 'dollar';
     $coupon->discount_in_cents->addCurrency('USD', 1500);
     $coupon->plan_codes = array('gold', 'monthly');
+    $coupon->item_codes = array('item_one', 'item_two', 'item_three');
 
     // should serialize these values
     $coupon->name = '$15 Off';

--- a/Tests/fixtures/coupons/show-200-2.xml
+++ b/Tests/fixtures/coupons/show-200-2.xml
@@ -15,7 +15,7 @@ Content-Type: application/xml; charset=utf-8
   <single_use type="boolean">false</single_use>
   <applies_for_months nil="nil"></applies_for_months>
   <max_redemptions nil="nil"></max_redemptions>
-  <applies_to_all_plans type="boolean">true</applies_to_all_plans>
+  <applies_to_all_plans type="boolean">false</applies_to_all_plans>
   <redemption_resource>account</redemption_resource>
   <created_at type="datetime">2011-04-10T07:00:00Z</created_at>
   <duration>forever</duration>

--- a/Tests/fixtures/coupons/show-200-3.xml
+++ b/Tests/fixtures/coupons/show-200-3.xml
@@ -1,0 +1,35 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<coupon href="https://api.recurly.com/v2/coupons/special">
+  <redemptions href="https://api.recurly.com/v2/coupons/special/redemptions"/>
+  <coupon_code>special</coupon_code>
+  <name>Special 50% Discount</name>
+  <state>redeemable</state>
+  <description></description>
+  <discount_type>percent</discount_type>
+  <discount_percent type="integer">50</discount_percent>
+  <invoice_description>Invoice description</invoice_description>
+  <redeem_by_date type="datetime">2020-04-09T07:00:00Z</redeem_by_date>
+  <single_use type="boolean">false</single_use>
+  <applies_for_months nil="nil"></applies_for_months>
+  <max_redemptions nil="nil"></max_redemptions>
+  <applies_to_all_plans type="boolean">false</applies_to_all_plans>
+  <applies_to_all_items type="boolean">false</applies_to_all_items>
+  <redemption_resource>account</redemption_resource>
+  <created_at type="datetime">2011-04-10T07:00:00Z</created_at>
+  <duration>forever</duration>
+  <temporal_unit></temporal_unit>
+  <temporal_amount type="integer"></temporal_amount>
+  <plan_codes type="array">
+    <plan_code>plan_one</plan_code>
+    <plan_code>plan_two</plan_code>
+  </plan_codes>
+  <item_codes type="array">
+    <item_code>item_one</item_code>
+    <item_code>item_two</item_code>
+    <item_code>item_three</item_code>
+  </item_codes>
+  <a name="redeem" href="https://api.recurly.com/v2/coupons/special/redeem" method="post"/>
+</coupon>

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -273,6 +273,8 @@ abstract class Recurly_Base
     'invoice_collection' => 'Recurly_InvoiceCollection',
     'item' => 'Recurly_Item',
     'items' => 'Recurly_ItemList',
+    'item_code' => 'string',
+    'item_codes' => 'array',
     'line_items' => 'array',
     'measured_unit' => 'Recurly_MeasuredUnit',
     'measured_units' => 'Recurly_MeasuredUnitList',

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -13,6 +13,7 @@
  * @property string $invoice_description Description of the coupon on the invoice.
  * @property int $max_redemptions Maximum number of accounts that may use the coupon before it can no longer be redeemed.
  * @property boolean $applies_to_all_plans The coupon is valid for all plans if true, defaults to true.
+ * @property boolean $applies_to_all_items The coupon is valid for all items if true, defaults to false.
  * @property string $duration Allowed values: [forever, single_use, temporal].  If single_use, the coupon applies to the first invoice only. If temporal the coupon will apply to invoices for the duration determined by the temporal_unit and temporal_amount attributes.
  * @property string $temporal_unit Allowed values: [day, week, month, year]. If duration is temporal then temporal_unit is multiplied by temporal_amount to define the duration that the coupon will be applied to invoices for.
  * @property integer $temporal_amount If duration is temporal then temporal_amount is an integer which is multiplied by temporal_unit to define the duration that the coupon will be applied to invoices for.
@@ -22,6 +23,7 @@
  * @property string $coupon_type Allowed values: [single_code, bulk]. Bulk coupons will require a unique_code_template and will generate unique codes through the generate endpoint.
  * @property string $unique_code_template The template for generating unique codes. See rules in the coupon docs: https://dev.recurly.com/docs/create-coupon
  * @property string[] $plan_codes Array of plan_codes the coupon applies to, if applies_to_all_plans is false.
+ * @property string[] $item_codes Array of item_codes the coupon applies to, if applies_to_all_items is false.
  * @property int $free_trial_amount Only relevant when the coupon type is free_trial. The free_trial_amount is used together with free_trial_unit to define the length of a free trial coupon. For example, a 2 week free trial would be defined as free_trial_amount = 2 and free_trial_unit = Week.
  * @property string $free_trial_unit Only relevant when the coupon type is free_trial. Allowed values are day or week or month. free_trial_unit is used together with free_trial_unit to define the length of a free trial coupon. For example, a 2 week free trial would be defined as free_trial_amount = 2 and free_trial_unit = Week.
  * @property DateTime $redeem_by_date Last date to redeem the coupon, defaults to no date.
@@ -166,8 +168,8 @@ class Recurly_Coupon extends Recurly_Resource
     return array(
       'coupon_code', 'name', 'discount_type', 'redeem_by_date', 'single_use',
       'applies_for_months', 'duration', 'temporal_unit', 'temporal_amount',
-      'max_redemptions', 'applies_to_all_plans', 'discount_percent',
-      'discount_in_cents', 'plan_codes', 'hosted_description',
+      'max_redemptions', 'applies_to_all_plans', 'applies_to_all_items', 'discount_percent',
+      'discount_in_cents', 'plan_codes', 'item_codes', 'hosted_description',
       'invoice_description', 'applies_to_non_plan_charges', 'redemption_resource',
       'max_redemptions_per_account', 'coupon_type', 'unique_code_template',
       'unique_coupon_codes', 'discount_type', 'free_trial_amount',


### PR DESCRIPTION
Add `item_codes` and `applies_to_all_items` to Coupon

Example:
```php
$coupon = new Recurly_Coupon();
$couponCode = 'special';
$coupon->name = 'Special';
$coupon->coupon_code = $couponCode;
$coupon->discount_type = 'percent';
$coupon->discount_percent = 20;
// `applies_to_all_items` defaults to false, so next line is optional
$coupon->applies_to_all_items = false
$coupon->item_codes = array('item_one', 'item_two', 'item_three');
$coupon->create();
```