### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly/resources/plan.php
+++ b/lib/recurly/resources/plan.php
@@ -29,6 +29,8 @@ class Plan extends RecurlyResource
     private $_interval_unit;
     private $_name;
     private $_object;
+    private $_pricing_model;
+    private $_ramp_intervals;
     private $_revenue_schedule_type;
     private $_setup_fee_accounting_code;
     private $_setup_fee_revenue_schedule_type;
@@ -43,6 +45,7 @@ class Plan extends RecurlyResource
 
     protected static $array_hints = [
         'setCurrencies' => '\Recurly\Resources\PlanPricing',
+        'setRampIntervals' => '\Recurly\Resources\PlanRampInterval',
     ];
 
     
@@ -438,6 +441,55 @@ If `false`, only plan add-ons can be used.
     public function setObject(string $object): void
     {
         $this->_object = $object;
+    }
+
+    /**
+    * Getter method for the pricing_model attribute.
+    * A fixed pricing model has the same price for each billing period.
+A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+a specified cadence of billing periods. The price change could be an increase or decrease.
+
+    *
+    * @return ?string
+    */
+    public function getPricingModel(): ?string
+    {
+        return $this->_pricing_model;
+    }
+
+    /**
+    * Setter method for the pricing_model attribute.
+    *
+    * @param string $pricing_model
+    *
+    * @return void
+    */
+    public function setPricingModel(string $pricing_model): void
+    {
+        $this->_pricing_model = $pricing_model;
+    }
+
+    /**
+    * Getter method for the ramp_intervals attribute.
+    * Ramp Intervals
+    *
+    * @return array
+    */
+    public function getRampIntervals(): array
+    {
+        return $this->_ramp_intervals ?? [] ;
+    }
+
+    /**
+    * Setter method for the ramp_intervals attribute.
+    *
+    * @param array $ramp_intervals
+    *
+    * @return void
+    */
+    public function setRampIntervals(array $ramp_intervals): void
+    {
+        $this->_ramp_intervals = $ramp_intervals;
     }
 
     /**

--- a/lib/recurly/resources/plan_ramp_interval.php
+++ b/lib/recurly/resources/plan_ramp_interval.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+namespace Recurly\Resources;
+
+use Recurly\RecurlyResource;
+
+// phpcs:disable
+class PlanRampInterval extends RecurlyResource
+{
+    private $_currencies;
+    private $_starting_billing_cycle;
+
+    protected static $array_hints = [
+        'setCurrencies' => '\Recurly\Resources\PlanRampPricing',
+    ];
+
+    
+    /**
+    * Getter method for the currencies attribute.
+    * Represents the price for the ramp interval.
+    *
+    * @return array
+    */
+    public function getCurrencies(): array
+    {
+        return $this->_currencies ?? [] ;
+    }
+
+    /**
+    * Setter method for the currencies attribute.
+    *
+    * @param array $currencies
+    *
+    * @return void
+    */
+    public function setCurrencies(array $currencies): void
+    {
+        $this->_currencies = $currencies;
+    }
+
+    /**
+    * Getter method for the starting_billing_cycle attribute.
+    * Represents the first billing cycle of a ramp.
+    *
+    * @return ?int
+    */
+    public function getStartingBillingCycle(): ?int
+    {
+        return $this->_starting_billing_cycle;
+    }
+
+    /**
+    * Setter method for the starting_billing_cycle attribute.
+    *
+    * @param int $starting_billing_cycle
+    *
+    * @return void
+    */
+    public function setStartingBillingCycle(int $starting_billing_cycle): void
+    {
+        $this->_starting_billing_cycle = $starting_billing_cycle;
+    }
+}

--- a/lib/recurly/resources/plan_ramp_pricing.php
+++ b/lib/recurly/resources/plan_ramp_pricing.php
@@ -10,11 +10,9 @@ namespace Recurly\Resources;
 use Recurly\RecurlyResource;
 
 // phpcs:disable
