### PR TITLE
Release 4.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.0
+current_version = 4.0.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -9,4 +9,3 @@ serialize =
 [bumpversion:file:composer.json]
 
 [bumpversion:file:lib/recurly/version.php]
-

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "recurly/recurly-client",
-    "version": "3.4.0",
+    "version": "4.0.0",
     "type": "library",
     "description": "The PHP client library for the Recurly API",
     "keywords": ["recurly", "payments", "pay"],

--- a/lib/recurly/version.php
+++ b/lib/recurly/version.php
@@ -4,5 +4,5 @@ namespace Recurly;
 
 class Version
 {
-    public const CURRENT = '3.4.0';
+    public const CURRENT = '4.0.0';
 }


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-php/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-php/compare/3.11.0...HEAD)

# Major Version Release

The 4.x major version of the client pairs with the `v2021-02-25` API version. This version of the client and the API contain breaking changes that should be considered before upgrading your integration.

## Breaking Changes in the API
All changes to the core API are documented in the [Developer Portal changelog](https://developers.recurly.com/api/changelog.html#v2021-02-25---current-ga-version)

## Breaking Changes in Client

- Require query string parameters to be specified under the `params` key of the `$options` parameter. [[#522](https://github.com/recurly/recurly-client-php/pull/522)]

    ### 3.x
    ```php
    $options = [
      'limit' => 200
    ];
    $accounts = $client->listAccounts($options);
   ```
    ### 4.x
    ```php
    $options = [
      'params' => [
        'limit' => 200
      ],
      'headers' => [
        'Accept-Language' => 'fr'
      ]
    ];
    $accounts = $client->listAccounts($options);
    ```

**Implemented enhancements:**

- Updating operations to accept generic request options instead of just query parameters [\#522](https://github.com/recurly/recurly-client-php/pull/522) ([douglasmiller](https://github.com/douglasmiller))

**Merged pull requests:**

- Updating changelog script and changelog generator config for 4.x release [\#582](https://github.com/recurly/recurly-client-php/pull/582) ([douglasmiller](https://github.com/douglasmiller))
- Null checking variable before calling property\_exists to prevent Warning [\#526](https://github.com/recurly/recurly-client-php/pull/526) ([douglasmiller](https://github.com/douglasmiller))
- Mon Jul  6 14:54:15 UTC 2020 Upgrade API version v2019-10-10 [\#515](https://github.com/recurly/recurly-client-php/pull/515) ([douglasmiller](https://github.com/douglasmiller))