### PR TITLE
Generated Latest Changes for v2021-02-25 (Support to new subscription fields and response)

### DIFF
--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -32,6 +32,7 @@ class Subscription extends RecurlyResource
     private $_customer_notes;
     private $_expiration_reason;
     private $_expires_at;
+    private $_gateway_code;
     private $_id;
     private $_net_terms;
     private $_object;
@@ -47,7 +48,10 @@ class Subscription extends RecurlyResource
     private $_shipping;
     private $_state;
     private $_subtotal;
+    private $_tax;
+    private $_tax_info;
     private $_terms_and_conditions;
+    private $_total;
     private $_total_billing_cycles;
     private $_trial_ends_at;
     private $_trial_started_at;
@@ -523,6 +527,29 @@ class Subscription extends RecurlyResource
     }
 
     /**
+    * Getter method for the gateway_code attribute.
+    * If present, this subscription's transactions will use the payment gateway with this code.
+    *
+    * @return ?string
+    */
+    public function getGatewayCode(): ?string
+    {
+        return $this->_gateway_code;
+    }
+
+    /**
+    * Setter method for the gateway_code attribute.
+    *
+    * @param string $gateway_code
+    *
+    * @return void
+    */
+    public function setGatewayCode(string $gateway_code): void
+    {
+        $this->_gateway_code = $gateway_code;
+    }
+
+    /**
     * Getter method for the id attribute.
     * Subscription ID
     *
@@ -868,6 +895,52 @@ class Subscription extends RecurlyResource
     }
 
     /**
+    * Getter method for the tax attribute.
+    * Estimated tax
+    *
+    * @return ?float
+    */
+    public function getTax(): ?float
+    {
+        return $this->_tax;
+    }
+
+    /**
+    * Setter method for the tax attribute.
+    *
+    * @param float $tax
+    *
+    * @return void
+    */
+    public function setTax(float $tax): void
+    {
+        $this->_tax = $tax;
+    }
+
+    /**
+    * Getter method for the tax_info attribute.
+    * Tax info
+    *
+    * @return ?\Recurly\Resources\TaxInfo
+    */
+    public function getTaxInfo(): ?\Recurly\Resources\TaxInfo
+    {
+        return $this->_tax_info;
+    }
+
+    /**
+    * Setter method for the tax_info attribute.
+    *
+    * @param \Recurly\Resources\TaxInfo $tax_info
+    *
+    * @return void
+    */
+    public function setTaxInfo(\Recurly\Resources\TaxInfo $tax_info): void
+    {
+        $this->_tax_info = $tax_info;
+    }
+
+    /**
     * Getter method for the terms_and_conditions attribute.
     * Terms and conditions
     *
@@ -888,6 +961,29 @@ class Subscription extends RecurlyResource
     public function setTermsAndConditions(string $terms_and_conditions): void
     {
         $this->_terms_and_conditions = $terms_and_conditions;
+    }
+
+    /**
+    * Getter method for the total attribute.
+    * Estimated total
+    *
+    * @return ?float
+    */
+    public function getTotal(): ?float
+    {
+        return $this->_total;
+    }
+
+    /**
+    * Setter method for the total attribute.
+    *
+    * @param float $total
+    *
+    * @return void
+    */
+    public function setTotal(float $total): void
+    {
+        $this->_total = $total;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12611,7 +12611,16 @@ paths:
       - subscription_change
       operationId: create_subscription_change
       summary: Create a new subscription change
-      description: Calling this will overwrite an existing, pending subscription change.
+      description: |
+        Calling this will overwrite an existing, pending subscription change.
+
+        If a subscription has a pending change, and a change is submitted which matches
+        the subscription as it currently exists, the pending change will be deleted,
+        and you will receive a 204 No Content response.
+
+        If a subscription has no pending
+        change, and a change is submitted which matches the subscription as it currently
+        exists, a 422 Unprocessable Entity validation error will be returned.
       parameters:
       - "$ref": "#/components/parameters/subscription_id"
       requestBody:
@@ -12627,6 +12636,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SubscriptionChange"
+        '204':
+          description: The previous pending change was reverted.
         '404':
           description: Incorrect site ID.
           content:
@@ -19443,6 +19454,16 @@ components:
           format: float
           title: Estimated total, before tax.
           minimum: 0
+        tax:
+          type: number
+          format: float
+          title: Estimated tax
+        tax_info:
+          "$ref": "#/components/schemas/TaxInfo"
+        total:
+          type: number
+          format: float
+          title: Estimated total
         collection_method:
           title: Collection method
           default: automatic
@@ -19502,6 +19523,12 @@ components:
             set. This timestamp is used for alerting customers to reauthorize in 3
             years in accordance with NACHA rules. If a subscription becomes inactive
             or the billing info is no longer a bank account, this timestamp is cleared.
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         billing_info_id:
           type: string
           title: Billing Info ID
@@ -19956,6 +19983,13 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+        address_id:
+          type: string
+          titpe: Shipping address ID
+          description: Assign a shipping address from the account's existing shipping
+            addresses. If this and address are both present, address will take precedence.
+        address:
+          "$ref": "#/components/schemas/ShippingAddressCreate"
     SubscriptionCreate:
       type: object
       properties:
@@ -20264,6 +20298,12 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:


### PR DESCRIPTION
Generated Latest Changes for v2021-02-25

SubscriptionCreate request format has changed:
* Added `setGatewayCode`.

SubscriptionUpdate request format has changed:
* Added `setGatewayCode`.

Subscription response format has changed:
* Added `getGatewayCode`.

SubscriptionChangeShippingCreate request format has changed:
* Added `setAddress`.
* Added `setAddressId`.

Added tax information to `Subscription` response
* Added the fields `getTax`, `getTaxInfo` and `getTotal`.

Updated the response for `POST /subscriptions/{subscription_id}/change`.
* Responding with `204 No Content` when the subscription has a pending change, and a change is submitted which matches the subscription as it currently exists.


