### PR TITLE
Added decline code to transaction error

### DIFF
--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -87,6 +87,7 @@ class Recurly_TransactionTest extends Recurly_TestCase
     $this->assertInstanceOf('Recurly_Transaction', $transaction);
     $this->assertInstanceOf('Recurly_TransactionError', $transaction->transaction_error);
     $this->assertEquals('invalid_card_number', $transaction->transaction_error->error_code);
+    $this->assertEquals('invalid_number', $transaction->transaction_error->decline_code);
     $this->assertEquals('hard', $transaction->transaction_error->error_category);
     $this->assertEquals('The credit card number is not valid. The customer needs to try a different number.', $transaction->transaction_error->merchant_message);
     $this->assertEquals('Your card number is not valid. Please update your card number.', $transaction->transaction_error->customer_message);

--- a/Tests/fixtures/transactions/show-200-error.xml
+++ b/Tests/fixtures/transactions/show-200-error.xml
@@ -16,6 +16,7 @@ Content-Type: application/xml; charset=utf-8
   <refundable type="boolean">true</refundable>
   <transaction_error>
     <error_code>invalid_card_number</error_code>
+    <decline_code>invalid_number</decline_code>
     <error_category>hard</error_category>
     <merchant_message>The credit card number is not valid. The customer needs to try a different number.</merchant_message>
     <customer_message>Your card number is not valid. Please update your card number.</customer_message>

--- a/lib/recurly/transaction_error.php
+++ b/lib/recurly/transaction_error.php
@@ -8,6 +8,11 @@ class Recurly_TransactionError
   var $error_code;
 
   /**
+   * Decline code
+   */
+  var $decline_code;
+
+  /**
    * Error category
    */
   var $error_category;
@@ -33,6 +38,6 @@ class Recurly_TransactionError
   var $three_d_secure_action_token_id;
 
   public function __toString() {
-    return "<Recurly_TransactionError error_code=\"{$this->error_code}\" error_category=\"{$this->error_category}\" customer_message=\"{$this->customer_message}\" transaction_error=\"{$this->merchant_message}\" gateway_error_code=\"{$this->gateway_error_code}\">";
+    return "<Recurly_TransactionError error_code=\"{$this->error_code}\" decline_code=\"{$this->decline_code}\" error_category=\"{$this->error_category}\" customer_message=\"{$this->customer_message}\" transaction_error=\"{$this->merchant_message}\" gateway_error_code=\"{$this->gateway_error_code}\">";
   }
 }


### PR DESCRIPTION
This PR adds decline_code field to the transaction_error response. This will be populated when a transactions are declined from the issuer.