### PR TITLE
Ignoring 'internal' tags in changelog generation

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,7 +1,7 @@
 user=recurly
 project=recurly-client-php
 unreleased=false
-exclude-labels=question,bug?,duplicate,V2
+exclude-labels=internal,question,bug?,duplicate,V2
 exclude-tags-regex=^[^3]+\..*
 issues-wo-labels=false
 verbose=false

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,8 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "doctrine/rst-parser": "dev-master",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpdocumentor/phpdocumentor": "dev-master",
-        "phpdocumentor/graphviz": "dev-master",
-        "phpdocumentor/reflection": "5.x-dev",
+        "phpdocumentor/phpdocumentor": "^3",
         "phpstan/phpstan": "^0.12.11",
         "phpunit/phpunit": "^8",
         "squizlabs/php_codesniffer": "^3.5"


### PR DESCRIPTION
Internal only update to ignore issues and pull requests with the `internal` label from changelog generation.