### PR TITLE
Generated Latest Changes for v2021-02-25 (Percentage tiers feature)

### DIFF
--- a/lib/recurly/resources/subscription_add_on.php
+++ b/lib/recurly/resources/subscription_add_on.php
@@ -180,7 +180,8 @@ the associated add-on data will be pulled from the site's item catalog.
     /**
     * Getter method for the percentage_tiers attribute.
     * If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
-removed and replaced by the percentage tiers in the request.
+removed and replaced by the percentage tiers in the request. Use only if add_on.tier_type is tiered or volume and
+add_on.usage_type is percentage
 
     *
     * @return array
@@ -301,7 +302,8 @@ to configure quantity-based pricing models.
     /**
     * Getter method for the tiers attribute.
     * If tiers are provided in the request, all existing tiers on the Subscription Add-on will be
-removed and replaced by the tiers in the request.
+removed and replaced by the tiers in the request. If add_on.tier_type is tiered or volume and
+add_on.usage_type is percentage use percentage_tiers instead.
 
     *
     * @return array

--- a/lib/recurly/resources/subscription_add_on_tier.php
+++ b/lib/recurly/resources/subscription_add_on_tier.php
@@ -95,7 +95,7 @@ If add-on's `add_on_type` is `usage` and `usage_type` is `percentage`, cannot be
 
     /**
     * Getter method for the usage_percentage attribute.
-    * This field is deprecated. Do not used it anymore for percentage tiers subscription add ons. Use the percentage_tiers object instead.
+    * (deprecated) -- Use the percentage_tiers object instead.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/tier.php
+++ b/lib/recurly/resources/tier.php
@@ -46,7 +46,7 @@ class Tier extends RecurlyResource
 
     /**
     * Getter method for the ending_quantity attribute.
-    * Ending quantity for the tier.  This represents a unit amount for unit-priced add ons, but for percentage type usage add ons, represents the site default currency in its minimum divisible unit.
+    * Ending quantity for the tier.  This represents a unit amount for unit-priced add ons.
     *
     * @return ?int
     */
