### PR TITLE
Generated Latest Changes for v2021-02-25 (Ramp Dates, Net Terms, Invoice Business Entity)

### DIFF
--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -32,6 +32,7 @@ class Invoice extends RecurlyResource
     private $_id;
     private $_line_items;
     private $_net_terms;
+    private $_net_terms_type;
     private $_number;
     private $_object;
     private $_origin;
@@ -502,7 +503,19 @@ class Invoice extends RecurlyResource
 
     /**
     * Getter method for the net_terms attribute.
-    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    * Integer paired with `Net Terms Type` and representing the number
+of days past the current date (for `net` Net Terms Type) or days after
+the last day of the current month (for `eom` Net Terms Type) that the
+invoice will become past due. For any value, an additional 24 hours is
+added to ensure the customer has the entire last day to make payment before
+becoming past due.  For example:
+
+If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+If an invoice is due `net 30`, it will become past due at 31 days exactly.
+If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
     *
     * @return ?int
     */
@@ -521,6 +534,34 @@ class Invoice extends RecurlyResource
     public function setNetTerms(int $net_terms): void
     {
         $this->_net_terms = $net_terms;
+    }
+
+    /**
+    * Getter method for the net_terms_type attribute.
+    * Optionally supplied string that may be either `net` or `eom` (end-of-month).
+When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+
+This field is only available when the EOM Net Terms feature is enabled.
+
+    *
+    * @return ?string
+    */
+    public function getNetTermsType(): ?string
+    {
+        return $this->_net_terms_type;
+    }
+
+    /**
+    * Setter method for the net_terms_type attribute.
+    *
+    * @param string $net_terms_type
+    *
+    * @return void
+    */
+    public function setNetTermsType(string $net_terms_type): void
+    {
+        $this->_net_terms_type = $net_terms_type;
     }
 
     /**

--- a/lib/recurly/resources/invoice_mini.php
+++ b/lib/recurly/resources/invoice_mini.php
@@ -12,6 +12,7 @@ use Recurly\RecurlyResource;
 // phpcs:disable
 class InvoiceMini extends RecurlyResource
 {
+    private $_business_entity_id;
     private $_id;
     private $_number;
     private $_object;
@@ -22,6 +23,29 @@ class InvoiceMini extends RecurlyResource
     ];
 
     
+    /**
+    * Getter method for the business_entity_id attribute.
+    * Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
+    *
+    * @return ?string
+    */
+    public function getBusinessEntityId(): ?string
+    {
+        return $this->_business_entity_id;
+    }
+
+    /**
+    * Setter method for the business_entity_id attribute.
+    *
+    * @param string $business_entity_id
+    *
+    * @return void
+    */
+    public function setBusinessEntityId(string $business_entity_id): void
+    {
+        $this->_business_entity_id = $business_entity_id;
+    }
+
     /**
     * Getter method for the id attribute.
     * Invoice ID

--- a/lib/recurly/resources/subscription.php
+++ b/lib/recurly/resources/subscription.php
@@ -37,6 +37,7 @@ class Subscription extends RecurlyResource
     private $_gateway_code;
     private $_id;
     private $_net_terms;
+    private $_net_terms_type;
     private $_object;
     private $_paused_at;
     private $_pending_change;
@@ -626,7 +627,19 @@ class Subscription extends RecurlyResource
 
     /**
     * Getter method for the net_terms attribute.
-    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    * Integer paired with `Net Terms Type` and representing the number
+of days past the current date (for `net` Net Terms Type) or days after
+the last day of the current month (for `eom` Net Terms Type) that the
+invoice will become past due. For any value, an additional 24 hours is
+added to ensure the customer has the entire last day to make payment before
+becoming past due.  For example:
+
+If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+If an invoice is due `net 30`, it will become past due at 31 days exactly.
+If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
     *
     * @return ?int
     */
