### PR TITLE
Generated Latest Changes for v2021-02-25 (Multiple Business Entities)

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -3368,6 +3368,35 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
     }
   
     /**
+     * Fetch a business entity
+     *
+     * @param string $business_entity_id Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-entity1`.
+     * @param array  $options            Associative array of optional parameters
+     *
+     * @return \Recurly\Resources\BusinessEntity Business entity details
+     * @link   https://developers.recurly.com/api/v2021-02-25#operation/get_business_entity
+     */
+    public function getBusinessEntity(string $business_entity_id, array $options = []): \Recurly\Resources\BusinessEntity
+    {
+        $path = $this->interpolatePath("/business_entities/{business_entity_id}", ['business_entity_id' => $business_entity_id]);
+        return $this->makeRequest('GET', $path, [], $options);
+    }
+  
+    /**
+     * List business entities
+     *
+     * @param array $options Associative array of optional parameters
+     *
+     * @return \Recurly\Pager List of all business entities on your site.
+     * @link   https://developers.recurly.com/api/v2021-02-25#operation/list_business_entities
+     */
+    public function listBusinessEntities(array $options = []): \Recurly\Pager
+    {
+        $path = $this->interpolatePath("/business_entities", []);
+        return new \Recurly\Pager($this, $path, $options);
+    }
+  
+    /**
      * List gift cards
      *
      * @param array $options Associative array of optional parameters
@@ -3440,6 +3469,49 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
     {
         $path = $this->interpolatePath("/gift_cards/{redemption_code}/redeem", ['redemption_code' => $redemption_code]);
         return $this->makeRequest('POST', $path, $body, $options);
+    }
+  
+    /**
+     * List a business entity's invoices
+     *
+     * @param string $business_entity_id Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-entity1`.
+     * @param array  $options            Associative array of optional parameters
+     *
+     * Supported optional query string parameters:
+     *
+     * - $options['params']['ids'] (array): Filter results by their IDs. Up to 200 IDs can be passed at once using
+     *        commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
+     *        
+     *        **Important notes:**
+     *        
+     *        * The `ids` parameter cannot be used with any other ordering or filtering
+     *          parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)
+     *        * Invalid or unknown IDs will be ignored, so you should check that the
+     *          results correspond to your request.
+     *        * Records are returned in an arbitrary order. Since results are all
+     *          returned at once you can sort the records yourself.
+     * - $options['params']['limit'] (int): Limit number of records 1-200.
+     * - $options['params']['order'] (string): Sort order.
+     * - $options['params']['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
+     *        order. In descending order updated records will move behind the cursor and could
+     *        prevent some records from being returned.
+     * - $options['params']['begin_time'] (string): Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+     *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
+     * - $options['params']['end_time'] (string): Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+     *        **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
+     * - $options['params']['type'] (string): Filter by type when:
+     *        - `type=charge`, only charge invoices will be returned.
+     *        - `type=credit`, only credit invoices will be returned.
+     *        - `type=non-legacy`, only charge and credit invoices will be returned.
+     *        - `type=legacy`, only legacy invoices will be returned.
+     *
+     * @return \Recurly\Pager A list of the business entity's invoices.
+     * @link   https://developers.recurly.com/api/v2021-02-25#operation/list_business_entity_invoices
+     */
+    public function listBusinessEntityInvoices(string $business_entity_id, array $options = []): \Recurly\Pager
+    {
+        $path = $this->interpolatePath("/business_entities/{business_entity_id}/invoices", ['business_entity_id' => $business_entity_id]);
+        return new \Recurly\Pager($this, $path, $options);
     }
   
 }

--- a/lib/recurly/resources/account.php
+++ b/lib/recurly/resources/account.php
@@ -37,6 +37,7 @@ class Account extends RecurlyResource
     private $_invoice_template_id;
     private $_last_name;
     private $_object;
+    private $_override_business_entity_id;
     private $_parent_account_id;
     private $_preferred_locale;
     private $_preferred_time_zone;
