### PR TITLE
Fixing issue with http_build_query converting booleans in params to integers

### DIFF
--- a/tests/BaseClient_Test.php
+++ b/tests/BaseClient_Test.php
@@ -217,4 +217,25 @@ final class BaseClientTest extends RecurlyTestCase
         $this->expectException(\Recurly\RecurlyError::class);
         $resource = $this->client->getResource("iexist", $options);
     }
+
+    public function testBooleanParams(): void
+    {
+        $url = "https://v3.recurly.com/resources/booleans?param-1=true&param-2=false";
+        $result = '{"id": "booleans", "object": "test_resource"}';
+        $headers = [
+            'Accept-Language' => 'fr'
+        ];
+        $this->client->addScenario("GET", $url, NULL, $result, "200 OK", [], $headers);
+
+        $options = [
+            'params' => [
+                'param-1' => true,
+                'param-2' => false,
+            ],
+            'headers' => $headers
+        ];
+
+        $resource = $this->client->getResource("booleans", $options);
+        $this->assertEquals($resource->getId(), "booleans");
+    }
 }


### PR DESCRIPTION
Currently, the `terminateSubscription` method returns a error if provided an option with parameter `'charge' => true`. It happens because internally the client uses the `http_build_query` that transforms booleans to integers, whereas API strictly requires a boolean.

This PR fixes the issue by casting booleans to strings before passing them to `http_build_query`, so that it does not do any transformations to them.

The code snippet I've used to test:

```php
$options = ['params' => ['refund' => 'none', 'charge' => true]];
$recurlyClient->terminateSubscription('redacted', $options);
```

Logs generated:

```
...
[2021-07-16T10:50:53.716533+00:00] test.INFO: Request {"method":"DELETE","path":"https://v3.recurly.com/subscriptions/redacted?refund=none&charge=1"} []
...
[2021-07-16T10:50:54.072023+00:00] test.DEBUG: Response {"response_body":"{\"error\":{\"type\":\"validation\",\"message\":\"Please provide valid values for these parameters: charge\",\"params\":[{\"param\":\"charge\",\"message\":\"Allowed values: true, false\"}]}}", ...}} []
```