### PR TITLE
Release 2.12.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Recurly PHP Client Library CHANGELOG
 
+## Version 2.12.20 (February 22, 2020)
+* PHPDoc: fix type of invoice type should be string instead of int [PR](https://github.com/recurly/recurly-client-php/pull/575)
+* Update language to match sunset policy [PR](https://github.com/recurly/recurly-client-php/pull/576)
+* Transaction: update phpdoc for invoice property [PR](https://github.com/recurly/recurly-client-php/pull/578)
+* PHPDoc: fix type of invoice origin - should be string instead of int [PR](https://github.com/recurly/recurly-client-php/pull/580)
+
 ## Version 2.12.19 (November 23, 2020)
 
 * Implement Pager#take [PR](https://github.com/recurly/recurly-client-php/pull/562)

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -51,7 +51,7 @@ class Recurly_Client
    */
   private static $apiUrl = 'https://%s.recurly.com/v2';
 
-  const API_CLIENT_VERSION = '2.12.19';
+  const API_CLIENT_VERSION = '2.12.20';
   const DEFAULT_ENCODING = 'UTF-8';
 
   const GET = 'GET';


### PR DESCRIPTION
- Bump PHP client library version to 2.12.20
- Update changelog
------------

* PHPDoc: fix type of invoice type should be string instead of int https://github.com/recurly/recurly-client-php/pull/575
* Update language to match sunset policy https://github.com/recurly/recurly-client-php/pull/576
* Transaction: update phpdoc for invoice property https://github.com/recurly/recurly-client-php/pull/578
* PHPDoc: fix type of invoice origin - should be string instead of int https://github.com/recurly/recurly-client-php/pull/580