@@ -627,6 +628,29 @@ class Account extends RecurlyResource
     public function setObject(string $object): void
     {
         $this->_object = $object;
+    }
+
+    /**
+    * Getter method for the override_business_entity_id attribute.
+    * Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+    *
+    * @return ?string
+    */
+    public function getOverrideBusinessEntityId(): ?string
+    {
+        return $this->_override_business_entity_id;
+    }
+
+    /**
+    * Setter method for the override_business_entity_id attribute.
+    *
+    * @param string $override_business_entity_id
+    *
+    * @return void
+    */
+    public function setOverrideBusinessEntityId(string $override_business_entity_id): void
+    {
+        $this->_override_business_entity_id = $override_business_entity_id;
     }
 
     /**

--- a/lib/recurly/resources/business_entity.php
+++ b/lib/recurly/resources/business_entity.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+namespace Recurly\Resources;
+
+use Recurly\RecurlyResource;
+
+// phpcs:disable
+class BusinessEntity extends RecurlyResource
+{
+    private $_code;
+    private $_created_at;
+    private $_default_registration_number;
+    private $_default_vat_number;
+    private $_id;
+    private $_invoice_display_address;
+    private $_name;
+    private $_object;
+    private $_subscriber_location_countries;
+    private $_tax_address;
+    private $_updated_at;
+
+    protected static $array_hints = [
+        'setSubscriberLocationCountries' => 'string',
+    ];
+
+    
+    /**
+    * Getter method for the code attribute.
+    * The entity code of the business entity.
+    *
+    * @return ?string
+    */
+    public function getCode(): ?string
+    {
+        return $this->_code;
+    }
+
+    /**
+    * Setter method for the code attribute.
+    *
+    * @param string $code
+    *
+    * @return void
+    */
+    public function setCode(string $code): void
+    {
+        $this->_code = $code;
+    }
+
+    /**
+    * Getter method for the created_at attribute.
+    * Created at
+    *
+    * @return ?string
+    */
+    public function getCreatedAt(): ?string
+    {
+        return $this->_created_at;
+    }
+
+    /**
+    * Setter method for the created_at attribute.
+    *
+    * @param string $created_at
+    *
+    * @return void
+    */
+    public function setCreatedAt(string $created_at): void
+    {
+        $this->_created_at = $created_at;
+    }
+
+    /**
+    * Getter method for the default_registration_number attribute.
+    * Registration number for the customer used on the invoice.
+    *
+    * @return ?string
+    */
+    public function getDefaultRegistrationNumber(): ?string
+    {
+        return $this->_default_registration_number;
+    }
+
+    /**
+    * Setter method for the default_registration_number attribute.
+    *
+    * @param string $default_registration_number
+    *
+    * @return void
+    */
+    public function setDefaultRegistrationNumber(string $default_registration_number): void
+    {
+        $this->_default_registration_number = $default_registration_number;
+    }
+
+    /**
+    * Getter method for the default_vat_number attribute.
+    * VAT number for the customer used on the invoice.
+    *
+    * @return ?string
+    */
+    public function getDefaultVatNumber(): ?string
+    {
+        return $this->_default_vat_number;
+    }
+
+    /**
+    * Setter method for the default_vat_number attribute.
+    *
+    * @param string $default_vat_number
+    *
+    * @return void
+    */
+    public function setDefaultVatNumber(string $default_vat_number): void
+    {
+        $this->_default_vat_number = $default_vat_number;
+    }
+
+    /**
+    * Getter method for the id attribute.
+    * Business entity ID
+    *
+    * @return ?string
+    */
+    public function getId(): ?string
+    {
+        return $this->_id;
+    }
+
+    /**
+    * Setter method for the id attribute.
+    *
+    * @param string $id
+    *
+    * @return void
+    */
+    public function setId(string $id): void
+    {
+        $this->_id = $id;
+    }
+
+    /**
+    * Getter method for the invoice_display_address attribute.
+    * Address information for the business entity that will appear on the invoice.
+    *
+    * @return ?\Recurly\Resources\Address
+    */
+    public function getInvoiceDisplayAddress(): ?\Recurly\Resources\Address
+    {
+        return $this->_invoice_display_address;
+    }
+
+    /**
+    * Setter method for the invoice_display_address attribute.
+    *
+    * @param \Recurly\Resources\Address $invoice_display_address
+    *
+    * @return void
+    */
+    public function setInvoiceDisplayAddress(\Recurly\Resources\Address $invoice_display_address): void
+    {
+        $this->_invoice_display_address = $invoice_display_address;
+    }
+
+    /**
+    * Getter method for the name attribute.
+    * This name describes your business entity and will appear on the invoice.
+    *
+    * @return ?string
+    */
+    public function getName(): ?string
+    {
+        return $this->_name;
+    }
+
+    /**
+    * Setter method for the name attribute.
+    *
+    * @param string $name
+    *
+    * @return void
+    */
+    public function setName(string $name): void
+    {
+        $this->_name = $name;
+    }
+
+    /**
+    * Getter method for the object attribute.
+    * Object type
+    *
+    * @return ?string
+    */
+    public function getObject(): ?string
+    {
+        return $this->_object;
+    }
+
+    /**
+    * Setter method for the object attribute.
+    *
+    * @param string $object
+    *
+    * @return void
+    */
+    public function setObject(string $object): void
+    {
+        $this->_object = $object;
+    }
+
+    /**
+    * Getter method for the subscriber_location_countries attribute.
+    * List of countries for which the business entity will be used.
+    *
+    * @return array
+    */
+    public function getSubscriberLocationCountries(): array
+    {
+        return $this->_subscriber_location_countries ?? [] ;
+    }
+
+    /**
+    * Setter method for the subscriber_location_countries attribute.
+    *
+    * @param array $subscriber_location_countries
+    *
+    * @return void
+    */
+    public function setSubscriberLocationCountries(array $subscriber_location_countries): void
+    {
+        $this->_subscriber_location_countries = $subscriber_location_countries;
+    }
+
+    /**
+    * Getter method for the tax_address attribute.
+    * Address information for the business entity that will be used for calculating taxes.
+    *
+    * @return ?\Recurly\Resources\Address
+    */
+    public function getTaxAddress(): ?\Recurly\Resources\Address
+    {
+        return $this->_tax_address;
+    }
+
+    /**
+    * Setter method for the tax_address attribute.
+    *
+    * @param \Recurly\Resources\Address $tax_address
+    *
+    * @return void
+    */
+    public function setTaxAddress(\Recurly\Resources\Address $tax_address): void
+    {
+        $this->_tax_address = $tax_address;
+    }
+
+    /**
+    * Getter method for the updated_at attribute.
+    * Last updated at
+    *
+    * @return ?string
+    */
+    public function getUpdatedAt(): ?string
+    {
+        return $this->_updated_at;
+    }
+
+    /**
+    * Setter method for the updated_at attribute.
+    *
+    * @param string $updated_at
+    *
+    * @return void
+    */
+    public function setUpdatedAt(string $updated_at): void
+    {
+        $this->_updated_at = $updated_at;
+    }
+}

