### PR TITLE
Add `preferred_time_zone` to Account

### DIFF
--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -33,6 +33,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $this->assertEquals($account->cc_emails, 'cheryl.hines@example.com,richard.lewis@example.com');
     $this->assertEquals($account->has_paused_subscription, false);
     $this->assertEquals($account->preferred_locale, 'en-US');
+    $this->assertEquals($account->preferred_time_zone, 'America/Los_Angeles');
     $this->assertEquals($account->dunning_campaign_id, '1234abcd');
     $this->assertInstanceOf('Recurly_Stub', $account->entitlements);
 
@@ -105,6 +106,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->exemption_certificate = 'Some Certificate';
     $account->entity_use_code = 'I';
     $account->preferred_locale = 'en-US';
+    $account->preferred_time_zone = 'America/Los_Angeles';
     $account->dunning_campaign_id = '1234abcd';
 
     $account_acquisition = new Recurly_AccountAcquisition();
@@ -148,7 +150,7 @@ class Recurly_AccountTest extends Recurly_TestCase
     $account->custom_fields[] = new Recurly_CustomField("serial_number", "4567-8900-1234");
 
     $this->assertEquals(
-      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt><entity_use_code>I</entity_use_code><shipping_addresses><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Home</nickname><first_name>Verena</first_name><last_name>Example</last_name></shipping_address></shipping_addresses><preferred_locale>en-US</preferred_locale><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields><account_acquisition><cost_in_cents>599</cost_in_cents><currency>USD</currency><channel>marketing_content</channel><subchannel>pickle sticks blog post</subchannel><campaign>mailchimp67a904de95.0914d8f4b4</campaign></account_acquisition><exemption_certificate>Some Certificate</exemption_certificate><dunning_campaign_id>1234abcd</dunning_campaign_id></account>\n",
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<account><account_code>act123</account_code><first_name>Verena</first_name><address><address1>123 Main St.</address1></address><tax_exempt>false</tax_exempt><entity_use_code>I</entity_use_code><shipping_addresses><shipping_address><address1>123 Main St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Work</nickname><first_name>Verena</first_name><last_name>Example</last_name><company>Recurly Inc.</company></shipping_address><shipping_address><address1>123 Dolores St.</address1><city>San Francisco</city><state>CA</state><zip>94110</zip><country>US</country><phone>555-555-5555</phone><email>verena@example.com</email><nickname>Home</nickname><first_name>Verena</first_name><last_name>Example</last_name></shipping_address></shipping_addresses><preferred_locale>en-US</preferred_locale><preferred_time_zone>America/Los_Angeles</preferred_time_zone><custom_fields><custom_field><name>serial_number</name><value>4567-8900-1234</value></custom_field></custom_fields><account_acquisition><cost_in_cents>599</cost_in_cents><currency>USD</currency><channel>marketing_content</channel><subchannel>pickle sticks blog post</subchannel><campaign>mailchimp67a904de95.0914d8f4b4</campaign></account_acquisition><exemption_certificate>Some Certificate</exemption_certificate><dunning_campaign_id>1234abcd</dunning_campaign_id></account>\n",
       $account->xml()
     );
   }

--- a/Tests/fixtures/accounts/hierarchy/show-parent-200.xml
+++ b/Tests/fixtures/accounts/hierarchy/show-parent-200.xml
@@ -22,6 +22,7 @@ Content-Type: application/xml; charset=utf-8
   <company_name nil="nil"></company_name>
   <vat_number nil="nil"></vat_number>
   <preferred_locale nil="nil"></preferred_locale>
+  <preferred_time_zone nil="nil"></preferred_time_zone>
   <address>
     <address1 nil="nil"></address1>
     <address2 nil="nil"></address2>

--- a/Tests/fixtures/accounts/show-200.xml
+++ b/Tests/fixtures/accounts/show-200.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
   <tax_exempt type="boolean">true</tax_exempt>
   <exemption_certificate>Some Certificate</exemption_certificate>
   <preferred_locale>en-US</preferred_locale>
+  <preferred_time_zone>America/Los_Angeles</preferred_time_zone>
   <address>
     <address1>123 Main St.</address1>
     <address2>APT #6</address2>

--- a/lib/recurly/account.php
+++ b/lib/recurly/account.php
@@ -26,6 +26,7 @@
  * @property string $accept_language The ISO 639-1 language code from the user's browser, indicating their preferred language and locale.
  * @property string $hosted_login_token The unique token for automatically logging the account in to the hosted management pages. You may automatically log the user into their hosted management pages by directing the user to: https://:subdomain.recurly.com/account/:hosted_login_token.
  * @property string $preferred_locale The locale for the emails
+ * @property string $preferred_time_zone The IANA time zone name to use for the emails
  * @property string $has_live_subscription True if the account has at least one live subscription.
  * @property string $has_active_subscription True if the account has at least one active subscription.
  * @property string $has_future_subscription True if the account has at least one future subscription.
@@ -143,7 +144,7 @@ class Recurly_Account extends Recurly_Resource
       'account_code', 'username', 'first_name', 'last_name', 'vat_number',
       'email', 'company_name', 'accept_language', 'billing_info', 'address',
       'tax_exempt', 'entity_use_code', 'cc_emails', 'shipping_addresses',
-      'preferred_locale', 'custom_fields', 'account_acquisition', 'exemption_certificate',
+      'preferred_locale', 'preferred_time_zone', 'custom_fields', 'account_acquisition', 'exemption_certificate',
       'parent_account_code', 'transaction_type', 'dunning_campaign_id', 'invoice_template_uuid',
     );
   }


### PR DESCRIPTION
Adds `Account#preferred_time_zone` as a string attribute for API version 2.29 which is used to determine the time zone of emails sent on behalf of the merchant to the customer.