### PR TITLE
Augment and patch iban implementation

### DIFF
--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -81,7 +81,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
   public function testGetIbanBillingInfo() {
     $billing_info = Recurly_BillingInfo::get('sepa1234567890', $this->client);
     $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
-    $this->assertEquals($billing_info->iban, 'US1234567890');
+    $this->assertEquals($billing_info->last_two, '06');
     $this->assertEquals($billing_info->name_on_account, 'Account Name');
   }
 

--- a/Tests/fixtures/billing_info/show-sepa-200.xml
+++ b/Tests/fixtures/billing_info/show-sepa-200.xml
@@ -5,14 +5,15 @@ Content-Type: application/xml; charset=utf-8
 <billing_info href="https://api.recurly.com/v2/accounts/sepa1234567890/billing_info">
   <account href="https://api.recurly.com/v2/accounts/sepa1234567890"/>
   <company nil="nil"></company>
-  <address1>123 Pretty Pretty Good St.</address1>
+  <address1 nil="nil"></address1>
   <address2 nil="nil"></address2>
-  <city>Los Angeles</city>
-  <state>CA</state>
-  <zip>90210</zip>
-  <country>US</country>
+  <city nil="nil"></city>
+  <state nil="nil"></state>
+  <zip nil="nil"></zip>
+  <country>FR</country>
   <phone nil="nil"></phone>
   <vat_number nil="nil"></vat_number>
-  <iban>US1234567890</iban>
   <name_on_account>Account Name</name_on_account>
+  <last_two>06</last_two>
+  <updated_at type="datetime">2020-11-06T21:57:23Z</updated_at>
 </billing_info>

--- a/lib/recurly/billing_info.php
+++ b/lib/recurly/billing_info.php
@@ -36,6 +36,7 @@
  * @property string $transaction_type Indicates type of resulting transaction. accepted_values: "moto".
  * @property-read string $first_six Credit card number, first six digits
  * @property-read string $last_four Credit card number, last four digits
+ * @property-read string $last_two International bank account number (IBAN), last two digits 
  * @property string $card_type Visa, MasterCard, American Express, Discover, JCB, etc
  * @property-write string $three_d_secure_action_result_token_id An id returned by Recurly.js referencing the result of the 3DS authentication for PSD2
  * @property string $iban International bank account number developed to identify an overseas bank account


### PR DESCRIPTION
- `last_two` added to php docs
- Test has also been fixed to include `last_two` and remove `iban`, which was included erroneously.