### PR TITLE
V2 refactor compatibility php 8 plus

### DIFF
--- a/Tests/Recurly/AccountAcquisition_Test.php
+++ b/Tests/Recurly/AccountAcquisition_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_AccountAcquisitionTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts/abcdef1234567890/acquisition', 'account_acquisition/show-200.xml'),
       array('PUT', '/accounts/abcdef1234567890/acquisition', 'account_acquisition/create-201.xml'),

--- a/Tests/Recurly/AccountBalance_Test.php
+++ b/Tests/Recurly/AccountBalance_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_AccountBalanceTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts/abcdef1234567890/balance', 'balance/show-200.xml'),
     );

--- a/Tests/Recurly/Account_List_Test.php
+++ b/Tests/Recurly/Account_List_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_AccountListTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts', 'accounts/index-200.xml')
     );

--- a/Tests/Recurly/Account_Test.php
+++ b/Tests/Recurly/Account_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_AccountTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts/abcdef1234567890', 'accounts/show-200.xml')
     );

--- a/Tests/Recurly/Addon_Test.php
+++ b/Tests/Recurly/Addon_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_AddonTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/plans/gold/add_ons/ipaddresses', 'addons/show-200.xml'),
       array('GET', '/plans/gold/add_ons/ipaddresses_revrec', 'addons/show-200-revrec.xml'),
@@ -96,8 +96,8 @@ class Recurly_AddonTest extends Recurly_TestCase
     $tier1->ending_quantity = 800;
     $tier2 = new Recurly_Tier();
     $tier2->unit_amount_in_cents->addCurrency('USD', 200);
-  
-    $addon->tiers = array($tier1, $tier2);  
+
+    $addon->tiers = array($tier1, $tier2);
 
     $this->assertXmlStringEqualsXmlString("
       <add_on>

--- a/Tests/Recurly/Adjustment_Test.php
+++ b/Tests/Recurly/Adjustment_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_AdjustmentTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/adjustments/abcdef1234567890', 'adjustments/show-200.xml'),
       array('GET', '/adjustments/abcdef1234567890_revrec', 'adjustments/show-200-revrec.xml'),

--- a/Tests/Recurly/Base_Test.php
+++ b/Tests/Recurly/Base_Test.php
@@ -51,26 +51,26 @@ class Recurly_BaseTest extends Recurly_TestCase {
     $this->client->addResponse('GET', 'accounts', 'accounts/index-200.xml');
     $accounts = Recurly_Base::_get('accounts', $this->client);
     $this->assertTrue(method_exists($accounts, 'getHeaders'),"Accounts Class does not have method getHeaders");
-    $this->assertInternalType('array', $accounts->getHeaders());
+    $this->assertIsArray($accounts->getHeaders());
 
     $this->client->addResponse('GET', 'subscriptions', 'subscriptions/index-200.xml');
     $subscriptions = Recurly_Base::_get('subscriptions', $this->client);
     $this->assertTrue(method_exists($subscriptions, 'getHeaders'),'Subscriptions Class does not have method getHeaders');
-    $this->assertInternalType('array', $subscriptions->getHeaders());
+    $this->assertIsArray($subscriptions->getHeaders());
 
     $this->client->addResponse('GET', 'abcdef1234567890', 'adjustments/show-200.xml');
     $adjustment = Recurly_Base::_get('abcdef1234567890', $this->client);
     $this->assertTrue(method_exists($adjustment, 'getHeaders'),'Adjustments Class does not have method getHeaders');
-    $this->assertInternalType('array', $adjustment->getHeaders());
+    $this->assertIsArray($adjustment->getHeaders());
   }
 
   public function testPassingEmptyResourceCode() {
     $this->expectException(Recurly_Error::class);
     $uri = Recurly_Base::_safeUri(
-      Recurly_Client::PATH_SUBSCRIPTIONS, "", 
+      Recurly_Client::PATH_SUBSCRIPTIONS, "",
       Recurly_Client::PATH_ADDONS, "marketing_emails",
       Recurly_Client::PATH_USAGE, 123456
-    );    
+    );
   }
 
   public function testUrlEncodingReplacement() {

--- a/Tests/Recurly/Billing_Info_Test.php
+++ b/Tests/Recurly/Billing_Info_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_BillingInfoTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts/venmo1234567890/billing_info', 'billing_info/show-venmo-200.xml'),
       array('GET', '/accounts/abcdef1234567890/billing_info', 'billing_info/show-200.xml'),
@@ -117,7 +117,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
   public function testVerifyBillingInfoCreditCard() {
     $billing_info = Recurly_BillingInfo::get('abcdef1234567890', $this->client);
     $this->client->addResponse('POST', 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info/verify', 'billing_info/verify-200.xml');
-    
+
     $verified = $billing_info->verify();
     $this->assertEquals($verified->origin, 'api_verify_card');
 
@@ -128,7 +128,7 @@ class Recurly_BillingInfoTest extends Recurly_TestCase
   public function testVerifyCvvBillingInfoCreditCard() {
     $billing_info = Recurly_BillingInfo::get('abcdef1234567890', $this->client);
     $this->client->addResponse('POST', 'https://api.recurly.com/v2/accounts/abcdef1234567890/billing_info/verify_cvv', 'billing_info/verify-cvv-200.xml');
-    
+
     $verified = $billing_info->verifyCvv('988');
     $this->assertInstanceOf('Recurly_BillingInfo', $billing_info);
     $this->assertEquals($verified->year, 2015);

--- a/Tests/Recurly/Coupon_Redemption_Test.php
+++ b/Tests/Recurly/Coupon_Redemption_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_CouponRedemptionTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts/abcdef1234567890/redemption', 'accounts/redemption/show-200.xml')
     );

--- a/Tests/Recurly/Coupon_Test.php
+++ b/Tests/Recurly/Coupon_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_CouponTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/coupons/special', 'coupons/show-200.xml')
     );

--- a/Tests/Recurly/CreditPaymentList_Test.php
+++ b/Tests/Recurly/CreditPaymentList_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_CreditPaymentListTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/credit_payments', 'credit_payments/index-200.xml')
     );

--- a/Tests/Recurly/DunningCampaign_List_Test.php
+++ b/Tests/Recurly/DunningCampaign_List_Test.php
@@ -2,7 +2,7 @@
 
 class RecurlyDunningCampaignListTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/dunning_campaigns', 'dunning_campaigns/index-200.xml')
     );

