### PR TITLE
Generated Latest Changes for v2019-10-10 (used_tax_service on Invoice)

### DIFF
--- a/lib/recurly/resources/custom_field_definition.php
+++ b/lib/recurly/resources/custom_field_definition.php
@@ -241,6 +241,7 @@ class CustomFieldDefinition extends RecurlyResource
 - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but
   editing will only be available via the API.
 - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI.
+- `set_only` - Users with the Customers role will be able to set this field's data via the admin console.
 
     *
     * @return ?string

--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -46,6 +46,7 @@ class Invoice extends RecurlyResource
     private $_transactions;
     private $_type;
     private $_updated_at;
+    private $_used_tax_service;
     private $_vat_number;
     private $_vat_reverse_charge_notes;
 
@@ -836,6 +837,29 @@ class Invoice extends RecurlyResource
     public function setUpdatedAt(string $updated_at): void
     {
         $this->_updated_at = $updated_at;
+    }
+
+    /**
+    * Getter method for the used_tax_service attribute.
+    * Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
+    *
+    * @return ?bool
+    */
+    public function getUsedTaxService(): ?bool
+    {
+        return $this->_used_tax_service;
+    }
+
+    /**
+    * Setter method for the used_tax_service attribute.
+    *
+    * @param bool $used_tax_service
+    *
+    * @return void
+    */
+    public function setUsedTaxService(bool $used_tax_service): void
+    {
+        $this->_used_tax_service = $used_tax_service;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -224,8 +224,8 @@ tags:
   x-displayName: Site
 - name: custom_field_definition
   x-displayName: Custom Field Definition
-  description: Describes the fields that can use used as custom fields on accounts
-    or subscriptions.
+  description: Describes the fields that can be used as custom fields on accounts,
+    items, line-items (one time charges), plans, or subscriptions.
 - name: item
   x-displayName: Item
   description: |-
@@ -15561,7 +15561,9 @@ components:
           - es-MX
           - es-US
           - fi-FI
+          - fr-BE
           - fr-CA
+          - fr-CH
           - fr-FR
           - hi-IN
           - it-IT
@@ -15698,7 +15700,9 @@ components:
           - es-MX
           - es-US
           - fi-FI
+          - fr-BE
           - fr-CA
+          - fr-CH
           - fr-FR
           - hi-IN
           - it-IT
@@ -16619,6 +16623,9 @@ components:
           title: Security code or CVV
           description: "*STRONGLY RECOMMENDED*"
           maxLength: 4
+        currency:
+          type: string
+          description: 3-letter ISO 4217 currency code.
         vat_number:
           type: string
           title: VAT number
@@ -17468,10 +17475,12 @@ components:
             - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but
               editing will only be available via the API.
             - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI.
+            - `set_only` - Users with the Customers role will be able to set this field's data via the admin console.
           enum:
           - api_only
           - read_only
           - write
+          - set_only
         display_name:
           type: string
           title: Display name
@@ -17966,6 +17975,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `used_tax_service`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.