### PR TITLE
Generated Latest Changes for v2019-10-10 (Account Hierarchy Invoice Rollup)

### DIFF
--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -19,6 +19,7 @@ class LineItem extends RecurlyResource
     private $_amount;
     private $_avalara_service_type;
     private $_avalara_transaction_type;
+    private $_bill_for_account_id;
     private $_created_at;
     private $_credit_applied;
     private $_credit_reason_code;
@@ -223,6 +224,29 @@ class LineItem extends RecurlyResource
     public function setAvalaraTransactionType(int $avalara_transaction_type): void
     {
         $this->_avalara_transaction_type = $avalara_transaction_type;
+    }
+
+    /**
+    * Getter method for the bill_for_account_id attribute.
+    * The UUID of the account responsible for originating the line item.
+    *
+    * @return ?string
+    */
+    public function getBillForAccountId(): ?string
+    {
+        return $this->_bill_for_account_id;
+    }
+
+    /**
+    * Setter method for the bill_for_account_id attribute.
+    *
+    * @param string $bill_for_account_id
+    *
+    * @return void
+    */
+    public function setBillForAccountId(string $bill_for_account_id): void
+    {
+        $this->_bill_for_account_id = $bill_for_account_id;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18279,6 +18279,12 @@ components:
           - carryforward
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21916,6 +21922,8 @@ components:
                 - batch_processing_error
                 - billing_agreement_already_accepted
                 - billing_agreement_not_accepted
+                - billing_agreement_not_found
+                - billing_agreement_replaced
                 - call_issuer
                 - call_issuer_update_cardholder_data
                 - cannot_refund_unsettled_transactions


### PR DESCRIPTION
Add `getBillForAccountId`/`setBillForAccountId` methods to the `LineItem` class.  This exposes the UUID of the account responsible for originating the line item.