### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -310,6 +310,22 @@ class Client extends BaseClient
     }
   
     /**
+     * Verify an account's credit card billing cvv
+     *
+     * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+     * @param array  $body       The body of the request.
+     * @param array  $options    Associative array of optional parameters
+     *
+     * @return \Recurly\Resources\Transaction Transaction information from verify.
+     * @link   https://developers.recurly.com/api/v2021-02-25#operation/verify_billing_info_cvv
+     */
+    public function verifyBillingInfoCvv(string $account_id, array $body, array $options = []): \Recurly\Resources\Transaction
+    {
+        $path = $this->interpolatePath("/accounts/{account_id}/billing_info/verify_cvv", ['account_id' => $account_id]);
+        return $this->makeRequest('POST', $path, $body, $options);
+    }
+  
+    /**
      * Get the list of billing information associated with an account
      *
      * @param string $account_id Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.

--- a/lib/recurly/resources/plan_ramp_interval.php
+++ b/lib/recurly/resources/plan_ramp_interval.php
@@ -45,7 +45,7 @@ class PlanRampInterval extends RecurlyResource
 
     /**
     * Getter method for the starting_billing_cycle attribute.
-    * Represents the first billing cycle of a ramp.
+    * Represents the billing cycle where a ramp interval starts.
     *
     * @return ?int
     */

--- a/lib/recurly/resources/subscription_ramp_interval_response.php
+++ b/lib/recurly/resources/subscription_ramp_interval_response.php
@@ -45,7 +45,7 @@ class SubscriptionRampIntervalResponse extends RecurlyResource
 
     /**
     * Getter method for the starting_billing_cycle attribute.
-    * Represents how many billing cycles are included in a ramp interval.
+    * Represents the billing cycle where a ramp interval starts.
     *
     * @return ?int
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2441,6 +2441,47 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Transaction:
           %v\", transaction)"
+  "/accounts/{account_id}/billing_info/verify_cvv":
+    post:
+      tags:
+      - billing_info
+      operationId: verify_billing_info_cvv
+      summary: Verify an account's credit card billing cvv
+      parameters:
+      - "$ref": "#/components/parameters/account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BillingInfoVerifyCVV"
+      responses:
+        '200':
+          description: Transaction information from verify.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Transaction"
+        '429':
+          description: Over limit error. A credit card can only be checked 3 times
+            in 24 hours.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Invalid billing information, or error running the verification
+            transaction.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorMayHaveTransaction"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/billing_infos":
     get:
       tags:
@@ -16942,6 +16983,12 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+    BillingInfoVerifyCVV:
+      type: object
+      properties:
+        verification_value:
+          type: string
+          description: Unique security code for a credit card.
     Coupon:
       type: object
       properties:
@@ -19275,7 +19322,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21239,7 +21286,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21250,7 +21297,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.


### PR DESCRIPTION
- Added `/accounts/{account_id}/billing_info/verify_cvv` route which takes a `verification_value` and returns a `transaction` if the `verification_value` matches the cvv of the credit card on file. A `422` is returned if the `verification_value` does not match the credit card on file and the a `429` is returned if the same credit card is checked more than 3 times in 24 hours.