### PR TITLE
Configure bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,9 @@
+[bumpversion]
+current_version = 2.12.19
+parse = (?P<major>\d+)
+	\.(?P<minor>\d+)
+	\.(?P<patch>\d+)
+serialize = 
+	{major}.{minor}.{patch}
+
+[bumpversion:file:lib/recurly/client.php]

--- a/scripts/bump
+++ b/scripts/bump
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+bump2version "$@"


### PR DESCRIPTION
Add ability to bump client library version with a script instead of needing to do so manually