### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/subscription_ramp_interval_response.php
+++ b/lib/recurly/resources/subscription_ramp_interval_response.php
@@ -70,9 +70,9 @@ class SubscriptionRampIntervalResponse extends RecurlyResource
     * Getter method for the unit_amount attribute.
     * Represents the price for the ramp interval.
     *
-    * @return ?int
+    * @return ?float
     */
-    public function getUnitAmount(): ?int
+    public function getUnitAmount(): ?float
     {
         return $this->_unit_amount;
     }
@@ -80,11 +80,11 @@ class SubscriptionRampIntervalResponse extends RecurlyResource
     /**
     * Setter method for the unit_amount attribute.
     *
-    * @param int $unit_amount
+    * @param float $unit_amount
     *
     * @return void
     */
-    public function setUnitAmount(int $unit_amount): void
+    public function setUnitAmount(float $unit_amount): void
     {
         $this->_unit_amount = $unit_amount;
     }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21302,7 +21302,9 @@ components:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
         unit_amount:
-          type: integer
+          type: number
+          format: float
+          title: Unit price
           description: Represents the price for the ramp interval.
     TaxInfo:
       type: object


### PR DESCRIPTION
Fixed incorrect type in OpenAPI spec for SubscriptionRampIntervalResponse, `unit_amount` is now `float`