### PR TITLE
V2 add processing_prepayment_balance_in_cents to Recurly_AccountBalance

### DIFF
--- a/Tests/Recurly/AccountBalance_Test.php
+++ b/Tests/Recurly/AccountBalance_Test.php
@@ -29,5 +29,9 @@ class Recurly_AccountBalanceTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_CurrencyList', $balance->balance_in_cents);
     $this->assertEquals(2910, $balance->balance_in_cents['USD']->amount_in_cents);
     $this->assertEquals(-520, $balance->balance_in_cents['EUR']->amount_in_cents);
+
+    $this->assertInstanceOf('Recurly_CurrencyList', $balance->processing_prepayment_balance_in_cents);
+    $this->assertEquals(-3000, $balance->processing_prepayment_balance_in_cents['USD']->amount_in_cents);
+    $this->assertEquals(0, $balance->processing_prepayment_balance_in_cents['EUR']->amount_in_cents);
   }
 }

--- a/Tests/fixtures/balance/show-200.xml
+++ b/Tests/fixtures/balance/show-200.xml
@@ -9,4 +9,8 @@ Content-Type: application/xml; charset=utf-8
     <USD type="integer">2910</USD>
     <EUR type="integer">-520</EUR>
   </balance_in_cents>
+  <processing_prepayment_balance_in_cents>
+    <USD type="integer">-3000</USD>
+    <EUR type="integer">0</EUR>
+  </processing_prepayment_balance_in_cents>
 </account_balance>

--- a/lib/recurly/account_balance.php
+++ b/lib/recurly/account_balance.php
@@ -5,6 +5,8 @@
  * @property Recurly_Stub $account The associated Recurly_Account for this balance.
  * @property boolean $past_due The account's past due status.
  * @property Recurly_CurrencyList $balance_in_cents The account balance in cents for each currency.
+ * @property Recurly_CurrencyList $processing_prepayment_balance_in_cents The account processing
+ * prepayment balance in cents for each currency.
  */
 class Recurly_AccountBalance extends Recurly_Resource
 {
@@ -15,6 +17,7 @@ class Recurly_AccountBalance extends Recurly_Resource
   function __construct($href = null, $client = null) {
     parent::__construct($href, $client);
     $this->balance_in_cents = new Recurly_CurrencyList('balance_in_cents');
+    $this->processing_prepayment_balance_in_cents = new Recurly_CurrencyList('processing_prepayment_balance_in_cents');
   }
 
   protected function getNodeName() {

--- a/lib/recurly/base.php
+++ b/lib/recurly/base.php
@@ -294,6 +294,7 @@ abstract class Recurly_Base
     'plan_code' => 'string',
     'plan_codes' => 'array',
     'pending_subscription' => 'Recurly_Subscription',
+    'processing_prepayment_balance_in_cents' => 'Recurly_CurrencyList',
     'redemption' => 'Recurly_CouponRedemption',
     'redemptions' => 'Recurly_CouponRedemptionList',
     'setup_fee_in_cents' => 'Recurly_CurrencyList',


### PR DESCRIPTION
Add new add `processing_prepayment_balance_in_cents` attribute to `Recurly_AccountBalance`. The `processing_prepayment_balance_in_cents` attribute is a similar format to the `balance_in_cents` attribute and contains
the total for processing prepayment credit invoices in each currency. This value is useful when trying to determine if the customer's prepayment balance has run out or if it is currently processing while waiting on a payment for the corresponding purchase invoice.