### PR TITLE
Fixing composer reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package is published on Packagist under the name [recurly/recurly-client](h
 ```json
 {
     "require": {
-        "recurly/recurly-client": "^3"
+        "recurly/recurly-client": "^4"
     }
 }
 ```


### PR DESCRIPTION
The README is incorrectly suggesting using the `3.x` version of the package where `4.x` is the latest.