### PR TITLE
Fixing bug with setValues method

### DIFF
--- a/lib/recurly/traits/xml_doc.php
+++ b/lib/recurly/traits/xml_doc.php
@@ -66,7 +66,7 @@ trait XmlDoc {
   public function setValues($values)
   {
     foreach($values as $key => $value) {
-      $this->_values[$key] = $value;
+      $this->$key = $value;
     }
     return $this;
   }


### PR DESCRIPTION
When the client was refactored to use the `XmlDoc` trait, the behavior of the `setValues` method changed. This change resulted in the `_unsavedKeys` array not to be populated properly.