### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -19,6 +19,7 @@ class LineItem extends RecurlyResource
     private $_amount;
     private $_avalara_service_type;
     private $_avalara_transaction_type;
+    private $_bill_for_account_id;
     private $_created_at;
     private $_credit_applied;
     private $_credit_reason_code;
@@ -224,6 +225,29 @@ class LineItem extends RecurlyResource
     public function setAvalaraTransactionType(int $avalara_transaction_type): void
     {
         $this->_avalara_transaction_type = $avalara_transaction_type;
+    }
+
+    /**
+    * Getter method for the bill_for_account_id attribute.
+    * The UUID of the account responsible for originating the line item.
+    *
+    * @return ?string
+    */
+    public function getBillForAccountId(): ?string
+    {
+        return $this->_bill_for_account_id;
+    }
+
+    /**
+    * Setter method for the bill_for_account_id attribute.
+    *
+    * @param string $bill_for_account_id
+    *
+    * @return void
+    */
+    public function setBillForAccountId(string $bill_for_account_id): void
+    {
+        $this->_bill_for_account_id = $bill_for_account_id;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16345,6 +16345,28 @@ components:
             characters comprising a country code; two check digits; and a number that
             includes the domestic bank account number, branch identifier, and potential
             routing information
+        name_on_account:
+          type: string
+          maxLength: 255
+          description: The name associated with the bank account (ACH, SEPA, Bacs
+            only)
+        account_number:
+          type: string
+          maxLength: 255
+          description: The bank account number. (ACH, Bacs only)
+        routing_number:
+          type: string
+          maxLength: 15
+          description: The bank's rounting number. (ACH only)
+        sort_code:
+          type: string
+          maxLength: 15
+          description: Bank identifier code for UK based banks. Required for Bacs
+            based billing infos. (Bacs only)
+        type:
+          "$ref": "#/components/schemas/AchTypeEnum"
+        account_type:
+          "$ref": "#/components/schemas/AchAccountTypeEnum"
         tax_identifier:
           type: string
           description: Tax identifier is required if adding a billing info that is
@@ -17898,6 +17920,12 @@ components:
           "$ref": "#/components/schemas/LegacyCategoryEnum"
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21885,6 +21913,7 @@ components:
       - billing_agreement_already_accepted
       - billing_agreement_not_accepted
       - billing_agreement_not_found
+      - billing_agreement_replaced
       - call_issuer
       - call_issuer_update_cardholder_data
       - cancelled
@@ -22058,3 +22087,15 @@ components:
       - automatic
       - manual
       - trial
+    AchTypeEnum:
+      type: string
+      description: The payment method type for a non-credit card based billing info.
+        The value of `bacs` is the only accepted value (Bacs only)
+      enum:
+      - bacs
+    AchAccountTypeEnum:
+      type: string
+      description: The bank account type. (ACH only)
+      enum:
+      - checking
+      - savings


### PR DESCRIPTION
Support for Account Hierarchy Invoice Rollup:
- Add `getBillForAccountId`/`setBillForAccountId` methods to the `LineItem` class.  This exposes the UUID of the account responsible for originating the line item.

BillingInfoCreate request format has changed:
- Added `setNameOnAccount`
- Added `setAccountNumber`
- Added `setRoutingNumber`
- Added `setSortCode`
- Added `setType`
- Added `setAccountType`