### PR TITLE
Add used_tax_service to Invoice response

### DIFF
--- a/Tests/fixtures/invoices/show-200.xml
+++ b/Tests/fixtures/invoices/show-200.xml
@@ -29,6 +29,7 @@ Content-Type: application/xml; charset=utf-8
   <recovery_reason nil="nil"></recovery_reason>
   <tax_types nil="nil"></tax_types>
   <dunning_campaign_id>1234abcd</dunning_campaign_id>
+  <used_tax_service type="boolean">true</used_tax_service>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/012345678901234567890123456789ab" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>

--- a/Tests/fixtures/invoices/show-with-prefix-200.xml
+++ b/Tests/fixtures/invoices/show-with-prefix-200.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
   <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
+  <used_tax_service type="boolean">true</used_tax_service>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/012345678901234567890123456789ab" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -44,6 +44,7 @@
  * @property int $subtotal_before_discount_in_cents The total of all adjustments on the invoice before discounts or taxes are applied.
  * @property int $credit_customer_notes Allows merchant to set customer notes on a credit invoice. Will only be rejected if type is set to "charge", otherwise will be ignored if no credit invoice is created.
  * @property string $dunning_campaign_id Unique ID to identify the dunning campaign used when dunning the invoice.
+ * @property boolean $used_tax_service If taxes are enabled for the site, it will be true when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
  */
 class Recurly_Invoice extends Recurly_Resource
 {


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `<used_tax_service>`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.