### PR TITLE
Generated Latest Changes for v2019-10-10(Decimal Usage and Quantities)

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -2724,14 +2724,15 @@ class Client extends BaseClient
     /**
      * Assign a dunning campaign to multiple plans
      *
-     * @param array $body The body of the request.
+     * @param string $dunning_campaign_id Dunning Campaign ID, e.g. `e28zov4fw0v2`.
+     * @param array  $body                The body of the request.
      *
      * @return \Recurly\Resources\DunningCampaignsBulkUpdateResponse A list of updated plans.
      * @link   https://developers.recurly.com/api/v2019-10-10#operation/put_dunning_campaign_bulk_update
      */
-    public function putDunningCampaignBulkUpdate(array $body): \Recurly\Resources\DunningCampaignsBulkUpdateResponse
+    public function putDunningCampaignBulkUpdate(string $dunning_campaign_id, array $body): \Recurly\Resources\DunningCampaignsBulkUpdateResponse
     {
-        $path = $this->interpolatePath("/dunning_campaigns/{dunning_campaign_id}/bulk_update", []);
+        $path = $this->interpolatePath("/dunning_campaigns/{dunning_campaign_id}/bulk_update", ['dunning_campaign_id' => $dunning_campaign_id]);
         return $this->makeRequest('PUT', $path, $body, null);
     }
   

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -43,8 +43,10 @@ class LineItem extends RecurlyResource
     private $_product_code;
     private $_proration_rate;
     private $_quantity;
+    private $_quantity_decimal;
     private $_refund;
     private $_refunded_quantity;
+    private $_refunded_quantity_decimal;
     private $_revenue_schedule_type;
     private $_shipping_address;
     private $_start_date;
@@ -785,6 +787,29 @@ class LineItem extends RecurlyResource
     }
 
     /**
+    * Getter method for the quantity_decimal attribute.
+    * A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+    *
+    * @return ?string
+    */
+    public function getQuantityDecimal(): ?string
+    {
+        return $this->_quantity_decimal;
+    }
+
+    /**
+    * Setter method for the quantity_decimal attribute.
+    *
+    * @param string $quantity_decimal
+    *
+    * @return void
+    */
+    public function setQuantityDecimal(string $quantity_decimal): void
+    {
+        $this->_quantity_decimal = $quantity_decimal;
+    }
+
+    /**
     * Getter method for the refund attribute.
     * Refund?
     *
@@ -828,6 +853,29 @@ class LineItem extends RecurlyResource
     public function setRefundedQuantity(int $refunded_quantity): void
     {
         $this->_refunded_quantity = $refunded_quantity;
+    }
+
+    /**
+    * Getter method for the refunded_quantity_decimal attribute.
+    * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+    *
+    * @return ?string
+    */
+    public function getRefundedQuantityDecimal(): ?string
+    {
+        return $this->_refunded_quantity_decimal;
+    }
+
+    /**
+    * Setter method for the refunded_quantity_decimal attribute.
+    *
+    * @param string $refunded_quantity_decimal
+    *
+    * @return void
+    */
+    public function setRefundedQuantityDecimal(string $refunded_quantity_decimal): void
+    {
+        $this->_refunded_quantity_decimal = $refunded_quantity_decimal;
     }
 
     /**

--- a/lib/recurly/resources/plan_ramp_interval.php
+++ b/lib/recurly/resources/plan_ramp_interval.php
@@ -45,7 +45,7 @@ class PlanRampInterval extends RecurlyResource
 
     /**
     * Getter method for the starting_billing_cycle attribute.
-    * Represents the first billing cycle of a ramp.
+    * Represents the billing cycle where a ramp interval starts.
     *
     * @return ?int
     */

--- a/lib/recurly/resources/subscription_ramp_interval_response.php
+++ b/lib/recurly/resources/subscription_ramp_interval_response.php
@@ -45,7 +45,7 @@ class SubscriptionRampIntervalResponse extends RecurlyResource
 
     /**
     * Getter method for the starting_billing_cycle attribute.
-    * Represents how many billing cycles are included in a ramp interval.
+    * Represents the billing cycle where a ramp interval starts.
     *
     * @return ?int
     */

--- a/lib/recurly/resources/usage.php
+++ b/lib/recurly/resources/usage.php
@@ -35,7 +35,7 @@ class Usage extends RecurlyResource
     
     /**
     * Getter method for the amount attribute.
-    * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+    * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
     *
     * @return ?float
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14463,6 +14463,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -18423,6 +18425,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18503,6 +18513,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18544,6 +18561,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -19335,7 +19360,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21093,7 +21118,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21104,7 +21129,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
@@ -21533,10 +21558,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           type: string
           enum:
@@ -21609,10 +21635,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `setQuantityDecimal`, `getQuantityDecimal `,  `refundedQuantityDecimal` and `getRefundedQuantityDecimal` to `LineItem` class
- Update `Usage` `amount` property description

Fix Bulk Dunning Campaign update
- Update `putDunningCampaignBulkUpdate` method to receive the `$dunningCampaignId`