### PR TITLE
Fixes method_exists exception on xml_doc.php

### DIFF
--- a/lib/recurly/traits/xml_doc.php
+++ b/lib/recurly/traits/xml_doc.php
@@ -97,7 +97,7 @@ trait XmlDoc {
       }
 
       // Check for nested objects.
-      if (method_exists($attrValue, 'getChangedAttributes')) {
+      if (is_object($attrValue) && method_exists($attrValue, 'getChangedAttributes')) {
         if ($attrValue->getChangedAttributes()) {
           $attributes[$attrName] = $attrValue;
         }


### PR DESCRIPTION
Fixes #710 - [Bug] Version 2.12.26 method_exists exception on xml_doc.php

For some reason, PHP7 throws no error when `method_exists()` is provided a non-object as the first argument, but PHP8 does. Adds a simple pre-check to the call to avoid the issue altogether.