### PR TITLE
Fixing deprecation warnings in client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: PHP ${{ matrix.php }} tests
     strategy:
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1]
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/lib/recurly/http_adapter.php
+++ b/lib/recurly/http_adapter.php
@@ -36,7 +36,7 @@ class HttpAdapter
             ]
         );
         // The Content-Length header is required by Recurly API infrastructure
-        $headers['Content-Length'] = strlen($body);
+        $headers['Content-Length'] = is_null($body) ? 0 : strlen($body);
         $headers_str = "";
         foreach ($headers as $k => $v) {
             $headers_str .= "$k: $v\r\n";

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -104,10 +104,10 @@ class Pager implements \Iterator
      * Implementation of the Iterator interfaces `key` method.
      * Will return NULL for every iteration.
      * 
-     * @return             void
+     * @return             mixed
      * @codeCoverageIgnore
      */
-    public function key(): void
+    public function key(): mixed
     {
         //NOOP
     }


### PR DESCRIPTION
Resolves https://github.com/recurly/recurly-client-php/issues/677

- Fixes deprecation warnings that are generated from the client when using PHP 8.x.
- Adds PHP 8.1 to the testing matrix.