### PR TITLE
Postpone subscriptions using the field next_bill_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.12.22](https://github.com/recurly/recurly-client-php/tree/2.12.22) (2021-05-24)
+
+[Full Changelog](https://github.com/recurly/recurly-client-php/compare/2.12.21...2.12.22)
+
+**Merged Pull Requests**
+
+- [Postpone subscriptions](https://developers.recurly.com/api-v2/v2.29/index.html#operation/postponeSubscriptionOrExtendTrial) using `next_bill_date` instead the deprecated `next_renewal_date`. [#TODO](https://github.com/recurly/recurly-client-php/pull/) ([cyberxander90](https://github.com/cyberxander90))
+
+
 ## [2.12.21](https://github.com/recurly/recurly-client-php/tree/2.12.21) (2021-04-22)
 
 [Full Changelog](https://github.com/recurly/recurly-client-php/compare/2.12.20...2.12.21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## [2.12.22](https://github.com/recurly/recurly-client-php/tree/2.12.22) (2021-05-24)
-
-[Full Changelog](https://github.com/recurly/recurly-client-php/compare/2.12.21...2.12.22)
-
-**Merged Pull Requests**
-
-- [Postpone subscriptions](https://developers.recurly.com/api-v2/v2.29/index.html#operation/postponeSubscriptionOrExtendTrial) using `next_bill_date` instead the deprecated `next_renewal_date`. [#TODO](https://github.com/recurly/recurly-client-php/pull/) ([cyberxander90](https://github.com/cyberxander90))
-
-
 ## [2.12.21](https://github.com/recurly/recurly-client-php/tree/2.12.21) (2021-04-22)
 
 [Full Changelog](https://github.com/recurly/recurly-client-php/compare/2.12.20...2.12.21)

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -326,6 +326,16 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->resume();
   }
 
+  public function testPostponeSubscription() {
+    $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200.xml');
+    $this->client->addResponse('PUT', 'https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/postpone?next_bill_date=2019-12-30T16:00:00-08:00&bulk=', 'subscriptions/postpone-200.xml');
+    $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
+
+    $subscription->postpone(date('c', strtotime('2019-12-31Z')));
+    
+    $this->assertEquals(new DateTime('2019-12-31Z'), $subscription->current_period_ends_at);
+  }
+
   public function testConvertTrialWithTransactionType() {
     $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200-trial.xml');
     $this->client->addResponse('PUT', 'https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/convert_trial', 'subscriptions/convert-trial-200.xml');

--- a/Tests/fixtures/subscriptions/postpone-200.xml
+++ b/Tests/fixtures/subscriptions/postpone-200.xml
@@ -1,0 +1,72 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab">
+  <account href="https://api.recurly.com/v2/accounts/verena"/>
+  <redemptions href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/redemptions"/>
+  <plan href="https://api.recurly.com/v2/plans/silver">
+    <plan_code>silver</plan_code>
+    <name>Silver Plan</name>
+  </plan>
+  <uuid>012345678901234567890123456789ab</uuid>
+  <state>active</state>
+  <net_terms type="integer">10</net_terms>
+  <collection_method>manual</collection_method>
+  <po_number>1000</po_number>
+  <quantity type="integer">1</quantity>
+  <total_amount_in_cents type="integer">1000</total_amount_in_cents>
+  <activated_at type="datetime">2011-04-30T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2011-04-01T07:00:00Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2019-12-31T00:00:00Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <customer_notes>Some Customer Notes</customer_notes>
+  <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
+  <started_with_gift type="boolean">false</started_with_gift>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <converted_at nil="nil"></converted_at>
+  <remaining_pause_cycles type="integer">1</remaining_pause_cycles>>
+  <paused_at type="datetime">2020-01-01T01:00:00Z</paused_at>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+      <add_on_type>usage</add_on_type>
+      <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
+      <usage href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/add_ons/marketing_emails/usage"/>
+      <add_on_code>marketing_emails</add_on_code>
+      <name>Marketing Emails</name>
+      <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <usage_type>price</usage_type>
+      <usage_percentage nil="nil"/>
+    </subscription_add_on>
+    <subscription_add_on>
+      <add_on_type>fixed</add_on_type>
+      <item href="https://api.recurlyqa.com/v2/items/mockitem"/>
+      <external_sku>tester-sku</external_sku>
+      <add_on_code>mockitem</add_on_code>
+      <unit_amount_in_cents type="integer">199</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <revenue_schedule_type>never</revenue_schedule_type>
+      <tier_type>flat</tier_type>
+      <add_on_source>item</add_on_source>
+    </subscription_add_on>
+  </subscription_add_ons>
+  <custom_fields type="array">
+    <custom_field>
+      <name>shasta</name>
+      <value>ate my tacos</value>
+    </custom_field>
+    <custom_field>
+      <name>license-number</name>
+      <value>0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz</value>
+    </custom_field>
+  </custom_fields>
+  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/cancel" method="put"/>
+  <a name="terminate" href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/terminate" method="put"/>
+</subscription>

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -195,12 +195,12 @@ class Recurly_Subscription extends Recurly_Resource
   /**
    * Postpone a subscription's renewal date.
    *
-   * @param string $nextRenewalDate ISO8601 DateTime String, postpone the subscription to this date
+   * @param string $nextBillDate ISO8601 DateTime String, postpone the subscription to this date
    * @param bool $bulk for making bulk updates, setting to true bypasses api check for accidental duplicate subscriptions.
    * @throws Recurly_Error
    */
-  public function postpone($nextRenewalDate, $bulk = false) {
-    $this->_save(Recurly_Client::PUT, $this->uri() . '/postpone?next_renewal_date=' . $nextRenewalDate . '&bulk=' . ((bool) $bulk));
+  public function postpone($nextBillDate, $bulk = false) {
+    $this->_save(Recurly_Client::PUT, $this->uri() . '/postpone?next_bill_date=' . $nextBillDate . '&bulk=' . ((bool) $bulk));
   }
 
   /**


### PR DESCRIPTION
According to the doc [Postponing Subscriptions](https://developers.recurly.com/api-v2/v2.29/index.html#operation/postponeSubscriptionOrExtendTrial) should be using the field `next_bill_date ` instead of the deprecated `next_renewal_date`.