### PR TITLE
Release 2.12.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.18 (November 5, 2020)
+
+* Support item-specific coupons [PR](https://github.com/recurly/recurly-client-php/pull/563)
+
 ## Version 2.12.17 (September 17, 2020)
 
 * New endpoint to verify an account's billing information [PR](https://github.com/recurly/recurly-client-php/pull/538)

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -51,7 +51,7 @@ class Recurly_Client
    */
   private static $apiUrl = 'https://%s.recurly.com/v2';
 
-  const API_CLIENT_VERSION = '2.12.17';
+  const API_CLIENT_VERSION = '2.12.18';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
- Bump PHP client library version to 2.12.18
- Update changelog

-----

- Support item-specific coupons https://github.com/recurly/recurly-client-php/pull/563
