### PR TITLE
decimal quanitity and decimal usage additions v2

### DIFF
--- a/Tests/Recurly/Usage_Test.php
+++ b/Tests/Recurly/Usage_Test.php
@@ -11,6 +11,7 @@ class Recurly_UsageTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Usage', $usage);
     $this->assertInstanceOf('Recurly_Stub', $usage->measured_unit);
     $this->assertEquals(6, $usage->amount);
+    $this->assertEquals(6.27934, $usage->amount_decimal);
     $this->assertEquals('Order Number: #198349243975', $usage->merchant_tag);
     $this->assertEquals('percentage', $usage->usage_type);
     $this->assertEquals(1.25, $usage->usage_percentage);

--- a/Tests/fixtures/adjustments/show-200.xml
+++ b/Tests/fixtures/adjustments/show-200.xml
@@ -15,6 +15,7 @@ Content-Type: application/xml; charset=utf-8
   <origin>plan</origin>
   <unit_amount_in_cents type="integer">1200</unit_amount_in_cents>
   <quantity type="integer">1</quantity>
+  <quantity_decimal>1.2</quantity_decimal>
   <discount_in_cents type="integer">0</discount_in_cents>
   <tax_in_cents type="integer">5000</tax_in_cents>
   <total_in_cents type="integer">1200</total_in_cents>

--- a/Tests/fixtures/usage/show-200.xml
+++ b/Tests/fixtures/usage/show-200.xml
@@ -5,6 +5,7 @@ Content-Type: application/xml; charset=utf-8
 <usage href="https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/add_ons/marketing_emails/usage/123456">
   <measured_unit href="https://yoursubdomain.recurly.com/v2/measured_units/7610" />
   <amount type="integer">6</amount>
+  <amount_decimal type="float">6.27934</amount_decimal>
   <merchant_tag>Order Number: #198349243975</merchant_tag>
   <recording_timestamp type="date">2016-03-15T23:17:15+00:00</recording_timestamp>
   <usage_timestamp type="date">2016-03-15T23:17:14+00:00</usage_timestamp>

--- a/lib/recurly/usage.php
+++ b/lib/recurly/usage.php
@@ -4,6 +4,7 @@
  * Class Recurly_Usage
  * @property Recurly_Stub $measured_unit The URL to the Recurly_MeasuredUnit associated with this usage.
  * @property integer $amount The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g. - $5.00 is "500").
+ * @property float $amount_decimal A floating-point alternative for the amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places for requests.  Otherwise, this field will not be used.
  * @property string $merchant_tag Custom field great for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint.
  * @property string $usage_type Whether the associated add-on has a pricing model of "price per unit" (price) or "percentage of an amount" (percentage).
  * @property integer $unit_amount_in_cents If usage_type = price, this is the price of the add-on at the usage_timestamp time and the price at which the usage will be billed on the invoice.
@@ -58,7 +59,7 @@ class Recurly_Usage extends Recurly_Resource
 
   protected static function uriForUsages($subUuid, $addOnCode) {
     return self::_safeUri(
-      Recurly_Client::PATH_SUBSCRIPTIONS, $subUuid, 
+      Recurly_Client::PATH_SUBSCRIPTIONS, $subUuid,
       Recurly_Client::PATH_ADDONS, $addOnCode,
       Recurly_Client::PATH_USAGE
     );
@@ -66,7 +67,7 @@ class Recurly_Usage extends Recurly_Resource
 
   protected static function uriForUsage($subUuid, $addOnCode, $usageId) {
     return self::_safeUri(
-      Recurly_Client::PATH_SUBSCRIPTIONS, $subUuid, 
+      Recurly_Client::PATH_SUBSCRIPTIONS, $subUuid,
       Recurly_Client::PATH_ADDONS, $addOnCode,
       Recurly_Client::PATH_USAGE, $usageId
     );
@@ -77,7 +78,7 @@ class Recurly_Usage extends Recurly_Resource
   }
   protected function getWriteableAttributes() {
     return array(
-      'amount', 'merchant_tag', 'usage_type', 'unit_amount_in_cents',
+      'amount', 'amount_decimal', 'merchant_tag', 'usage_type', 'unit_amount_in_cents',
       'billed_at', 'recording_timestamp', 'usage_timestamp', 'measured_unit'
     );
   }


### PR DESCRIPTION
Add `quantity_decimal` and `quantity_decimal_remaining` fields to `Adjustment` class. Also add missing `quantity_remaining` field to `Adjustment` class. Add `amount_decimal `field to `Usage` class.  Also add `refundWithDecimal()` and `toRefundAttributesWithDecimal()` to `Adjustment` class for refunds.