--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -16,6 +16,7 @@ class Invoice extends RecurlyResource
     private $_address;
     private $_balance;
     private $_billing_info_id;
+    private $_business_entity_id;
     private $_closed_at;
     private $_collection_method;
     private $_created_at;
@@ -152,6 +153,29 @@ class Invoice extends RecurlyResource
     public function setBillingInfoId(string $billing_info_id): void
     {
         $this->_billing_info_id = $billing_info_id;
+    }
+
+    /**
+    * Getter method for the business_entity_id attribute.
+    * Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
+    *
+    * @return ?string
+    */
+    public function getBusinessEntityId(): ?string
+    {
+        return $this->_business_entity_id;
+    }
+
+    /**
+    * Setter method for the business_entity_id attribute.
+    *
+    * @param string $business_entity_id
+    *
+    * @return void
+    */
+    public function setBusinessEntityId(string $business_entity_id): void
+    {
+        $this->_business_entity_id = $business_entity_id;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -228,6 +228,7 @@ x-tagGroups:
   - custom_field_definition
   - shipping_method
   - dunning_campaigns
+  - business_entities
 tags:
 - name: site
   x-displayName: Site
@@ -374,6 +375,10 @@ tags:
   description: An account from an external resource that is not managed by the Recurly
     platform and instead is managed by third-party platforms like Apple App Store
     and Google Play Store.
+- name: business_entities
+  x-displayName: Business Entities
+  description: Describes the business address that will be used for invoices and taxes
+    depending on settings and subscriber location.
 paths:
   "/sites":
     get:
@@ -15974,6 +15979,60 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}":
+    parameters:
+    - "$ref": "#/components/parameters/business_entity_id"
+    get:
+      tags:
+      - business_entities
+      operationId: get_business_entity
+      summary: Fetch a business entity
+      responses:
+        '200':
+          description: Business entity details
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntity"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/business_entities":
+    get:
+      tags:
+      - business_entities
+      operationId: list_business_entities
+      summary: List business entities
+      responses:
+        '200':
+          description: List of all business entities on your site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntityList"
+        '404':
+          description: Incorrect site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/gift_cards":
     get:
       tags:
