### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly/resources/account_balance_amount.php
+++ b/lib/recurly/resources/account_balance_amount.php
@@ -14,6 +14,7 @@ class AccountBalanceAmount extends RecurlyResource
 {
     private $_amount;
     private $_currency;
+    private $_processing_prepayment_amount;
 
     protected static $array_hints = [
     ];
@@ -63,5 +64,28 @@ class AccountBalanceAmount extends RecurlyResource
     public function setCurrency(string $currency): void
     {
         $this->_currency = $currency;
+    }
+
+    /**
+    * Getter method for the processing_prepayment_amount attribute.
+    * Total amount for the prepayment credit invoices in a `processing` state on the account.
+    *
+    * @return ?float
+    */
+    public function getProcessingPrepaymentAmount(): ?float
+    {
+        return $this->_processing_prepayment_amount;
+    }
+
+    /**
+    * Setter method for the processing_prepayment_amount attribute.
+    *
+    * @param float $processing_prepayment_amount
+    *
+    * @return void
+    */
+    public function setProcessingPrepaymentAmount(float $processing_prepayment_amount): void
+    {
+        $this->_processing_prepayment_amount = $processing_prepayment_amount;
     }
 }

--- a/lib/recurly/resources/add_on_pricing.php
+++ b/lib/recurly/resources/add_on_pricing.php
@@ -45,7 +45,7 @@ class AddOnPricing extends RecurlyResource
 
     /**
     * Getter method for the tax_inclusive attribute.
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     *
     * @return ?bool
     */

--- a/lib/recurly/resources/plan_pricing.php
+++ b/lib/recurly/resources/plan_pricing.php
@@ -69,7 +69,7 @@ class PlanPricing extends RecurlyResource
 
     /**
     * Getter method for the tax_inclusive attribute.
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     *
     * @return ?bool
     */

--- a/lib/recurly/resources/pricing.php
+++ b/lib/recurly/resources/pricing.php
@@ -45,7 +45,7 @@ class Pricing extends RecurlyResource
 
     /**
     * Getter method for the tax_inclusive attribute.
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     *
     * @return ?bool
     */

--- a/lib/recurly/resources/subscription_change.php
+++ b/lib/recurly/resources/subscription_change.php
@@ -408,7 +408,7 @@ class SubscriptionChange extends RecurlyResource
 
     /**
     * Getter method for the tax_inclusive attribute.
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     *
     * @return ?bool
     */

--- a/lib/recurly/resources/subscription_change_preview.php
+++ b/lib/recurly/resources/subscription_change_preview.php
@@ -408,7 +408,7 @@ class SubscriptionChangePreview extends RecurlyResource
 
     /**
     * Getter method for the tax_inclusive attribute.
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     *
     * @return ?bool
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15426,11 +15426,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15556,11 +15558,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15714,6 +15718,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19127,9 +19137,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19294,9 +19303,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -19318,9 +19326,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20289,9 +20296,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20401,9 +20407,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20862,9 +20867,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferred_locale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processing_prepayment_amount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `tax_inclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.