### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/add_on.php
+++ b/lib/recurly/resources/add_on.php
@@ -38,6 +38,7 @@ class AddOn extends RecurlyResource
     private $_tiers;
     private $_updated_at;
     private $_usage_percentage;
+    private $_usage_timeframe;
     private $_usage_type;
 
     protected static $array_hints = [
@@ -647,6 +648,29 @@ to configure quantity-based pricing models.
     public function setUsagePercentage(float $usage_percentage): void
     {
         $this->_usage_percentage = $usage_percentage;
+    }
+
+    /**
+    * Getter method for the usage_timeframe attribute.
+    * The time at which usage totals are reset for billing purposes.
+    *
+    * @return ?string
+    */
+    public function getUsageTimeframe(): ?string
+    {
+        return $this->_usage_timeframe;
+    }
+
+    /**
+    * Setter method for the usage_timeframe attribute.
+    *
+    * @param string $usage_timeframe
+    *
+    * @return void
+    */
+    public function setUsageTimeframe(string $usage_timeframe): void
+    {
+        $this->_usage_timeframe = $usage_timeframe;
     }
 
     /**

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -14,6 +14,7 @@ class Subscription extends RecurlyResource
 {
     private $_account;
     private $_activated_at;
+    private $_active_invoice_id;
     private $_add_ons;
     private $_add_ons_total;
     private $_auto_renew;
@@ -110,6 +111,29 @@ class Subscription extends RecurlyResource
     public function setActivatedAt(string $activated_at): void
     {
         $this->_activated_at = $activated_at;
+    }
+
+    /**
+    * Getter method for the active_invoice_id attribute.
+    * The invoice ID of the latest invoice created for an active subscription.
+    *
+    * @return ?string
+    */
+    public function getActiveInvoiceId(): ?string
+    {
+        return $this->_active_invoice_id;
+    }
+
+    /**
+    * Setter method for the active_invoice_id attribute.
+    *
+    * @param string $active_invoice_id
+    *
+    * @return void
+    */
+    public function setActiveInvoiceId(string $active_invoice_id): void
+    {
+        $this->_active_invoice_id = $active_invoice_id;
     }
 
     /**

--- a/lib/recurly/resources/subscription_add_on.php
+++ b/lib/recurly/resources/subscription_add_on.php
@@ -28,6 +28,7 @@ class SubscriptionAddOn extends RecurlyResource
     private $_unit_amount_decimal;
     private $_updated_at;
     private $_usage_percentage;
+    private $_usage_timeframe;
 
     protected static $array_hints = [
         'setPercentageTiers' => '\Recurly\Resources\SubscriptionAddOnPercentageTier',
@@ -417,5 +418,28 @@ There must be one tier without an `ending_quantity` value which represents the f
     public function setUsagePercentage(float $usage_percentage): void
     {
         $this->_usage_percentage = $usage_percentage;
+    }
+
+    /**
+    * Getter method for the usage_timeframe attribute.
+    * The time at which usage totals are reset for billing purposes.
+    *
+    * @return ?string
+    */
+    public function getUsageTimeframe(): ?string
+    {
+        return $this->_usage_timeframe;
+    }
+
+    /**
+    * Setter method for the usage_timeframe attribute.
+    *
+    * @param string $usage_timeframe
+    *
+    * @return void
+    */
+    public function setUsageTimeframe(string $usage_timeframe): void
+    {
+        $this->_usage_timeframe = $usage_timeframe;
     }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16265,6 +16265,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -16443,6 +16445,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -20059,6 +20063,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -20098,6 +20109,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -22176,6 +22189,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.

Adds `usage_timeframe` to the add-on create request and responses. It represents the time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.  The valid values are `billing_period` or `subscription_term` with `billing_period` being the default value.