### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly/resources/tax_detail.php
+++ b/lib/recurly/resources/tax_detail.php
@@ -12,6 +12,9 @@ use Recurly\RecurlyResource;
 // phpcs:disable
 class TaxDetail extends RecurlyResource
 {
+    private $_billable;
+    private $_level;
+    private $_name;
     private $_rate;
     private $_region;
     private $_tax;
@@ -21,6 +24,75 @@ class TaxDetail extends RecurlyResource
     ];
 
     
+    /**
+    * Getter method for the billable attribute.
+    * Whether or not the line item is taxable. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
+    *
+    * @return ?bool
+    */
+    public function getBillable(): ?bool
+    {
+        return $this->_billable;
+    }
+
+    /**
+    * Setter method for the billable attribute.
+    *
+    * @param bool $billable
+    *
+    * @return void
+    */
+    public function setBillable(bool $billable): void
+    {
+        $this->_billable = $billable;
+    }
+
+    /**
+    * Getter method for the level attribute.
+    * Provides the jurisdiction level for the Communications tax applied. Example values include city, state and federal. Present only when Avalara for Communications is enabled.
+    *
+    * @return ?string
+    */
+    public function getLevel(): ?string
+    {
+        return $this->_level;
+    }
+
+    /**
+    * Setter method for the level attribute.
+    *
+    * @param string $level
+    *
+    * @return void
+    */
+    public function setLevel(string $level): void
+    {
+        $this->_level = $level;
+    }
+
+    /**
+    * Getter method for the name attribute.
+    * Provides the name of the Communications tax applied. Present only when Avalara for Communications is enabled.
+    *
+    * @return ?string
+    */
+    public function getName(): ?string
+    {
+        return $this->_name;
+    }
+
+    /**
+    * Setter method for the name attribute.
+    *
+    * @param string $name
+    *
+    * @return void
+    */
+    public function setName(string $name): void
+    {
+        $this->_name = $name;
+    }
+
     /**
     * Getter method for the rate attribute.
     * Provides the tax rate for the region.
@@ -46,7 +118,7 @@ class TaxDetail extends RecurlyResource
 
     /**
     * Getter method for the region attribute.
-    * Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code.
+    * Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code. Not present when Avalara for Communications is enabled.
     *
     * @return ?string
     */
@@ -92,7 +164,7 @@ class TaxDetail extends RecurlyResource
 
     /**
     * Getter method for the type attribute.
-    * Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or PST.
+    * Provides the tax type for the region or type of Comminications tax when Avalara for Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/tax_info.php
+++ b/lib/recurly/resources/tax_info.php
@@ -24,7 +24,7 @@ class TaxInfo extends RecurlyResource
     
     /**
     * Getter method for the rate attribute.
-    * Rate
+    * The combined tax rate. Not present when Avalara for Communications is enabled.
     *
     * @return ?float
     */
@@ -47,7 +47,7 @@ class TaxInfo extends RecurlyResource
 
     /**
     * Getter method for the region attribute.
-    * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.
+    * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST. Not present when Avalara for Communications is enabled.
     *
     * @return ?string
     */
@@ -70,7 +70,7 @@ class TaxInfo extends RecurlyResource
 
     /**
     * Getter method for the tax_details attribute.
-    * Provides additional tax details for Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItem.
+    * Provides additional tax details for Communications taxes when Avalara for Communications is enabled or Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
     *
     * @return array
     */
@@ -93,7 +93,7 @@ class TaxInfo extends RecurlyResource
 
     /**
     * Getter method for the type attribute.
-    * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+    * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries. Not present when Avalara for Communications is enabled.
     *
     * @return ?string
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21336,23 +21336,29 @@ components:
           description: Provides the tax type as "vat" for EU VAT, "usst" for U.S.
             Sales Tax, or the 2 letter country code for country level tax types like
             Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+            Not present when Avalara for Communications is enabled.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For U.S. Sales
             Tax, this will be the 2 letter state code. For EU VAT this will be the
             2 letter country code. For all country level tax types, this will display
-            the regional tax, like VAT, GST, or PST.
+            the regional tax, like VAT, GST, or PST. Not present when Avalara for
+            Communications is enabled.
         rate:
           type: number
           format: float
           title: Rate
+          description: The combined tax rate. Not present when Avalara for Communications
+            is enabled.
         tax_details:
           type: array
-          description: Provides additional tax details for Canadian Sales Tax when
-            there is tax applied at both the country and province levels. This will
-            only be populated for the Invoice response when fetching a single invoice
-            and not for the InvoiceList or LineItem.
+          description: Provides additional tax details for Communications taxes when
+            Avalara for Communications is enabled or Canadian Sales Tax when there
+            is tax applied at both the country and province levels. This will only
+            be populated for the Invoice response when fetching a single invoice and
+            not for the InvoiceList or LineItemList. Only populated for a single LineItem
+            fetch when Avalara for Communications is enabled.
           items:
             "$ref": "#/components/schemas/TaxDetail"
     TaxDetail:
@@ -21362,13 +21368,15 @@ components:
         type:
           type: string
           title: Type
-          description: Provides the tax type for the region. For Canadian Sales Tax,
+          description: Provides the tax type for the region or type of Comminications
+            tax when Avalara for Communications is enabled. For Canadian Sales Tax,
             this will be GST, HST, QST or PST.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For Canadian
             Sales Tax, this will be either the 2 letter province code or country code.
+            Not present when Avalara for Communications is enabled.
         rate:
           type: number
           format: float
@@ -21379,6 +21387,22 @@ components:
           format: float
           title: Tax
           description: The total tax applied for this tax type.
+        name:
+          type: string
+          title: Name
+          description: Provides the name of the Communications tax applied. Present
+            only when Avalara for Communications is enabled.
+        level:
+          type: string
+          title: Level
+          description: Provides the jurisdiction level for the Communications tax
+            applied. Example values include city, state and federal. Present only
+            when Avalara for Communications is enabled.
+        billable:
+          type: boolean
+          title: Billable
+          description: Whether or not the line item is taxable. Only populated for
+            a single LineItem fetch when Avalara for Communications is enabled.
     Transaction:
       type: object
       properties:


### PR DESCRIPTION
LineItem response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`
  * `billable`

Invoice response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`