### PR TITLE
Add support for custom field definitions

### DIFF
--- a/Tests/Recurly/CustomFieldDefinitionList_Test.php
+++ b/Tests/Recurly/CustomFieldDefinitionList_Test.php
@@ -1,0 +1,36 @@
+<?php
+
+class Recurly_CustomFieldDefinitionListTest extends Recurly_TestCase
+{
+  public function testGetCustomFieldDefinitionListAll() {
+    $this->client->addResponse(
+      'GET',
+      '/custom_field_definitions',
+      'custom_field_definitions/list-200.xml'
+    );
+
+    $custom_field_definitions = Recurly_CustomFieldDefinitionList::get(null, $this->client);
+    $this->assertInstanceOf('Recurly_CustomFieldDefinitionList', $custom_field_definitions);
+
+    $custom_field_definition = $custom_field_definitions->current();
+    $this->assertInstanceOf('Recurly_CustomFieldDefinition', $custom_field_definition);
+
+    $this->assertEquals(iterator_count($custom_field_definitions), 3);
+  }
+
+  public function testGetCustomFieldDefinitionListFiltered() {
+    $this->client->addResponse(
+      'GET',
+      '/custom_field_definitions?related_type=plan',
+      'custom_field_definitions/list_filtered-200.xml'
+    );
+
+    $custom_field_definitions = Recurly_CustomFieldDefinitionList::getByRelatedType('plan', $this->client);
+    $this->assertInstanceOf('Recurly_CustomFieldDefinitionList', $custom_field_definitions);
+
+    $custom_field_definition = $custom_field_definitions->current();
+    $this->assertInstanceOf('Recurly_CustomFieldDefinition', $custom_field_definition);
+
+    $this->assertEquals(iterator_count($custom_field_definitions), 2);
+  }
+}

--- a/Tests/Recurly/CustomFieldDefinition_Test.php
+++ b/Tests/Recurly/CustomFieldDefinition_Test.php
@@ -1,0 +1,23 @@
+<?php
+
+class Recurly_CustomFieldDefinitionTest extends Recurly_TestCase
+{
+  public function testGetCustomFieldDefinition() {
+    $this->client->addResponse(
+      'GET',
+      '/custom_field_definitions/3722298505492673710',
+      'custom_field_definitions/show-200.xml'
+    );
+
+    $custom_field_definition = Recurly_CustomFieldDefinition::get('3722298505492673710', $this->client);
+    $this->assertInstanceOf('Recurly_CustomFieldDefinition', $custom_field_definition);
+    $this->assertEquals($custom_field_definition->id, '3722298505492673710');
+    $this->assertEquals($custom_field_definition->related_type, 'plan');
+    $this->assertEquals($custom_field_definition->name, 'package');
+    $this->assertEquals($custom_field_definition->user_access, 'writable');
+    $this->assertEquals($custom_field_definition->display_name, 'Package');
+    $this->assertEquals($custom_field_definition->tooltip, 'Value can be \'Basic\' or \'Premium\'');
+    $this->assertEquals($custom_field_definition->created_at, new DateTime('2023-01-23T19:02:40Z'));
+    $this->assertEquals($custom_field_definition->updated_at, new DateTime('2023-01-23T19:02:47Z'));
+  }
+}

--- a/Tests/fixtures/custom_field_definitions/list-200.xml
+++ b/Tests/fixtures/custom_field_definitions/list-200.xml
@@ -1,0 +1,39 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definitions type="array">
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3722298505492673710">
+    <id>3722298505492673710</id>
+    <related_type>plan</related_type>
+    <name>package</name>
+    <user_access>writable</user_access>
+    <display_name>Package</display_name>
+    <tooltip>Value can be 'Basic' or 'Premium'</tooltip>
+    <created_at type="datetime">2023-01-23T19:02:40Z</created_at>
+    <updated_at type="datetime">2023-01-23T19:02:47Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3717783227799104920">
+    <id>3717783227799104920</id>
+    <related_type>charge</related_type>
+    <name>size</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2023-01-17T13:31:37Z</created_at>
+    <updated_at type="datetime">2023-01-17T13:31:37Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3704733972259271618">
+    <id>3704733972259271618</id>
+    <related_type>charge</related_type>
+    <name>color</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2022-12-30T13:25:04Z</created_at>
+    <updated_at type="datetime">2022-12-30T13:25:04Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+</custom_field_definitions>

--- a/Tests/fixtures/custom_field_definitions/list_filtered-200.xml
+++ b/Tests/fixtures/custom_field_definitions/list_filtered-200.xml
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definitions type="array">
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3717783227799104920">
+    <id>3717783227799104920</id>
+    <related_type>charge</related_type>
+    <name>size</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2023-01-17T13:31:37Z</created_at>
+    <updated_at type="datetime">2023-01-17T13:31:37Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3704733972259271618">
+    <id>3704733972259271618</id>
+    <related_type>charge</related_type>
+    <name>size</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2022-12-30T13:25:04Z</created_at>
+    <updated_at type="datetime">2022-12-30T13:25:04Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+</custom_field_definitions>

