### PR TITLE
Adding psr/log requirement to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": ">= 7.2.0"
+        "php": ">= 7.2.0",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",


### PR DESCRIPTION
The `psr/log` requirement should be included in `composer.json` as it is a requirement.