--- a/Tests/Recurly/DunningCampaign_Test.php
+++ b/Tests/Recurly/DunningCampaign_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_DunningCampaignTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/dunning_campaigns/1234abcd', 'dunning_campaigns/show-200.xml'),
     );

--- a/Tests/Recurly/Entitlement_List_Test.php
+++ b/Tests/Recurly/Entitlement_List_Test.php
@@ -2,7 +2,7 @@
 
 class RecurlyEntitlementListTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts/abcdef1234567890/entitlements', 'accounts/entitlements/index-200.xml')
     );

--- a/Tests/Recurly/ExportDate_List_Test.php
+++ b/Tests/Recurly/ExportDate_List_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_ExportDateList_Test extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/export_dates', 'export_dates/index-200.xml'),
     );

--- a/Tests/Recurly/ExportFile_List_Test.php
+++ b/Tests/Recurly/ExportFile_List_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_ExportFileList_Test extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/export_dates/2016-08-01/export_files', 'export_files/index-200.xml'),
     );

--- a/Tests/Recurly/ExportFile_Test.php
+++ b/Tests/Recurly/ExportFile_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_ExportFile_Test extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/export_dates/2016-08-01/export_files/revenue_schedules_full.csv', 'export_files/show-200.xml'),
     );

--- a/Tests/Recurly/GiftCard_List_Test.php
+++ b/Tests/Recurly/GiftCard_List_Test.php
@@ -2,7 +2,7 @@
 
 class RecurlyGiftCardListTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/gift_cards', 'gift_cards/index-200.xml')
     );

--- a/Tests/Recurly/GiftCard_Test.php
+++ b/Tests/Recurly/GiftCard_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_GiftCardTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/gift_cards/1988596967980562362', 'gift_cards/show-200.xml')
     );

