### PR TITLE
Add RevRec POBs support

### DIFF
--- a/Tests/Recurly/PerformanceObligation_List_Test.php
+++ b/Tests/Recurly/PerformanceObligation_List_Test.php
@@ -1,0 +1,20 @@
+<?php
+
+class Recurly_PerformanceObligationListTest extends Recurly_TestCase
+{
+  public function testPerformanceObligationListAll() {
+    $this->client->addResponse(
+      'GET',
+      '/performance_obligations',
+      'performance_obligations/list-200.xml'
+    );
+
+    $performance_obligations = Recurly_PerformanceObligationList::get(null, $this->client);
+    $this->assertInstanceOf('Recurly_PerformanceObligationList', $performance_obligations);
+
+    $performance_obligation = $performance_obligations->current();
+    $this->assertInstanceOf('Recurly_PerformanceObligation', $performance_obligation);
+
+    $this->assertEquals(iterator_count($performance_obligations), 3);
+  }
+}

--- a/Tests/Recurly/PerformanceObligation_Test.php
+++ b/Tests/Recurly/PerformanceObligation_Test.php
@@ -1,0 +1,20 @@
+<?php
+
+class Recurly_PerformanceObligationTest extends Recurly_TestCase
+{
+  function defaultResponses() {
+    return array(
+      array('GET', '/performance_obligations/6', 'performance_obligations/show-200.xml'),
+    );
+  }
+
+  public function testPerformanceObligation() {
+    $pob = Recurly_PerformanceObligation::get('6', $this->client);
+
+    $this->assertInstanceOf('Recurly_PerformanceObligation', $pob);
+    $this->assertEquals('Over Time (Daily)', $pob->name);
+    $this->assertEquals('6', $pob->id);
+    $this->assertInstanceOf('DateTime', $pob->created_at);
+    $this->assertInstanceOf('DateTime', $pob->updated_at);
+  }
+}

--- a/Tests/fixtures/performance_obligations/list-200.xml
+++ b/Tests/fixtures/performance_obligations/list-200.xml
@@ -1,0 +1,24 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<performance_obligations type="array">
+  <performance_obligation href="https://api.recurly.com/v2/performance_obligations/6">
+    <id>6</id>
+    <name>Over Time (Daily)</name>
+    <created_at type="datetime">2023-08-11T18:57:57Z</created_at>
+    <updated_at type="datetime">2023-08-11T18:57:57Z</updated_at>
+  </performance_obligation>
+  <performance_obligation href="https://api.recurly.com/v2/performance_obligations/5">
+    <id>5</id>
+    <name>Over Time (Partial Monthly)</name>
+    <created_at type="datetime">2023-08-11T18:57:57Z</created_at>
+    <updated_at type="datetime">2023-08-11T18:57:57Z</updated_at>
+  </performance_obligation>
+  <performance_obligation href="https://api.recurly.com/v2/performance_obligations/4">
+    <id>4</id>
+    <name>Point in Time</name>
+    <created_at type="datetime">2023-08-11T18:57:57Z</created_at>
+    <updated_at type="datetime">2023-08-11T18:57:57Z</updated_at>
+  </performance_obligation>
+</performance_obligations>

--- a/Tests/fixtures/performance_obligations/show-200.xml
+++ b/Tests/fixtures/performance_obligations/show-200.xml
@@ -1,0 +1,10 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<performance_obligation href="https://api.recurly.com/v2/performance_obligations/6">
+  <id>6</id>
+  <name>Over Time (Daily)</name>
+  <created_at type="datetime">2023-08-11T18:57:57Z</created_at>
+  <updated_at type="datetime">2023-08-11T18:57:57Z</updated_at>
+</performance_obligation>

--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -77,6 +77,8 @@ require_once(__DIR__ . '/recurly/measured_unit_list.php');
 require_once(__DIR__ . '/recurly/note.php');
 require_once(__DIR__ . '/recurly/note_list.php');
 require_once(__DIR__ . '/recurly/percentage_tier.php');
+require_once(__DIR__ . '/recurly/performance_obligation.php');
+require_once(__DIR__ . '/recurly/performance_obligation_list.php');
 require_once(__DIR__ . '/recurly/plan.php');
 require_once(__DIR__ . '/recurly/plan_list.php');
 require_once(__DIR__ . '/recurly/ramp_interval.php');

--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -94,6 +94,7 @@ class Recurly_Client
   const PATH_EXTERNAL_ACCOUNTS = 'external_accounts';
   const PATH_BUSINESS_ENTITIES = 'business_entities';
   const PATH_GENERAL_LEDGER_ACCOUNTS = 'general_ledger_accounts';
+  const PATH_PERFORMANCE_OBLIGATIONS = 'performance_obligations';
 
   /**
    * Create a new Recurly Client

--- a/lib/recurly/performance_obligation.php
+++ b/lib/recurly/performance_obligation.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Class Recurly PerformanceObligation
+ * @property string $id
+ * @property string $name The name of the POB.
+ * @property DateTime $created_at The date and time the gla was created in Recurly.
+ * @property DateTime $updated_at The date and time the gla was last updated.
+ */
+
+class Recurly_PerformanceObligation extends Recurly_Resource
+{
+  /**
+   * @param string $id
+   * @param Recurly_Client $client
+   * @return Recurly_PerformanceObligation
+   * @throws Recurly_Error
+   */
+  public static function get($id, $client = null) {
+      return Recurly_Base::_get(Recurly_PerformanceObligation::uriForPerformanceObligation($id), $client);
+  }
+
+  protected static function uriForPerformanceObligation($id) {
+    return self::_safeUri(Recurly_Client::PATH_PERFORMANCE_OBLIGATIONS, $id);
+  }
+
+  protected function getNodeName() {
+    return 'performance_obligation';
+  }
+
+  protected function getWriteableAttributes() {
+    return array();
+  }
+}

--- a/lib/recurly/performance_obligation_list.php
+++ b/lib/recurly/performance_obligation_list.php
@@ -1,0 +1,13 @@
+<?php
+
+class Recurly_PerformanceObligationList extends Recurly_Pager
+{
+  public static function get($params = null, $client = null) {
+    $uri = self::_uriWithParams(Recurly_Client::PATH_PERFORMANCE_OBLIGATIONS, $params);
+    return new self($uri, $client);
+  }
+
+  protected function getNodeName() {
+    return 'performance_obligations';
+  }
+}

--- a/lib/recurly/util/xml_tools.php
+++ b/lib/recurly/util/xml_tools.php
@@ -93,6 +93,8 @@ class XmlTools
     'measured_units' => 'Recurly_MeasuredUnitList',
     'note' => 'Recurly_Note',
     'notes' => 'Recurly_NoteList',
+    'performance_obligation' => 'Recurly_PerformanceObligation',
+    'performance_obligations' => 'Recurly_PerformanceObligationList',
     'plan' => 'Recurly_Plan',
     'plans' => 'Recurly_PlanList',
     'plan_code' => 'string',


### PR DESCRIPTION
This change creates the PerformanceObligation entity for the V2 client, part of the new (and upcoming) RevRec API features.