### PR TITLE
Generated Latest Changes for v2019-10-10 (gateway_attributes on PaymentMethod)

### DIFF
--- a/lib/recurly/resources/gateway_attributes.php
+++ b/lib/recurly/resources/gateway_attributes.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+namespace Recurly\Resources;
+
+use Recurly\RecurlyResource;
+
+// phpcs:disable
+class GatewayAttributes extends RecurlyResource
+{
+    private $_account_reference;
+
+    protected static $array_hints = [
+    ];
+
+    
+    /**
+    * Getter method for the account_reference attribute.
+    * Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+    *
+    * @return ?string
+    */
+    public function getAccountReference(): ?string
+    {
+        return $this->_account_reference;
+    }
+
+    /**
+    * Setter method for the account_reference attribute.
+    *
+    * @param string $account_reference
+    *
+    * @return void
+    */
+    public function setAccountReference(string $account_reference): void
+    {
+        $this->_account_reference = $account_reference;
+    }
+}

--- a/lib/recurly/resources/payment_method.php
+++ b/lib/recurly/resources/payment_method.php
@@ -19,6 +19,7 @@ class PaymentMethod extends RecurlyResource
     private $_exp_month;
     private $_exp_year;
     private $_first_six;
+    private $_gateway_attributes;
     private $_gateway_code;
     private $_gateway_token;
     private $_last_four;
@@ -191,6 +192,29 @@ class PaymentMethod extends RecurlyResource
     public function setFirstSix(string $first_six): void
     {
         $this->_first_six = $first_six;
+    }
+
+    /**
+    * Getter method for the gateway_attributes attribute.
+    * Gateway specific attributes associated with this PaymentMethod
+    *
+    * @return ?\Recurly\Resources\GatewayAttributes
+    */
+    public function getGatewayAttributes(): ?\Recurly\Resources\GatewayAttributes
+    {
+        return $this->_gateway_attributes;
+    }
+
+    /**
+    * Setter method for the gateway_attributes attribute.
+    *
+    * @param \Recurly\Resources\GatewayAttributes $gateway_attributes
+    *
+    * @return void
+    */
+    public function setGatewayAttributes(\Recurly\Resources\GatewayAttributes $gateway_attributes): void
+    {
+        $this->_gateway_attributes = $gateway_attributes;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16645,6 +16645,17 @@ components:
           title: An identifier for a specific payment gateway. Must be used in conjunction
             with `gateway_token`.
           maxLength: 12
+        gateway_attributes:
+          type: object
+          description: Additional attributes to send to the gateway.
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created. Must be used in conjunction with
+                gateway_token and gateway_code.
+              maxLength: 264
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
@@ -21470,6 +21481,7 @@ components:
           - force_collect
           - refunded_externally
           - chargeback
+          - external_recovery
         currency:
           type: string
           title: Currency
@@ -22185,6 +22197,7 @@ components:
         object:
           type: string
           enum:
+          - bacs
           - credit_card
           - paypal
           - amazon
@@ -22255,6 +22268,16 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+        gateway_attributes:
+          type: object
+          description: Gateway specific attributes associated with this PaymentMethod
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created.
+              maxLength: 264
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal


### PR DESCRIPTION
Add new property to `BillingInfoCreate` and `PaymentMethod`

- Added `gateway_attributes` property
- `gateway_attributes` allows an `account_reference` value to be be submitted. This field must be passed in with a `gateway_code` and `gateway_token`
- `gateway_attributes` is returned in response if present