@@ -69,7 +69,7 @@ class Tier extends RecurlyResource
 
     /**
     * Getter method for the usage_percentage attribute.
-    * This field is deprecated. Do not used it anymore for percentage tiers add ons. Use the percentage_tiers object instead.
+    * (deprecated) -- Use the percentage_tiers object instead.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/usage.php
+++ b/lib/recurly/resources/usage.php
@@ -19,6 +19,7 @@ class Usage extends RecurlyResource
     private $_measured_unit_id;
     private $_merchant_tag;
     private $_object;
+    private $_percentage_tiers;
     private $_recording_timestamp;
     private $_tier_type;
     private $_tiers;
@@ -30,6 +31,7 @@ class Usage extends RecurlyResource
     private $_usage_type;
 
     protected static $array_hints = [
+        'setPercentageTiers' => '\Recurly\Resources\SubscriptionAddOnPercentageTier',
         'setTiers' => '\Recurly\Resources\SubscriptionAddOnTier',
     ];
 
@@ -196,6 +198,29 @@ class Usage extends RecurlyResource
     }
 
     /**
+    * Getter method for the percentage_tiers attribute.
+    * The percentage tiers of the subscription based on the usage_timestamp. If tier_type = flat, percentage_tiers = []
+    *
+    * @return array
+    */
+    public function getPercentageTiers(): array
+    {
+        return $this->_percentage_tiers ?? [] ;
+    }
+
+    /**
+    * Setter method for the percentage_tiers attribute.
+    *
+    * @param array $percentage_tiers
+    *
+    * @return void
+    */
+    public function setPercentageTiers(array $percentage_tiers): void
+    {
+        $this->_percentage_tiers = $percentage_tiers;
+    }
+
+    /**
     * Getter method for the recording_timestamp attribute.
     * When the usage was recorded in your system.
     *
@@ -247,7 +272,7 @@ to configure quantity-based pricing models.
 
     /**
     * Getter method for the tiers attribute.
-    * The tiers and prices of the subscription based on the usage_timestamp. If tier_type = flat, tiers = null
+    * The tiers and prices of the subscription based on the usage_timestamp. If tier_type = flat, tiers = []
     *
     * @return array
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16451,8 +16451,17 @@ components:
           description: |
             If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount` for
-            the desired `currencies`, or alternatively, `usage_percentage` for usage percentage type usage add ons. There must be one tier with an `ending_quantity`
+            the desired `currencies`. There must be one tier with an `ending_quantity`
             of 999999999 which is the default if not provided.
+        percentage_tiers:
+          type: array
+          title: Percentage Tiers By Currency
+          items:
+            "$ref": "#/components/schemas/PercentageTiersByCurrency"
+          description: |
+            Array of objects which must have at least one set of tiers
+            per currency and the currency code. The tier_type must be `volume` or `tiered`,
+            if not, it must be absent. There must be one tier without ending_amount value.
       required:
       - code
       - name
@@ -16580,8 +16589,17 @@ components:
           description: |
             If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount` for
-            the desired `currencies`, or alternatively, `usage_percentage` for usage percentage type usage add ons. There must be one tier with an `ending_quantity`
-            of 999999999 which is the default if not provided.
+            the desired `currencies`. There must be one tier without an `ending_quantity` value
+            that represents the final tier.
+        percentage_tiers:
+          type: array
+          title: Percentage Tiers By Currency
+          items:
+            "$ref": "#/components/schemas/PercentageTiersByCurrency"
+          description: |
+            `percentage_tiers` is an array of objects, which must have the set of tiers
+            per currency and the currency code. The tier_type must be `volume` or `tiered`,
+            if not, it must be absent.
     BillingInfo:
       type: object
       properties:
@@ -19345,16 +19363,14 @@ components:
           type: integer
           title: Ending quantity
           description: Ending quantity for the tier.  This represents a unit amount
-            for unit-priced add ons, but for percentage type usage add ons, represents
-            the site default currency in its minimum divisible unit.
+            for unit-priced add ons.
           minimum: 1
           maximum: 999999999
           default: 999999999
         usage_percentage:
           type: string
           title: Usage Percentage
-          description: This field is deprecated. Do not used it anymore for percentage
-            tiers add ons. Use the percentage_tiers object instead.
+          description: "(deprecated) -- Use the percentage_tiers object instead."
           deprecated: true
         currencies:
           type: array
@@ -20083,7 +20099,8 @@ components:
           minItems: 1
           description: |
             If tiers are provided in the request, all existing tiers on the Subscription Add-on will be
-            removed and replaced by the tiers in the request.
+            removed and replaced by the tiers in the request. If add_on.tier_type is tiered or volume and
+            add_on.usage_type is percentage use percentage_tiers instead.
         percentage_tiers:
           type: array
           title: Percentage Tiers
@@ -20092,7 +20109,8 @@ components:
           minItems: 1
           description: |
             If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
-            removed and replaced by the percentage tiers in the request.
+            removed and replaced by the percentage tiers in the request. Use only if add_on.tier_type is tiered or volume and
+            add_on.usage_type is percentage
         usage_percentage:
           type: number
           format: float
@@ -20158,9 +20176,19 @@ components:
           description: |
             If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount`.
-            There must be one tier with an `ending_quantity` of 999999999 which is the
-            default if not provided. See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html)
+            There must be one tier without ending_quantity value.
+            See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html)
             for an overview of how to configure quantity-based pricing models.
+        percentage_tiers:
+          type: array
+          title: Percentage Tiers
+          items:
+            "$ref": "#/components/schemas/SubscriptionAddOnPercentageTier"
+          minItems: 1
+          description: |
+            If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
+            removed and replaced by the percentage tiers in the request. There must be one tier without ending_amount value.
+            Use only if add_on.tier_type is tiered or volume and add_on.usage_type is percentage.
         usage_percentage:
           type: number
           format: float
@@ -20247,7 +20275,7 @@ components:
           title: Ending quantity
           minimum: 1
           maximum: 999999999
-          default: 999999999
+          default: 
         unit_amount:
           type: number
           format: float
@@ -20267,8 +20295,7 @@ components:
         usage_percentage:
           type: string
           title: Usage Percentage
-          description: This field is deprecated. Do not used it anymore for percentage
-            tiers subscription add ons. Use the percentage_tiers object instead.
+          description: "(deprecated) -- Use the percentage_tiers object instead."
           deprecated: true
     SubscriptionAddOnPercentageTier:
       type: object
@@ -20866,9 +20893,10 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Do not use it anymore to update a
+            subscription's tax inclusivity. Use the POST subscription change route
+            instead.
+          deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -21349,7 +21377,14 @@ components:
           items:
             "$ref": "#/components/schemas/SubscriptionAddOnTier"
           description: The tiers and prices of the subscription based on the usage_timestamp.
-            If tier_type = flat, tiers = null
+            If tier_type = flat, tiers = []
+        percentage_tiers:
+          type: array
+          title: Percentage Tiers
+          items:
+            "$ref": "#/components/schemas/SubscriptionAddOnPercentageTier"
+          description: The percentage tiers of the subscription based on the usage_timestamp.
+            If tier_type = flat, percentage_tiers = []
         measured_unit_id:
           type: string
           description: The ID of the measured unit associated with the add-on the


### PR DESCRIPTION
Percentage Tier support
- add setter and getter to for `percentage_tiers` in usage resource
- add `percentage_tiers` on creating `add_on` feature
- add `percentage_tiers` on updating `add_on` feature
- add `percentage_tiers` on creating `subscription_add_on` feature
- add `percentage_tiers` on retrieving `usage` feature