### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19961,8 +19961,10 @@ components:
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription
-      description: The shipping address can currently only be changed immediately,
-        using SubscriptionUpdate.
+      description: Shipping addresses are tied to a customer's account. Each account
+        can have up to 20 different shipping addresses, and if you have enabled multiple
+        subscriptions per account, you can associate different shipping addresses
+        to each subscription.
       properties:
         method_id:
           type: string
@@ -21777,6 +21779,7 @@ components:
       - roku
       - sepadirectdebit
       - wire_transfer
+      - braintree_v_zero
     CardTypeEnum:
       type: string
       enum:


### PR DESCRIPTION
- Adds `braintree_v_zero` to the `PaymentMethodEnum`. 
- Updates the `SubscriptionChangeShippingCreate` description to include the number of shipping addresses allowed per account as well as specifying specific shipping addresses to individual subscriptions.