--- a/Tests/Recurly/InvoiceTemplate_List_Test.php
+++ b/Tests/Recurly/InvoiceTemplate_List_Test.php
@@ -2,7 +2,7 @@
 
 class RecurlyInvoiceTemplateListTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/invoice_templates', 'invoice_templates/index-200.xml')
     );

--- a/Tests/Recurly/InvoiceTemplate_Test.php
+++ b/Tests/Recurly/InvoiceTemplate_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_InvoiceTemplateTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/invoice_templates/q0tzf7o7fpbl', 'invoice_templates/show-200.xml'),
     );

--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -4,7 +4,7 @@
 class Recurly_InvoiceTest extends Recurly_TestCase
 {
 
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/invoices/1001', 'invoices/show-200.xml'),
       array('GET', '/invoices/1002', 'invoices/show-with-prefix-200.xml'),

--- a/Tests/Recurly/Item_Test.php
+++ b/Tests/Recurly/Item_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_ItemTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/items/plastic_gloves', 'items/show-200.xml'),
     );
@@ -17,7 +17,7 @@ class Recurly_ItemTest extends Recurly_TestCase
 
     $this->assertSame($client, $prop->getValue($item));
   }
-  
+
   public function testGetItem() {
     $item = Recurly_Item::get('plastic_gloves', $this->client);
 

--- a/Tests/Recurly/Plan_Test.php
+++ b/Tests/Recurly/Plan_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_PlanTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/plans/silver', 'plans/show-200.xml'),
       array('GET', '/plans/ramp-priced-plan', 'plans/show-ramps-200.xml'),

--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_PurchaseTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('POST', '/purchases', 'purchases/create-201.xml'),
       array('POST', '/purchases', 'purchases/create-with-action-result-201.xml'),

--- a/Tests/Recurly/ShippingAddress_Test.php
+++ b/Tests/Recurly/ShippingAddress_Test.php
@@ -2,7 +2,7 @@
 
 class Recurly_ShippingAddressTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/accounts/abcdef1234567890', 'accounts/show-200.xml')
     );

