### PR TITLE
Fix return type of RecurlyError::getApiError

### DIFF
--- a/lib/recurly/recurly_error.php
+++ b/lib/recurly/recurly_error.php
@@ -26,7 +26,7 @@ class RecurlyError extends \Error
      * 
      * @return \Recurly\Resources\ErrorMayHaveTransaction
      */
-    public function getApiError(): \Recurly\Resources\ErrorMayHaveTransaction
+    public function getApiError(): ?\Recurly\Resources\ErrorMayHaveTransaction
     {
         return $this->_api_error;
     }


### PR DESCRIPTION
Hello,

The `_api_error` property is type hinted with nullable in the constructor However, the return type is incorrect and can lead to a `TypeError`

This PR fixes this