### PR TITLE
Lock down the version of phpDocumentor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpdocumentor/phpdocumentor": "^3",
+        "phpdocumentor/phpdocumentor": "~3.0.0",
         "phpstan/phpstan": "^0.12.11",
         "phpunit/phpunit": "^8",
         "squizlabs/php_codesniffer": "^3.5"

--- a/scripts/build
+++ b/scripts/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-composer install --dev
+composer update --dev
 
 rm -rf ./docs
 ./vendor/bin/phpdoc -d ./lib/recurly -t ./docs/ --title "Recurly v3 API"


### PR DESCRIPTION
The 3.1.x version has a bug in it:
https://github.com/phpDocumentor/phpDocumentor/issues/2949