-class PlanPricing extends RecurlyResource
+class PlanRampPricing extends RecurlyResource
 {
     private $_currency;
-    private $_setup_fee;
-    private $_tax_inclusive;
     private $_unit_amount;
 
     protected static $array_hints = [
@@ -45,54 +43,8 @@ class PlanPricing extends RecurlyResource
     }
 
     /**
-    * Getter method for the setup_fee attribute.
-    * Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
-    *
-    * @return ?float
-    */
-    public function getSetupFee(): ?float
-    {
-        return $this->_setup_fee;
-    }
-
-    /**
-    * Setter method for the setup_fee attribute.
-    *
-    * @param float $setup_fee
-    *
-    * @return void
-    */
-    public function setSetupFee(float $setup_fee): void
-    {
-        $this->_setup_fee = $setup_fee;
-    }
-
-    /**
-    * Getter method for the tax_inclusive attribute.
-    * This field is deprecated. Please do not use it.
-    *
-    * @return ?bool
-    */
-    public function getTaxInclusive(): ?bool
-    {
-        return $this->_tax_inclusive;
-    }
-
-    /**
-    * Setter method for the tax_inclusive attribute.
-    *
-    * @param bool $tax_inclusive
-    *
-    * @return void
-    */
-    public function setTaxInclusive(bool $tax_inclusive): void
-    {
-        $this->_tax_inclusive = $tax_inclusive;
-    }
-
-    /**
     * Getter method for the unit_amount attribute.
-    * This field should not be sent when the pricing model is 'ramp'.
+    * Represents the price for the Ramp Interval.
     *
     * @return ?float
     */

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -41,6 +41,7 @@ class Subscription extends RecurlyResource
     private $_plan;
     private $_po_number;
     private $_quantity;
+    private $_ramp_intervals;
     private $_remaining_billing_cycles;
     private $_remaining_pause_cycles;
     private $_renewal_billing_cycles;
@@ -61,6 +62,7 @@ class Subscription extends RecurlyResource
         'setAddOns' => '\Recurly\Resources\SubscriptionAddOn',
         'setCouponRedemptions' => '\Recurly\Resources\CouponRedemptionMini',
         'setCustomFields' => '\Recurly\Resources\CustomField',
+        'setRampIntervals' => '\Recurly\Resources\SubscriptionRampIntervalResponse',
     ];
 
     
@@ -729,6 +731,29 @@ class Subscription extends RecurlyResource
     public function setQuantity(int $quantity): void
     {
         $this->_quantity = $quantity;
+    }
+
+    /**
+    * Getter method for the ramp_intervals attribute.
+    * The ramp intervals representing the pricing schedule for the subscription.
+    *
+    * @return array
+    */
+    public function getRampIntervals(): array
+    {
+        return $this->_ramp_intervals ?? [] ;
+    }
+
+    /**
+    * Setter method for the ramp_intervals attribute.
+    *
+    * @param array $ramp_intervals
+    *
+    * @return void
+    */
+    public function setRampIntervals(array $ramp_intervals): void
+    {
+        $this->_ramp_intervals = $ramp_intervals;
     }
 
     /**

--- a/lib/recurly/resources/subscription_change.php
+++ b/lib/recurly/resources/subscription_change.php
@@ -24,6 +24,7 @@ class SubscriptionChange extends RecurlyResource
     private $_object;
     private $_plan;
     private $_quantity;
+    private $_ramp_intervals;
     private $_revenue_schedule_type;
     private $_setup_fee_revenue_schedule_type;
     private $_shipping;
@@ -35,6 +36,7 @@ class SubscriptionChange extends RecurlyResource
     protected static $array_hints = [
         'setAddOns' => '\Recurly\Resources\SubscriptionAddOn',
         'setCustomFields' => '\Recurly\Resources\CustomField',
+        'setRampIntervals' => '\Recurly\Resources\SubscriptionRampIntervalResponse',
     ];
 
     
@@ -312,6 +314,29 @@ class SubscriptionChange extends RecurlyResource
     public function setQuantity(int $quantity): void
     {
         $this->_quantity = $quantity;
+    }
+
+    /**
+    * Getter method for the ramp_intervals attribute.
+    * The ramp intervals representing the pricing schedule for the subscription.
+    *
+    * @return array
+    */
+    public function getRampIntervals(): array
+    {
+        return $this->_ramp_intervals ?? [] ;
+    }
+
+    /**
+    * Setter method for the ramp_intervals attribute.
+    *
+    * @param array $ramp_intervals
+    *
+    * @return void
+    */
+    public function setRampIntervals(array $ramp_intervals): void
+    {
+        $this->_ramp_intervals = $ramp_intervals;
     }
 
     /**

--- a/lib/recurly/resources/subscription_change_preview.php
+++ b/lib/recurly/resources/subscription_change_preview.php
@@ -24,6 +24,7 @@ class SubscriptionChangePreview extends RecurlyResource
     private $_object;
     private $_plan;
     private $_quantity;
+    private $_ramp_intervals;
     private $_revenue_schedule_type;
     private $_setup_fee_revenue_schedule_type;
     private $_shipping;
@@ -35,6 +36,7 @@ class SubscriptionChangePreview extends RecurlyResource
     protected static $array_hints = [
         'setAddOns' => '\Recurly\Resources\SubscriptionAddOn',
         'setCustomFields' => '\Recurly\Resources\CustomField',
+        'setRampIntervals' => '\Recurly\Resources\SubscriptionRampIntervalResponse',
     ];
 
     
@@ -312,6 +314,29 @@ class SubscriptionChangePreview extends RecurlyResource
     public function setQuantity(int $quantity): void
     {
         $this->_quantity = $quantity;
+    }
+
+    /**
+    * Getter method for the ramp_intervals attribute.
+    * The ramp intervals representing the pricing schedule for the subscription.
+    *
+    * @return array
+    */
+    public function getRampIntervals(): array
+    {
+        return $this->_ramp_intervals ?? [] ;
+    }
+
+    /**
+    * Setter method for the ramp_intervals attribute.
+    *
+    * @param array $ramp_intervals
+    *
+    * @return void
+    */
+    public function setRampIntervals(array $ramp_intervals): void
+    {
+        $this->_ramp_intervals = $ramp_intervals;
     }
 
     /**

--- a/lib/recurly/resources/subscription_ramp_interval_response.php
+++ b/lib/recurly/resources/subscription_ramp_interval_response.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+namespace Recurly\Resources;
+
+use Recurly\RecurlyResource;
+
+// phpcs:disable
+class SubscriptionRampIntervalResponse extends RecurlyResource
+{
+    private $_remaining_billing_cycles;
+    private $_starting_billing_cycle;
+    private $_unit_amount;
+
+    protected static $array_hints = [
+    ];
+
+    
+    /**
+    * Getter method for the remaining_billing_cycles attribute.
+    * Represents how many billing cycles are left in a ramp interval.
+    *
+    * @return ?int
+    */
+    public function getRemainingBillingCycles(): ?int
+    {
+        return $this->_remaining_billing_cycles;
+    }
+
+    /**
+    * Setter method for the remaining_billing_cycles attribute.
+    *
+    * @param int $remaining_billing_cycles
+    *
+    * @return void
+    */
+    public function setRemainingBillingCycles(int $remaining_billing_cycles): void
+    {
+        $this->_remaining_billing_cycles = $remaining_billing_cycles;
+    }
+
+    /**
+    * Getter method for the starting_billing_cycle attribute.
+    * Represents how many billing cycles are included in a ramp interval.
+    *
+    * @return ?int
+    */
+    public function getStartingBillingCycle(): ?int
+    {
+        return $this->_starting_billing_cycle;
+    }
+
+    /**
+    * Setter method for the starting_billing_cycle attribute.
+    *
+    * @param int $starting_billing_cycle
+    *
+    * @return void
+    */
+    public function setStartingBillingCycle(int $starting_billing_cycle): void
+    {
+        $this->_starting_billing_cycle = $starting_billing_cycle;
+    }
+
+    /**
+    * Getter method for the unit_amount attribute.
+    * Represents the price for the ramp interval.
+    *
+    * @return ?int
+    */
+    public function getUnitAmount(): ?int
+    {
+        return $this->_unit_amount;
+    }
+
+    /**
+    * Setter method for the unit_amount attribute.
+    *
+    * @param int $unit_amount
+    *
+    * @return void
+    */
+    public function setUnitAmount(int $unit_amount): void
+    {
+        $this->_unit_amount = $unit_amount;
+    }
+}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17259,7 +17259,7 @@ components:
           title: Field value
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
-          maxLength: 100
+          maxLength: 255
       required:
       - name
       - value
