### PR TITLE
Change null to zero when attribute type is a float

### DIFF
--- a/lib/recurly/resources/account_acquisition_cost.php
+++ b/lib/recurly/resources/account_acquisition_cost.php
@@ -27,6 +27,7 @@ class AccountAcquisitionCost extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 

--- a/lib/recurly/resources/account_balance_amount.php
+++ b/lib/recurly/resources/account_balance_amount.php
@@ -27,6 +27,7 @@ class AccountBalanceAmount extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 

--- a/lib/recurly/resources/add_on.php
+++ b/lib/recurly/resources/add_on.php
@@ -609,6 +609,7 @@ to configure quantity-based pricing models.
     */
     public function getUsagePercentage(): ?float
     {
+        is_null($this->usage_percentage) ? $this->_usage_percentage = 0 : '';
         return $this->_usage_percentage;
     }
 

--- a/lib/recurly/resources/add_on_mini.php
+++ b/lib/recurly/resources/add_on_mini.php
@@ -243,6 +243,7 @@ class AddOnMini extends RecurlyResource
     */
     public function getUsagePercentage(): ?float
     {
+        is_null($this->usage_percentage) ? $this->_usage_percentage = 0 : '';
         return $this->_usage_percentage;
     }
 

--- a/lib/recurly/resources/add_on_pricing.php
+++ b/lib/recurly/resources/add_on_pricing.php
@@ -51,6 +51,7 @@ class AddOnPricing extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/coupon_discount_pricing.php
+++ b/lib/recurly/resources/coupon_discount_pricing.php
@@ -27,6 +27,7 @@ class CouponDiscountPricing extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 

--- a/lib/recurly/resources/coupon_redemption.php
+++ b/lib/recurly/resources/coupon_redemption.php
@@ -128,6 +128,7 @@ class CouponRedemption extends RecurlyResource
     */
     public function getDiscounted(): ?float
     {
+        is_null($this->discounted) ? $this->_discounted = 0 : '';
         return $this->_discounted;
     }
 

--- a/lib/recurly/resources/coupon_redemption_mini.php
+++ b/lib/recurly/resources/coupon_redemption_mini.php
@@ -77,6 +77,7 @@ class CouponRedemptionMini extends RecurlyResource
     */
     public function getDiscounted(): ?float
     {
+        is_null($this->discounted) ? $this->_discounted = 0 : '';
         return $this->_discounted;
     }
 

--- a/lib/recurly/resources/credit_payment.php
+++ b/lib/recurly/resources/credit_payment.php
@@ -85,6 +85,7 @@ class CreditPayment extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 

--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -111,6 +111,7 @@ class Invoice extends RecurlyResource
     */
     public function getBalance(): ?float
     {
+        is_null($this->balance) ? $this->_balance = 0 : '';
         return $this->_balance;
     }
 
@@ -295,6 +296,7 @@ class Invoice extends RecurlyResource
     */
     public function getDiscount(): ?float
     {
+        is_null($this->discount) ? $this->_discount = 0 : '';
         return $this->_discount;
     }
 
@@ -502,6 +504,7 @@ class Invoice extends RecurlyResource
     */
     public function getPaid(): ?float
     {
+        is_null($this->paid) ? $this->_paid = 0 : '';
         return $this->_paid;
     }
 
@@ -571,6 +574,7 @@ class Invoice extends RecurlyResource
     */
     public function getRefundableAmount(): ?float
     {
+        is_null($this->refundable_amount) ? $this->_refundable_amount = 0 : '';
         return $this->_refundable_amount;
     }
 
@@ -663,6 +667,7 @@ class Invoice extends RecurlyResource
     */
     public function getSubtotal(): ?float
     {
+        is_null($this->subtotal) ? $this->_subtotal = 0 : '';
         return $this->_subtotal;
     }
 
@@ -686,6 +691,7 @@ class Invoice extends RecurlyResource
     */
     public function getTax(): ?float
     {
+        is_null($this->tax) ? $this->_tax = 0 : '';
         return $this->_tax;
     }
 
@@ -755,6 +761,7 @@ class Invoice extends RecurlyResource
     */
     public function getTotal(): ?float
     {
+        is_null($this->total) ? $this->_total = 0 : '';
         return $this->_total;
     }
 

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -165,6 +165,7 @@ class LineItem extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 
@@ -257,6 +258,7 @@ class LineItem extends RecurlyResource
     */
     public function getCreditApplied(): ?float
     {
+        is_null($this->credit_applied) ? $this->_credit_applied = 0 : '';
         return $this->_credit_applied;
     }
 
@@ -349,6 +351,7 @@ class LineItem extends RecurlyResource
     */
     public function getDiscount(): ?float
     {
+        is_null($this->discount) ? $this->_discount = 0 : '';
         return $this->_discount;
     }
 
@@ -722,6 +725,7 @@ class LineItem extends RecurlyResource
     */
     public function getProrationRate(): ?float
     {
+        is_null($this->proration_rate) ? $this->_proration_rate = 0 : '';
         return $this->_proration_rate;
     }
 
