### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/account.php
+++ b/lib/recurly/resources/account.php
@@ -33,6 +33,7 @@ class Account extends RecurlyResource
     private $_has_paused_subscription;
     private $_hosted_login_token;
     private $_id;
+    private $_invoice_template;
     private $_last_name;
     private $_object;
     private $_parent_account_id;
@@ -531,6 +532,29 @@ class Account extends RecurlyResource
     public function setId(string $id): void
     {
         $this->_id = $id;
+    }
+
+    /**
+    * Getter method for the invoice_template attribute.
+    * Invoice template associated to the account. Available when invoice customization flag is enabled.
+    *
+    * @return ?\Recurly\Resources\AccountInvoiceTemplate
+    */
+    public function getInvoiceTemplate(): ?\Recurly\Resources\AccountInvoiceTemplate
+    {
+        return $this->_invoice_template;
+    }
+
+    /**
+    * Setter method for the invoice_template attribute.
+    *
+    * @param \Recurly\Resources\AccountInvoiceTemplate $invoice_template
+    *
+    * @return void
+    */
+    public function setInvoiceTemplate(\Recurly\Resources\AccountInvoiceTemplate $invoice_template): void
+    {
+        $this->_invoice_template = $invoice_template;
     }
 
     /**

--- a/lib/recurly/resources/account_invoice_template.php
+++ b/lib/recurly/resources/account_invoice_template.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+namespace Recurly\Resources;
+
+use Recurly\RecurlyResource;
+
+// phpcs:disable
+class AccountInvoiceTemplate extends RecurlyResource
+{
+    private $_id;
+    private $_name;
+
+    protected static $array_hints = [
+    ];
+
+    
+    /**
+    * Getter method for the id attribute.
+    * Unique ID to identify the invoice template.
+    *
+    * @return ?string
+    */
+    public function getId(): ?string
+    {
+        return $this->_id;
+    }
+
+    /**
+    * Setter method for the id attribute.
+    *
+    * @param string $id
+    *
+    * @return void
+    */
+    public function setId(string $id): void
+    {
+        $this->_id = $id;
+    }
+
+    /**
+    * Getter method for the name attribute.
+    * Template name
+    *
+    * @return ?string
+    */
+    public function getName(): ?string
+    {
+        return $this->_name;
+    }
+
+    /**
+    * Setter method for the name attribute.
+    *
+    * @param string $name
+    *
+    * @return void
+    */
+    public function setName(string $name): void
+    {
+        $this->_name = $name;
+    }
+}

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -413,7 +413,7 @@ class LineItem extends RecurlyResource
 
     /**
     * Getter method for the external_sku attribute.
-    * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+    * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices feature is enabled.
     *
     * @return ?string
     */
@@ -505,7 +505,7 @@ class LineItem extends RecurlyResource
 
     /**
     * Getter method for the item_code attribute.
-    * Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+    * Unique code to identify an item. Available when the Credit Invoices feature is enabled.
     *
     * @return ?string
     */
@@ -528,7 +528,7 @@ class LineItem extends RecurlyResource
 
     /**
     * Getter method for the item_id attribute.
-    * System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+    * System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.
     *
     * @return ?string
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -232,7 +232,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices and Subscription Billing Terms features to be enabled.
+    Recurly's item catalog requires the Credit Invoices features to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -15540,6 +15540,8 @@ components:
           "$ref": "#/components/schemas/BillingInfo"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        invoice_template:
+          "$ref": "#/components/schemas/AccountInvoiceTemplate"
     AccountNote:
       type: object
       required:
@@ -15636,6 +15638,20 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+    AccountInvoiceTemplate:
+      type: object
+      title: Invoice Template
+      description: Invoice template associated to the account. Available when invoice
+        customization flag is enabled.
+      properties:
+        id:
+          type: string
+          title: ID
+          description: Unique ID to identify the invoice template.
+        name:
+          type: string
+          title: Name
+          description: Template name
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -15900,16 +15916,16 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` and `Subscription Billing Terms` features are enabled. If `item_id`
-            and `item_code` are both present, `item_id` will be used.
+            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the `Credit Invoices` and `Subscription Billing Terms` features are enabled.
-            If `item_id` and `item_code` are both present, `item_id` will be used.
+            the `Credit Invoices` feature is enabled. If `item_id` and `item_code`
+            are both present, `item_id` will be used.
           maxLength: 13
         code:
           type: string
@@ -17888,20 +17904,20 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         external_sku:
           type: string
           title: External SKU
           description: Optional Stock Keeping Unit assigned to an item. Available
-            when the Credit Invoices and Subscription Billing Terms features are enabled.
+            when the Credit Invoices feature is enabled.
           maxLength: 50
         revenue_schedule_type:
           title: Revenue schedule type
@@ -18204,14 +18220,14 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
@@ -22160,9 +22176,10 @@ components:
     AchTypeEnum:
       type: string
       description: The payment method type for a non-credit card based billing info.
-        The value of `bacs` is the only accepted value (Bacs only)
+        `bacs` and `becs` are the only accepted values.
       enum:
       - bacs
+      - becs
     AchAccountTypeEnum:
       type: string
       description: The bank account type. (ACH only)


### PR DESCRIPTION
Support `becs` as a payment method type for non-credit card based billing info.
- Added `becs` as a valid non-credit card payment method type.

Support `invoice_template` in account when invoice customization feature is enabled.
- Added `getInvoiceTemplate` and `setInvoiceTemplate` methods to Account.

Updated documentation for the removal of the `Subscription Billing Terms` feature flag as the feature is now fully accessible on all sites.