### PR TITLE
Latest Changes for 2019-10-10

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -403,6 +403,7 @@ class Client extends BaseClient
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
      * - $options['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
      *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
+     * - $options['state'] (string): Filter by state.
      *
      * @return \Recurly\Pager A list of the the coupon redemptions on an account.
      * @link   https://developers.recurly.com/api/v2019-10-10#operation/list_account_coupon_redemptions
@@ -2148,6 +2149,7 @@ class Client extends BaseClient
      *        In the event that the most recent invoice is a $0 invoice paid entirely by credit, Recurly will apply the credit back to the customer’s account.
      *        
      *        You may also terminate a subscription with no refund and then manually refund specific invoices.
+     * - $options['charge'] (bool): Applicable only if the subscription has usage based add-ons and unbilled usage logged for the current billing cycle. If true, current billing cycle unbilled usage is billed on the final invoice. If false, Recurly will create a negative usage record for current billing cycle usage that will zero out the final invoice line items.
      *
      * @return \Recurly\Resources\Subscription An expired subscription.
      * @link   https://developers.recurly.com/api/v2019-10-10#operation/terminate_subscription

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -271,7 +271,7 @@ class Subscription extends RecurlyResource
 
     /**
     * Getter method for the coupon_redemptions attribute.
-    * Coupon redemptions
+    * Returns subscription level coupon redemptions that are tied to this subscription.
     *
     * @return array
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -10043,7 +10043,7 @@ paths:
           }
       - lang: Go
         source: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
-          beans shipped monthly\"),\n\tCurrencies: []recurly.PricingCreate{\n\t\t{\n\t\t\tCurrency:
+          beans shipped monthly\"),\n\tCurrencies: []recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
           err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2481,6 +2481,7 @@ paths:
       - "$ref": "#/components/parameters/sort_dates"
       - "$ref": "#/components/parameters/filter_begin_time"
       - "$ref": "#/components/parameters/filter_end_time"
+      - "$ref": "#/components/parameters/filter_state"
       responses:
         '200':
           description: A list of the the coupon redemptions on an account.
@@ -10042,7 +10043,7 @@ paths:
           }
       - lang: Go
         source: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
-          beans shipped monthly\"),\n\tCurrencies: []recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
+          beans shipped monthly\"),\n\tCurrencies: []recurly.PricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
           err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
@@ -11451,6 +11452,16 @@ paths:
           - partial
           - none
           default: none
+      - name: charge
+        in: query
+        description: Applicable only if the subscription has usage based add-ons and
+          unbilled usage logged for the current billing cycle. If true, current billing
+          cycle unbilled usage is billed on the final invoice. If false, Recurly will
+          create a negative usage record for current billing cycle usage that will
+          zero out the final invoice line items.
+        schema:
+          default: true
+          type: boolean
       responses:
         '200':
           description: An expired subscription.
@@ -19310,6 +19321,8 @@ components:
         coupon_redemptions:
           type: array
           title: Coupon redemptions
+          description: Returns subscription level coupon redemptions that are tied
+            to this subscription.
           items:
             "$ref": "#/components/schemas/CouponRedemptionMini"
         pending_change:


### PR DESCRIPTION
- Adds the `state` parameter to the `listAccountCouponRedemptions` operation.
- Adds the `charge` parameter to the `terminateSubscription` operation so that a merchant can choose to not bill a customer for un-billed usage when terminating a subscription 