@@ -929,6 +933,7 @@ class LineItem extends RecurlyResource
     */
     public function getSubtotal(): ?float
     {
+        is_null($this->subtotal) ? $this->_subtotal = 0 : '';
         return $this->_subtotal;
     }
 
@@ -952,6 +957,7 @@ class LineItem extends RecurlyResource
     */
     public function getTax(): ?float
     {
+        is_null($this->tax) ? $this->_tax = 0 : '';
         return $this->_tax;
     }
 
@@ -1090,6 +1096,7 @@ class LineItem extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/plan_pricing.php
+++ b/lib/recurly/resources/plan_pricing.php
@@ -51,6 +51,7 @@ class PlanPricing extends RecurlyResource
     */
     public function getSetupFee(): ?float
     {
+        is_null($this->setup_fee) ? $this->_setup_fee = 0 : '';
         return $this->_setup_fee;
     }
 
@@ -74,6 +75,7 @@ class PlanPricing extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/pricing.php
+++ b/lib/recurly/resources/pricing.php
@@ -50,6 +50,7 @@ class Pricing extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -139,6 +139,7 @@ class Subscription extends RecurlyResource
     */
     public function getAddOnsTotal(): ?float
     {
+        is_null($this->add_ons_total) ? $this->_add_ons_total = 0 : '';
         return $this->_add_ons_total;
     }
 
@@ -852,6 +853,7 @@ class Subscription extends RecurlyResource
     */
     public function getSubtotal(): ?float
     {
+        is_null($this->subtotal) ? $this->_subtotal = 0 : '';
         return $this->_subtotal;
     }
 
@@ -967,6 +969,7 @@ class Subscription extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/subscription_add_on.php
+++ b/lib/recurly/resources/subscription_add_on.php
@@ -304,6 +304,7 @@ removed and replaced by the tiers in the request.
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 
@@ -373,6 +374,7 @@ removed and replaced by the tiers in the request.
     */
     public function getUsagePercentage(): ?float
     {
+        is_null($this->usage_percentage) ? $this->_usage_percentage = 0 : '';
         return $this->_usage_percentage;
     }
 

--- a/lib/recurly/resources/subscription_add_on_tier.php
+++ b/lib/recurly/resources/subscription_add_on_tier.php
@@ -51,6 +51,7 @@ class SubscriptionAddOnTier extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/subscription_change.php
+++ b/lib/recurly/resources/subscription_change.php
@@ -365,6 +365,7 @@ class SubscriptionChange extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/subscription_shipping.php
+++ b/lib/recurly/resources/subscription_shipping.php
@@ -52,6 +52,7 @@ class SubscriptionShipping extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 

--- a/lib/recurly/resources/tax_info.php
+++ b/lib/recurly/resources/tax_info.php
@@ -28,6 +28,7 @@ class TaxInfo extends RecurlyResource
     */
     public function getRate(): ?float
     {
+        is_null($this->rate) ? $this->_rate = 0 : '';
         return $this->_rate;
     }
 

--- a/lib/recurly/resources/tier_pricing.php
+++ b/lib/recurly/resources/tier_pricing.php
@@ -51,6 +51,7 @@ class TierPricing extends RecurlyResource
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 

--- a/lib/recurly/resources/transaction.php
+++ b/lib/recurly/resources/transaction.php
@@ -86,6 +86,7 @@ class Transaction extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 
@@ -408,6 +409,7 @@ class Transaction extends RecurlyResource
     */
     public function getGatewayResponseTime(): ?float
     {
+        is_null($this->gateway_response_time) ? $this->_gateway_response_time = 0 : '';
         return $this->_gateway_response_time;
     }
 

--- a/lib/recurly/resources/usage.php
+++ b/lib/recurly/resources/usage.php
@@ -42,6 +42,7 @@ class Usage extends RecurlyResource
     */
     public function getAmount(): ?float
     {
+        is_null($this->amount) ? $this->_amount = 0 : '';
         return $this->_amount;
     }
 
@@ -276,6 +277,7 @@ to configure quantity-based pricing models.
     */
     public function getUnitAmount(): ?float
     {
+        is_null($this->unit_amount) ? $this->_unit_amount = 0 : '';
         return $this->_unit_amount;
     }
 
@@ -345,6 +347,7 @@ to configure quantity-based pricing models.
     */
     public function getUsagePercentage(): ?float
     {
+        is_null($this->usage_percentage) ? $this->_usage_percentage = 0 : '';
         return $this->_usage_percentage;
     }
 


### PR DESCRIPTION
Addresses report where a subscription/plan with `unitAmount` of zero will return `NULL` when calling `getUnitAmount()`. This PR accounts for all instances where an attribute type is a float and returns null, and instead forces it to return zero. I targeted all floats instead of just the `unitAmount` attribute, as the merchant has reported encountering the same bug in other instances, e.g. `getTax()`.