### PR TITLE
feat: allow for psr/log ^2/3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "authors": [],
     "require": {
         "php": ">= 7.2.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",


### PR DESCRIPTION
Allowing for PSR Log v2/3 so as to not block other dependencies that support those versions