### PR TITLE
Generated Latest Changes for v2021-02-25(Decimal Usage and Quantities and DunningEvent new fields)

### DIFF
--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -25,6 +25,8 @@ class Invoice extends RecurlyResource
     private $_discount;
     private $_due_at;
     private $_dunning_campaign_id;
+    private $_dunning_events_sent;
+    private $_final_dunning_event;
     private $_has_more_line_items;
     private $_id;
     private $_line_items;
@@ -356,6 +358,52 @@ class Invoice extends RecurlyResource
     public function setDunningCampaignId(string $dunning_campaign_id): void
     {
         $this->_dunning_campaign_id = $dunning_campaign_id;
+    }
+
+    /**
+    * Getter method for the dunning_events_sent attribute.
+    * Number of times the event was sent.
+    *
+    * @return ?int
+    */
+    public function getDunningEventsSent(): ?int
+    {
+        return $this->_dunning_events_sent;
+    }
+
+    /**
+    * Setter method for the dunning_events_sent attribute.
+    *
+    * @param int $dunning_events_sent
+    *
+    * @return void
+    */
+    public function setDunningEventsSent(int $dunning_events_sent): void
+    {
+        $this->_dunning_events_sent = $dunning_events_sent;
+    }
+
+    /**
+    * Getter method for the final_dunning_event attribute.
+    * Last communication attempt.
+    *
+    * @return ?bool
+    */
+    public function getFinalDunningEvent(): ?bool
+    {
+        return $this->_final_dunning_event;
+    }
+
+    /**
+    * Setter method for the final_dunning_event attribute.
+    *
+    * @param bool $final_dunning_event
+    *
+    * @return void
+    */
+    public function setFinalDunningEvent(bool $final_dunning_event): void
+    {
+        $this->_final_dunning_event = $final_dunning_event;
     }
 
     /**

--- a/lib/recurly/resources/line_item.php
+++ b/lib/recurly/resources/line_item.php
@@ -43,8 +43,10 @@ class LineItem extends RecurlyResource
     private $_product_code;
     private $_proration_rate;
     private $_quantity;
+    private $_quantity_decimal;
     private $_refund;
     private $_refunded_quantity;
+    private $_refunded_quantity_decimal;
     private $_revenue_schedule_type;
     private $_shipping_address;
     private $_start_date;
@@ -786,6 +788,29 @@ class LineItem extends RecurlyResource
     }
 
     /**
+    * Getter method for the quantity_decimal attribute.
+    * A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+    *
+    * @return ?string
+    */
+    public function getQuantityDecimal(): ?string
+    {
+        return $this->_quantity_decimal;
+    }
+
+    /**
+    * Setter method for the quantity_decimal attribute.
+    *
+    * @param string $quantity_decimal
+    *
+    * @return void
+    */
+    public function setQuantityDecimal(string $quantity_decimal): void
+    {
+        $this->_quantity_decimal = $quantity_decimal;
+    }
+
+    /**
     * Getter method for the refund attribute.
     * Refund?
     *
@@ -829,6 +854,29 @@ class LineItem extends RecurlyResource
     public function setRefundedQuantity(int $refunded_quantity): void
     {
         $this->_refunded_quantity = $refunded_quantity;
+    }
+
+    /**
+    * Getter method for the refunded_quantity_decimal attribute.
+    * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+    *
+    * @return ?string
+    */
+    public function getRefundedQuantityDecimal(): ?string
+    {
+        return $this->_refunded_quantity_decimal;
+    }
+
+    /**
+    * Setter method for the refunded_quantity_decimal attribute.
+    *
+    * @param string $refunded_quantity_decimal
+    *
+    * @return void
+    */
+    public function setRefundedQuantityDecimal(string $refunded_quantity_decimal): void
+    {
+        $this->_refunded_quantity_decimal = $refunded_quantity_decimal;
     }
 
     /**

--- a/lib/recurly/resources/usage.php
+++ b/lib/recurly/resources/usage.php
@@ -38,7 +38,7 @@ class Usage extends RecurlyResource
     
     /**
     * Getter method for the amount attribute.
-    * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+    * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
     *
     * @return ?float
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18141,6 +18141,14 @@ components:
           description: Unique ID to identify the dunning campaign used when dunning
             the invoice. For sites without multiple dunning campaigns enabled, this
             will always be the default dunning campaign.
+        dunning_events_sent:
+          type: integer
+          title: Dunning Event Sent
+          description: Number of times the event was sent.
+        final_dunning_event:
+          type: boolean
+          title: Final Dunning Event
+          description: Last communication attempt.
     InvoiceCreate:
       type: object
       properties:
@@ -18622,6 +18630,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18706,6 +18722,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18747,6 +18770,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -21667,10 +21698,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           "$ref": "#/components/schemas/UsageTypeEnum"
         tier_type:
@@ -21741,10 +21773,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time
@@ -23058,12 +23091,16 @@ components:
       - savings
     ExternalHppTypeEnum:
       type: string
-      description: Use for Adyen HPP billing info.
+      description: Use for Adyen HPP billing info. This should only be used as part
+        of a pending purchase request, when the billing info is nested inside an account
+        object.
       enum:
       - adyen
     OnlineBankingPaymentTypeEnum:
       type: string
-      description: Use for Online Banking billing info.
+      description: Use for Online Banking billing info. This should only be used as
+        part of a pending purchase request, when the billing info is nested inside
+        an account object.
       enum:
       - ideal
       - sofort


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `setQuantityDecimal`, `getQuantityDecimal `,  `refundedQuantityDecimal` and `getRefundedQuantityDecimal` to `LineItem` class
- Update `Usage` `amount` property description

Invoice request format has changed:
- Added `dunning_events_sent` and `final_dunning_event`