--- a/Tests/fixtures/custom_field_definitions/show-200.xml
+++ b/Tests/fixtures/custom_field_definitions/show-200.xml
@@ -1,0 +1,15 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3722298505492673710">
+  <id>3722298505492673710</id>
+  <related_type>plan</related_type>
+  <name>package</name>
+  <user_access>writable</user_access>
+  <display_name>Package</display_name>
+  <tooltip>Value can be 'Basic' or 'Premium'</tooltip>
+  <created_at type="datetime">2023-01-23T19:02:40Z</created_at>
+  <updated_at type="datetime">2023-01-23T19:02:47Z</updated_at>
+  <deleted_at nil="nil"></deleted_at>
+</custom_field_definition>

--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -34,6 +34,8 @@ require_once(__DIR__ . '/recurly/credit_payment_list.php');
 require_once(__DIR__ . '/recurly/currency_percentage_tier.php');
 require_once(__DIR__ . '/recurly/custom_field.php');
 require_once(__DIR__ . '/recurly/custom_field_list.php');
+require_once(__DIR__ . '/recurly/custom_field_definition.php');
+require_once(__DIR__ . '/recurly/custom_field_definition_list.php');
 require_once(__DIR__ . '/recurly/customer_permission.php');
 require_once(__DIR__ . '/recurly/dunning_campaign.php');
 require_once(__DIR__ . '/recurly/dunning_campaign_list.php');

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -71,6 +71,7 @@ class Recurly_Client
   const PATH_COUPON_REDEMPTIONS = 'redemptions';
   const PATH_COUPONS = 'coupons';
   const PATH_CREDIT_PAYMENTS = 'credit_payments';
+  const PATH_CUSTOM_FIELD_DEFINITIONS = 'custom_field_definitions';
   const PATH_GIFT_CARDS = 'gift_cards';
   const PATH_UNIQUE_COUPONS = 'unique_coupon_codes';
   const PATH_INVOICES = 'invoices';

--- a/lib/recurly/custom_field_definition.php
+++ b/lib/recurly/custom_field_definition.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Class Recurly_CustomFieldDefinition
+
+ * @property string $id Custom field definition ID
+ * @property string $related_type Related Recurly object type
+ * @property string $name Used by the API to identify the field or reading and writing. The name can only be used once per Recurly object type.
+ * @property string $user_access The access control applied inside Recurly's admin UI
+ * @property string $display_name Used to label the field when viewing and editing the field in Recurly's admin UI.
+ * @property string $tooltip Displayed as a tooltip when editing the field in the Recurly admin UI.
+ * @property DateTime $created_at Created at
+ * @property DateTime $updated_at Last updated at
+ */
+class Recurly_CustomFieldDefinition extends Recurly_Resource
+{
+  public static function get($customFieldDefinitionId, $client = null) {
+    return Recurly_Base::_get(
+      Recurly_CustomFieldDefinition::uriForCustomFieldDefinition($customFieldDefinitionId),
+      $client
+    );
+  }
+
+  protected function uri() {
+    if (!empty($this->_href))
+      return $this->getHref();
+    else
+      return Recurly_CustomFieldDefinition::uriForCustomFieldDefinition($this->id);
+  }
+
+  protected static function uriForCustomFieldDefinition($customFieldDefinitionId) {
+    return self::_safeUri(Recurly_Client::PATH_CUSTOM_FIELD_DEFINITIONS, $customFieldDefinitionId);
+  }
+
+  protected function getNodeName() {
+    return 'custom_field_definition';
+  }
+
+  protected function getWriteableAttributes() {
+    return array(
+      'id',
+      'related_type',
+      'name',
+      'user_access',
+      'display_name',
+      'tooltip',
+      'created_at',
+      'updated_at',
+    );
+  }
+}

--- a/lib/recurly/custom_field_definition_list.php
+++ b/lib/recurly/custom_field_definition_list.php
@@ -1,0 +1,18 @@
+<?php
+
+class Recurly_CustomFieldDefinitionList extends Recurly_Pager
+{
+  public static function get($params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_CUSTOM_FIELD_DEFINITIONS, $params);
+    return new self($uri, $client);
+  }
+
+  public static function getByRelatedType($related_type, $client = null) {
+    $params['related_type'] = $related_type;
+    return self::get($params, $client);
+  }
+
+  protected function getNodeName() {
+    return 'custom_field_definitions';
+  }
+}

--- a/lib/recurly/util/xml_tools.php
+++ b/lib/recurly/util/xml_tools.php
@@ -32,6 +32,8 @@ class XmlTools
     'currency' => 'Recurly_Currency',
     'custom_fields' => 'Recurly_CustomFieldList',
     'custom_field' => 'Recurly_CustomField',
+    'custom_field_definition' => 'Recurly_CustomFieldDefinition',
+    'custom_field_definitions' => 'Recurly_CustomFieldDefinitionList',
     'customer_permission' => 'Recurly_CustomerPermission',
     'credit_invoices' => 'array',
     'credit_payment' => 'Recurly_CreditPayment',


### PR DESCRIPTION
Added support for the following Custom Field Definition endpoints:

* `GET /custom_field_definitions`
* `GET /custom_field_definitions?related_type=:related_type`
* `GET /custom_field_definitions/:custom_field_definition_id`