### PR TITLE
Add composer dump-autoload to test script

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+CODEFRESH=${CI:-false}
+
+if [ "$CODEFRESH" == "false" ]; then
+    composer dump-autoload
+fi
+
 ./vendor/bin/phpunit


### PR DESCRIPTION
This should make local development easier when running the test script.