@@ -18828,6 +18828,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         accounting_code:
           type: string
           title: Plan accounting code
@@ -19006,6 +19022,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19137,6 +19169,7 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
         tax_inclusive:
@@ -19214,6 +19247,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19291,6 +19329,19 @@ components:
             a non-default dunning campaign should be assigned to this plan. For sites
             without multiple dunning campaigns enabled, the default dunning campaign
             will always be used.
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     AddOnPricing:
       type: object
       properties:
@@ -19311,6 +19362,24 @@ components:
           default: false
           description: This field is deprecated. Please do not use it.
           deprecated: true
+      required:
+      - currency
+      - unit_amount
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
       required:
       - currency
       - unit_amount
@@ -19899,6 +19968,13 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
         paused_at:
           type: string
           format: date-time
@@ -20362,6 +20438,13 @@ components:
           readOnly: true
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfo"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
     SubscriptionChangeBillingInfo:
       type: object
       description: Accept nested attributes for three_d_secure_action_result_token_id
@@ -20501,6 +20584,12 @@ components:
           - moto
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfoCreate"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
     SubscriptionChangePreview:
       type: object
       allOf:
@@ -20652,6 +20741,12 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -20803,6 +20898,12 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
       required:
       - plan_code
     SubscriptionUpdate:
@@ -20986,6 +21087,30 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+    SubscriptionRampInterval:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+          default: 1
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
+    SubscriptionRampIntervalResponse:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+        remaining_billing_cycles:
+          type: integer
+          description: Represents how many billing cycles are left in a ramp interval.
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
     TaxInfo:
       type: object
       title: Tax info


### PR DESCRIPTION
- Adds `pricing_model` property to plan requests and responses (`Plan`, `PlanCreate`), which indicates if the plan is 'fixed' or 'ramp' -priced
- Adds `ramp_intervals` property (`PlanRampInterval`) to plan requests and responses (`Plan`, `PlanCreate`), which defines the pricing schedule of a ramp plan
- Adds `ramp_intervals` property (`SubscriptionRampIntervalResponse`, `SubscriptionRampInterval`) to subscription requests and responses (`Subscription`, `SubscriptionCreate`, `SubscriptionChangeCreate`, `SubscriptionChangePreview`, `SubscriptionPurchase`), which defines the pricing schedule of a ramp subscription