### PR TITLE
Add PHP 8.0 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 8.0
   - 7.4
   - 7.3
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
-php:
-  - 8.0
-  - 7.4
-  - 7.3
-  - 7.2
+matrix:
+  include:
+    - php: 8.0
+    - php: 7.4
+    - php: 7.3
+      dist: trusty
+    - php: 7.2
+      dist: trusty
 sudo: false
-dist: trusty
 install:
   - composer install --dev
 script: vendor/bin/phpunit tests


### PR DESCRIPTION
Updates the travis matrix to include php 8.0 now that the dev dependancy  [phpDocumentor/FlyFinder#1.1.0](https://github.com/phpDocumentor/FlyFinder/releases/tag/1.1.0) has been released with php 8.0 support.