### PR TITLE
Replace empty() with is_null()

### DIFF
--- a/lib/recurly/recurly_resource.php
+++ b/lib/recurly/recurly_resource.php
@@ -100,7 +100,7 @@ abstract class RecurlyResource
     {
         $klass = new static();
         foreach ($data as $key => $value) {
-            if (empty($value)) {
+            if (is_null($value)) {
                 continue;
             }
 

--- a/tests/RecurlyResource_Test.php
+++ b/tests/RecurlyResource_Test.php
@@ -22,6 +22,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
     public function testFromJsonValidResource(): void
     {
         $test_resource = (object)array(
+            "id" => "0",
             "object" => "test_resource",
             "name" => "test-resource",
             "single_child" => (object)array(
@@ -42,22 +43,7 @@ final class RecurlyResourceTest extends RecurlyTestCase
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result);
         $this->assertEquals($response, $result->getResponse());
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result->getSingleChild());
-    }
-
-    public function testCast(): void
-    // accepts response object of decoded json
-    // returns RecurlyResource
-    {
-        $test_response_object = (object)array(
-            "id" => 0,
-            "object" => "plan",
-            "name" => "0",
-        );
-
-        $resource = Recurly\Resources\TestResource::cast($test_response_object);
-        $this->assertNotNull($resource->getName());
-        $this->assertNotNull($resource->getId());
-        $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $resource);
+        $this->assertEquals($result->getId(), 0);
     }
 
     public function testFromJsonUnknownKeys(): void

--- a/tests/RecurlyResource_Test.php
+++ b/tests/RecurlyResource_Test.php
@@ -44,6 +44,22 @@ final class RecurlyResourceTest extends RecurlyTestCase
         $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $result->getSingleChild());
     }
 
+    public function testCast(): void
+    // accepts response object of decoded json
+    // returns RecurlyResource
+    {
+        $test_response_object = (object)array(
+            "id" => 0,
+            "object" => "plan",
+            "name" => "0",
+        );
+
+        $resource = Recurly\Resources\TestResource::cast($test_response_object);
+        $this->assertNotNull($resource->getName());
+        $this->assertNotNull($resource->getId());
+        $this->assertInstanceOf(\Recurly\Resources\TestResource::class, $resource);
+    }
+
     public function testFromJsonUnknownKeys(): void
     {
         $test_resource = (object)array(


### PR DESCRIPTION
Addresses report where a subscription/plan with `unitAmount` of zero will return `NULL` when calling `getUnitAmount()`, when desired result is to return a float type of zero. `empty()` was [too inclusive](https://www.w3schools.com/php/func_var_empty.asp).