--- a/Tests/Recurly/Transaction_Test.php
+++ b/Tests/Recurly/Transaction_Test.php
@@ -3,7 +3,7 @@
 
 class Recurly_TransactionTest extends Recurly_TestCase
 {
-  function defaultResponses() {
+  function defaultResponses(): array {
     return array(
       array('GET', '/transactions/012345678901234567890123456789ab', 'transactions/show-200.xml'),
       array('GET', '/invoices/1001', 'invoices/show-200.xml'),

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -13,11 +13,10 @@ if (! class_exists(TestCase::class)) {
 
 /**
  * Base class for our tests that sets up a mock client.
- *
- * @property Recurly_MockClient $client
  */
 abstract class Recurly_TestCase extends TestCase {
-  function setUp() {
+  protected Recurly_MockClient $client;
+  function setUp(): void {
     $this->client = new Recurly_MockClient();
     foreach ($this->defaultResponses() as $request) {
       call_user_func_array(array($this->client, 'addResponse'), $request);
@@ -27,7 +26,8 @@ abstract class Recurly_TestCase extends TestCase {
   /**
    * Return an array of responses that will be added to the mock client.
    */
-  function defaultResponses() {
+  function defaultResponses(): array
+  {
     return array();
   }
 }
@@ -36,18 +36,22 @@ abstract class Recurly_TestCase extends TestCase {
  * Return canned client responses.
  */
 class Recurly_MockClient {
+  private array $_responses;
+
   public function __construct() {
     $this->_responses = array();
   }
 
-  public function addResponse($method, $uri, $fixture_filename) {
+  public function addResponse($method, $uri, $fixture_filename): void
+  {
     if (!isset($this->_responses[$method])) {
       $this->_responses[$method] = array();
     }
     $this->_responses[$method][$uri] = $fixture_filename;
   }
 
-  public function request($method, $uri, $data = null) {
+  public function request($method, $uri, $data = null): Recurly_ClientResponse
+  {
     if (isset($this->_responses[$method][$uri])) {
       $fixture_filename = $this->_responses[$method][$uri];
     }
@@ -58,11 +62,13 @@ class Recurly_MockClient {
     return $this->responseFromFixture($fixture_filename);
   }
 
-  public function getPdf($uri, $locale = null) {
+  public function getPdf($uri, $locale = null): array
+  {
     return array($uri, $locale);
   }
 
-  protected function responseFromFixture($filename) {
+  protected function responseFromFixture($filename): Recurly_ClientResponse
+  {
     $statusCode = 200;
     $headers = array();
     $body = null;

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,25 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.*"
+        "phpunit/phpunit": "9.*",
+        "squizlabs/php_codesniffer": "3.*",
+        "phpcsstandards/phpcsutils": "@alpha",
+        "phpcompatibility/php-compatibility": "dev-develop"
     },
     "autoload": {
         "classmap": ["lib"]
+    },
+    "config": {
+      "allow-plugins": {
+        "dealerdirect/phpcodesniffer-composer-installer": true
+      }
     },
     "extra": {
         "branch-alias": {
             "dev-master": "2.4.x-dev"
         }
-    }
+    },
+  "scripts": {
+    "compatibility": "phpcs --extensions=php --severity=1 --standard=PHPCompatibility --runtime-set testVersion 8.1- lib Tests"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.7,<8"
+        "phpunit/phpunit": "9.*"
     },
     "autoload": {
         "classmap": ["lib"]

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -143,7 +143,9 @@ class Recurly_Client
         $disable = (bool)$disable;
     }
 
-    libxml_disable_entity_loader($disable);
+    if (\PHP_VERSION_ID < 80000) {
+      libxml_disable_entity_loader($disable);
+    }
   }
 
   /**

--- a/lib/recurly/coupon.php
+++ b/lib/recurly/coupon.php
@@ -122,7 +122,7 @@ class Recurly_Coupon extends Recurly_Resource
         $val = $val->format('c');
       }
 
-      $root->appendChild($doc->createElement($attr, $val));
+      $root->appendChild($doc->createElement($attr, $val ?? ''));
     }
 
     return XmlTools::renderXML($doc);

--- a/lib/recurly/currency_list.php
+++ b/lib/recurly/currency_list.php
@@ -10,7 +10,7 @@ class Recurly_CurrencyList implements ArrayAccess, Countable, IteratorAggregate
     $this->currencies = array();
   }
 
-  public function addCurrency($currencyCode, $amountInCents) {
+  public function addCurrency($currencyCode, $amountInCents): void {
     if (is_string($currencyCode) && strlen($currencyCode) == 3) {
       $this->currencies[$currencyCode] = new Recurly_Currency($currencyCode, $amountInCents);
     }
@@ -20,18 +20,19 @@ class Recurly_CurrencyList implements ArrayAccess, Countable, IteratorAggregate
     return isset($this->currencies[$currencyCode]) ? $this->currencies[$currencyCode] : null;
   }
 
-  public function offsetSet($offset, $value) {
-    return $this->addCurrency($offset, $value);
+  public function offsetSet($offset, $value): void {
+    $this->addCurrency($offset, $value);
   }
 
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return isset($this->currencies[$offset]);
   }
 
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     unset($this->currencies[$offset]);
   }
 
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return $this->getCurrency($offset);
   }
@@ -44,11 +45,11 @@ class Recurly_CurrencyList implements ArrayAccess, Countable, IteratorAggregate
     return $this->offsetGet($k);
   }
 
-  public function count() {
+  public function count(): int {
     return count($this->currencies);
   }
 
-  public function getIterator() {
+  public function getIterator(): Traversable {
     return new ArrayIterator($this->currencies);
   }
 

--- a/lib/recurly/custom_field_list.php
+++ b/lib/recurly/custom_field_list.php
@@ -10,7 +10,7 @@ class Recurly_CustomFieldList extends ArrayObject
    * @param object $value Must be instance of Recurly_CustomField
    * @throws Exception
    */
-  public function offsetSet($index, $value) {
+  public function offsetSet($index, $value): void {
     if (!$value instanceof Recurly_CustomField) {
       throw new Exception("value must be an instance of Recurly_CustomField");
     }
@@ -25,7 +25,7 @@ class Recurly_CustomFieldList extends ArrayObject
     parent::offsetSet($index, $value);
   }
 
-  public function offsetUnset($index) {
+  public function offsetUnset($index): void {
     parent::offsetSet($index, new Recurly_CustomField($index, null));
   }
 

--- a/lib/recurly/error_list.php
+++ b/lib/recurly/error_list.php
@@ -25,29 +25,30 @@ class Recurly_ErrorList implements ArrayAccess, Countable, IteratorAggregate
   }
 
   // array access to the errors collection
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
     if (is_null($offset)) {
       $this->errors[] = $value;
     } else {
       $this->errors[$offset] = $value;
     }
   }
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return isset($this->errors[$offset]);
   }
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     unset($this->errors[$offset]);
   }
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->errors[$offset]) ? $this->errors[$offset] : null;
   }
 
-  public function count()
+  public function count(): int
   {
     return count($this->errors);
   }
 
-  public function getIterator() {
+  public function getIterator(): Traversable {
     return new ArrayIterator($this->errors);
   }
 

--- a/lib/recurly/pager.php
+++ b/lib/recurly/pager.php
@@ -18,6 +18,7 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
    * @return integer number of records in list
    * @throws Recurly_Error
    */
+  #[ReturnTypeWillChange]
   public function count() {
     if (isset($this->_href)) {
       $headers = Recurly_Base::_head($this->_href, $this->_client);
@@ -47,7 +48,7 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
    *
    * @throws Recurly_Error
    */
-  public function rewind() {
+  public function rewind(): void {
     $this->_loadFrom($this->_href);
     $this->_position = 0;
   }
@@ -58,6 +59,7 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
    * @return Recurly_Resource the current object
    * @throws Recurly_Error
    */
+  #[ReturnTypeWillChange]
   public function current()
   {
     // Work around pre-PHP 5.5 issue that prevents `empty($this->count())`:
@@ -84,6 +86,7 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   /**
    * @return integer current position within the current page
    */
+  #[ReturnTypeWillChange]
   public function key() {
     return $this->_position;
   }
@@ -91,14 +94,14 @@ abstract class Recurly_Pager extends Recurly_Base implements Iterator, Countable
   /**
    * Increments the position to the next element
    */
-  public function next() {
+  public function next(): void {
     ++$this->_position;
   }
 
   /**
    * @return boolean True if the current position is valid.
    */
-  public function valid() {
+  public function valid(): bool {
     return (isset($this->_objects[$this->_position]) || isset($this->_links['next']));
   }
 


### PR DESCRIPTION
Dear Reviewers,

Please review this PR regarding PHP 8+ compatibility. And could you merge it if you feel it meets expectations?

**Goal**
Fix errors and warnings caused by upgrading the runtime PHP version to 8+, keeping compatibility with <=7.4 versions and not changing business logic. You will find the error log file that contains the error I was facing that triggered the making of this PR.

All changes were made based on compatibility check results provided by the tool in the commit  2c76458d972b650e4b2921d43e872d8147a42e34 (this commit is entirely optional and can be removed from the branch if required). Compatibility check results are attached to this PR (you will notice that I left some compatibility check items as they go beyond my initial intention, _e.g._ `PHP has reserved all method names with a double underscore prefix for future use`).

This change keeps code compatibility with PHP's previous versions and will work with <= 7.4. The whole test suite was run using PHP 7.4 and PHP 8.1. Test suit execution results can be found attached to this PR.

There are no logic changes in this PR apart from
- `lib/recurly/coupon.php` line 125
- `lib/recurly/client.php` line 139

**Supporting files**
- [error.log](https://github.com/recurly/recurly-client-php/files/10874465/error.log)
- [compatibility.log](https://github.com/recurly/recurly-client-php/files/10874462/compatibility.log)
- [test-74-results.log](https://github.com/recurly/recurly-client-php/files/10874463/test-74-results.log)
- [test-81-results.log](https://github.com/recurly/recurly-client-php/files/10874464/test-81-results.log)

Fix created for
https://github.com/proposify

Ref
#637