@@ -645,6 +658,34 @@ class Subscription extends RecurlyResource
     public function setNetTerms(int $net_terms): void
     {
         $this->_net_terms = $net_terms;
+    }
+
+    /**
+    * Getter method for the net_terms_type attribute.
+    * Optionally supplied string that may be either `net` or `eom` (end-of-month).
+When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+
+This field is only available when the EOM Net Terms feature is enabled.
+
+    *
+    * @return ?string
+    */
+    public function getNetTermsType(): ?string
+    {
+        return $this->_net_terms_type;
+    }
+
+    /**
+    * Setter method for the net_terms_type attribute.
+    *
+    * @param string $net_terms_type
+    *
+    * @return void
+    */
+    public function setNetTermsType(string $net_terms_type): void
+    {
+        $this->_net_terms_type = $net_terms_type;
     }
 
     /**

--- a/lib/recurly/resources/subscription_ramp_interval_response.php
+++ b/lib/recurly/resources/subscription_ramp_interval_response.php
@@ -12,14 +12,39 @@ use Recurly\RecurlyResource;
 // phpcs:disable
 class SubscriptionRampIntervalResponse extends RecurlyResource
 {
+    private $_ending_on;
     private $_remaining_billing_cycles;
     private $_starting_billing_cycle;
+    private $_starting_on;
     private $_unit_amount;
 
     protected static $array_hints = [
     ];
 
     
+    /**
+    * Getter method for the ending_on attribute.
+    * Date the ramp interval ends
+    *
+    * @return ?string
+    */
+    public function getEndingOn(): ?string
+    {
+        return $this->_ending_on;
+    }
+
+    /**
+    * Setter method for the ending_on attribute.
+    *
+    * @param string $ending_on
+    *
+    * @return void
+    */
+    public function setEndingOn(string $ending_on): void
+    {
+        $this->_ending_on = $ending_on;
+    }
+
     /**
     * Getter method for the remaining_billing_cycles attribute.
     * Represents how many billing cycles are left in a ramp interval.
@@ -64,6 +89,29 @@ class SubscriptionRampIntervalResponse extends RecurlyResource
     public function setStartingBillingCycle(int $starting_billing_cycle): void
     {
         $this->_starting_billing_cycle = $starting_billing_cycle;
+    }
+
+    /**
+    * Getter method for the starting_on attribute.
+    * Date the ramp interval starts
+    *
+    * @return ?string
+    */
+    public function getStartingOn(): ?string
+    {
+        return $this->_starting_on;
+    }
+
+    /**
+    * Setter method for the starting_on attribute.
+    *
+    * @param string $starting_on
+    *
+    * @return void
+    */
+    public function setStartingOn(string $starting_on): void
+    {
+        $this->_starting_on = $starting_on;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15202,7 +15202,7 @@ paths:
 
         Use for **Adyen HPP** and **Online Banking** transaction requests.
         This runs the validations but not the transactions.
-        The API request allows the inclusion of one of the following fields: **external_hpp_type** with `'adyen'` and **online_banking_payment_type** with `'ideal'` or `'sofort'` in the **billing_info** object.
+        The API request allows the inclusion of the following field: **external_hpp_type** with `'adyen'` in the **billing_info** object.
 
         For additional information regarding shipping fees, please see https://docs.recurly.com/docs/shipping
 
@@ -18291,6 +18291,7 @@ components:
           "$ref": "#/components/schemas/ExternalHppTypeEnum"
         online_banking_payment_type:
           "$ref": "#/components/schemas/OnlineBankingPaymentTypeEnum"
+          deprecated: true
         card_type:
           "$ref": "#/components/schemas/CardTypeEnum"
     BillingInfoVerify:
@@ -19332,13 +19333,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         address:
           "$ref": "#/components/schemas/InvoiceAddress"
         shipping_address:
@@ -19516,13 +19528,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
-          default: 0
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
+          default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         po_number:
           type: string
           title: Purchase order number
@@ -19629,6 +19652,11 @@ components:
         number:
           type: string
           title: Invoice number
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
         type:
           title: Invoice type
           "$ref": "#/components/schemas/InvoiceTypeEnum"
@@ -21600,13 +21628,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -22162,13 +22201,17 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer normally paired with `Net Terms Type` and representing the number of days past
+            the current date (for `net` Net Terms Type) or days after the last day of the current
+            month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription
+            change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22373,13 +22416,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22549,13 +22603,24 @@ components:
         net_terms:
           type: integer
           title: Terms that the subscription is due on
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         gateway_code:
           type: string
           title: Gateway Code
@@ -22694,6 +22759,14 @@ components:
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
+        starting_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval starts
+        ending_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval ends
         unit_amount:
           type: number
           format: float
@@ -23253,13 +23326,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -24798,6 +24882,19 @@ components:
       - at_range_start
       - evenly
       - never
+    NetTermsTypeEnum:
+      type: string
+      title: Net Terms Type
+      description: |
+        Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+
+        This field is only available when the EOM Net Terms feature is enabled.
+      enum:
+      - net
+      - eom
+      default: net
     InvoiceTypeEnum:
       type: string
       enum:


### PR DESCRIPTION
- Adds `NetTermsType` to the `Subscription`, `SubscriptionChange`, `Purchase`, and `Invoice` resources
- Adds `BusinessEntityId` to the `InvoiceMini` resource
- Adds `StartingOn` and `EndingOn` to `SubscriptionRampIntervalResponse` resources