@@ -16143,6 +16202,49 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}/invoices":
+    get:
+      tags:
+      - invoice
+      operationId: list_business_entity_invoices
+      summary: List a business entity's invoices
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/business_entity_id"
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/filter_begin_time"
+      - "$ref": "#/components/parameters/filter_end_time"
+      - "$ref": "#/components/parameters/filter_invoice_type"
+      responses:
+        '200':
+          description: A list of the business entity's invoices.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceList"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
 servers:
 - url: https://v3.recurly.com
 - url: https://v3.eu.recurly.com
@@ -16177,6 +16279,14 @@ components:
       in: path
       description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
         feature.
+      required: true
+      schema:
+        type: string
+    business_entity_id:
+      name: business_entity_id
+      in: path
+      description: Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`.
+        For code use prefix `code-`, e.g. `code-entity1`.
       required: true
       schema:
         type: string
@@ -17101,6 +17211,11 @@ components:
             merchant has an integration for the Vertex tax provider, this optional
             value will be sent in any tax calculation requests for the account.
           maxLength: 30
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         parent_account_code:
           type: string
           maxLength: 50
@@ -17169,6 +17284,11 @@ components:
             The customer will also use this email address to log into your hosted
             account management pages. This value does not need to be unique.
           maxLength: 255
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         preferred_locale:
           description: Used to determine the language and locale of emails sent on
             behalf of the merchant to the customer.
@@ -19358,6 +19478,11 @@ components:
           type: boolean
           title: Final Dunning Event
           description: Last communication attempt.
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
     InvoiceCreate:
       type: object
       properties:
@@ -23939,6 +24064,84 @@ components:
           type: string
           description: Username of the associated payment method. Currently only associated
             with Venmo.
+    BusinessEntityList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/BusinessEntity"
+    BusinessEntity:
+      type: object
+      description: Business entity details
+      properties:
+        id:
+          title: Business entity ID
+          type: string
+          maxLength: 13
+          readOnly: true
+        object:
+          title: Object type
+          type: string
+          readOnly: true
+        code:
+          title: Business entity code
+          type: string
+          maxLength: 50
+          description: The entity code of the business entity.
+        name:
+          type: string
+          title: Name
+          description: This name describes your business entity and will appear on
+            the invoice.
+          maxLength: 255
+        invoice_display_address:
+          title: Invoice display address
+          description: Address information for the business entity that will appear
+            on the invoice.
+          "$ref": "#/components/schemas/Address"
+        tax_address:
+          title: Tax address
+          description: Address information for the business entity that will be used
+            for calculating taxes.
+          "$ref": "#/components/schemas/Address"
+        default_vat_number:
+          type: string
+          title: Default VAT number
+          description: VAT number for the customer used on the invoice.
+          maxLength: 20
+        default_registration_number:
+          type: string
+          title: Default registration number
+          description: Registration number for the customer used on the invoice.
+          maxLength: 30
+        subscriber_location_countries:
+          type: array
+          title: Subscriber location countries
+          description: List of countries for which the business entity will be used.
+          items:
+            type: string
+            title: Country code
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
     GiftCardList:
       type: object
       properties:


### PR DESCRIPTION
Adds support for Multiple Business Entities:
  - Adds operations for Multiple Business Entities:
    - `getBusinessEntity`
    - `listBusinessEntities`
    - `listBusinessEntityInvoices`
  - Adds `override_business_entity_id` (`getOverrideBusinessEntityId`, `setOverrideBusinessEntityId`) to the `Account` resource and as params for the following requests:
    - `AccountCreate`
    - `AccountUpdate`
    - `AccountPurchase`
  - Adds `business_entity_id` (`getBusinessEntityId`, `setBusinessEntityId`) to the `Invoice` resource