### PR TITLE
Add net_terms_type to Invoices, Purchases, and Subscriptions

### DIFF
--- a/Tests/Recurly/Invoice_Test.php
+++ b/Tests/Recurly/Invoice_Test.php
@@ -219,4 +219,22 @@ class Recurly_InvoiceTest extends Recurly_TestCase
       $this->assertEquals(sizeof($line_item->custom_fields), 1);
     }
   }
+
+  public function testInvoiceWithEomNetTerms() {
+    $this->client->addResponse('POST', '/accounts/abcdef1234567890/invoices', 'invoices/create-201-with-eom-net-terms.xml');
+
+    $invoice = Recurly_Invoice::invoicePendingCharges('abcdef1234567890', array("net_terms" => 60), $this->client);
+
+    $this->assertInstanceOf('Recurly_Invoice', $invoice);
+    $this->assertInstanceOf('Recurly_Stub', $invoice->account);
+    $this->assertEquals($invoice->uuid, '012345678901234567890123456789ab');
+    $this->assertEquals($invoice->currency, 'USD');
+    $this->assertEquals($invoice->total_in_cents, 300);
+    $this->assertEquals($invoice->getHref(),'https://api.recurly.com/v2/invoices/012345678901234567890123456789ab');
+    $this->assertEquals($invoice->terms_and_conditions, 'Some Terms and Conditions');
+    $this->assertEquals($invoice->customer_notes, 'Some Customer Notes');
+    $this->assertEquals($invoice->vat_reverse_charge_notes, 'Some VAT Notes');
+    $this->assertEquals($invoice->net_terms, 60);
+    $this->assertEquals($invoice->net_terms_type, 'eom');
+  }
 }

--- a/Tests/Recurly/Purchase_Test.php
+++ b/Tests/Recurly/Purchase_Test.php
@@ -169,9 +169,21 @@ class Recurly_PurchaseTest extends Recurly_TestCase
 
   public function testPurchaseIncludesTransactionActionResultResponse(){
     $this->client->addResponse('POST', '/purchases', 'purchases/create-with-action-result-201.xml');
-    
+
     $purchase = new Recurly_Purchase(null, $this->client);
     $collection = Recurly_Purchase::invoice($purchase, $this->client);
     $this->assertEquals('example', $collection->charge_invoice->transactions->current()->action_result);
+  }
+
+  public function testPurchaseWithEomNetTerms(){
+    $this->client->addResponse('POST', '/purchases', 'purchases/create-201-with-eom-net-terms.xml');
+
+    $purchase = $this->mockPurchase();
+    $purchase->net_terms = 30;
+    $purchase->net_terms_type = "eom";
+    $collection = Recurly_Purchase::invoice($purchase, $this->client);
+
+    $this->assertInstanceOf('Recurly_InvoiceCollection', $collection);
+    $this->assertInstanceOf('Recurly_Invoice', $collection->charge_invoice);
   }
 }

--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -630,7 +630,7 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
   }
 
   public function testPreviewNewSubscriptionWithActionResult(){
-  
+
     $this->client->addResponse('POST', '/subscriptions/preview', 'subscriptions/preview-200-new-with-action-result.xml');
     $subscription = new Recurly_Subscription(null, $this->client);
 
@@ -640,5 +640,37 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $subscription->account->billing_info->token_id = 'abc123';
     $subscription->preview();
     $this->assertEquals('example', $subscription->action_result);
+  }
+
+  public function testSubscriptionWithEomNetTerms() {
+    $subscription = new Recurly_Subscription();
+    $subscription->plan_code = 'gold';
+    $subscription->currency = 'USD';
+    $subscription->net_terms = 10;
+    $subscription->net_terms_type = 'eom';
+    $subscription->collection_method = 'automatic';
+    $subscription->po_number = '1000';
+    $subscription->imported_trial = true;
+
+    $account = new Recurly_Account();
+    $account->account_code = '123';
+
+    $subscription->account = $account;
+
+    $this->assertXmlStringEqualsXmlString(
+      "<subscription>
+        <account>
+          <account_code>123</account_code>
+        </account>
+        <plan_code>gold</plan_code>
+        <currency>USD</currency>
+        <subscription_add_ons></subscription_add_ons>
+        <net_terms>10</net_terms>
+        <net_terms_type>eom</net_terms_type>
+        <po_number>1000</po_number>
+        <collection_method>automatic</collection_method>
+        <imported_trial>true</imported_trial>
+      </subscription>", $subscription->xml());
+
   }
 }

--- a/Tests/fixtures/invoices/create-201-with-eom-net-terms.xml
+++ b/Tests/fixtures/invoices/create-201-with-eom-net-terms.xml
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/created-invoice
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="https://api.recurly.com/v2/invoices/012345678901234567890123456789ab">
+  <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
+  <uuid>012345678901234567890123456789ab</uuid>
+  <state>pending</state>
+  <invoice_number type="integer">1000</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
+  <currency>USD</currency>
+  <net_terms>60</net_terms>
+  <net_terms_type>eom</net_terms_type>
+  <total_in_cents type="integer">300</total_in_cents>
+  <subtotal_in_cents type="integer">300</subtotal_in_cents>
+  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <customer_notes>Some Customer Notes</customer_notes>
+  <vat_reverse_charge_notes>Some VAT Notes</vat_reverse_charge_notes>
+</invoice>

--- a/Tests/fixtures/purchases/create-201-with-eom-net-terms.xml
+++ b/Tests/fixtures/purchases/create-201-with-eom-net-terms.xml
@@ -1,0 +1,144 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/3704
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_collection>
+  <charge_invoice href="https://api.recurly.com/v2/invoices/3704">
+    <account href="https://api.recurly.com/v2/accounts/6b97ec05-7e9d-4506-a4b6-5459acbd6403"/>
+    <address>
+      <address1>400 Alabama St</address1>
+      <address2 nil="nil"></address2>
+      <city>San Francisco</city>
+      <state>CA</state>
+      <zip>94110</zip>
+      <country>US</country>
+      <phone nil="nil"></phone>
+    </address>
+    <uuid>3d8648fcf2be67ed304ff242d6bbb9d4</uuid>
+    <state>paid</state>
+    <invoice_number_prefix></invoice_number_prefix>
+    <invoice_number type="integer">3704</invoice_number>
+    <po_number nil="nil"></po_number>
+    <vat_number nil="nil"></vat_number>
+    <subtotal_in_cents type="integer">1000</subtotal_in_cents>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <total_in_cents type="integer">1000</total_in_cents>
+    <subtotal_after_discount_in_cents type="integer">1000</subtotal_after_discount_in_cents>
+    <currency>USD</currency>
+    <created_at type="datetime">2017-05-17T17:38:55Z</created_at>
+    <updated_at type="datetime">2017-05-17T17:38:55Z</updated_at>
+    <attempt_next_collection_at nil="nil"></attempt_next_collection_at>
+    <closed_at type="datetime">2017-05-17T17:38:55Z</closed_at>
+    <terms_and_conditions nil="nil"></terms_and_conditions>
+    <customer_notes nil="nil"></customer_notes>
+    <recovery_reason nil="nil"></recovery_reason>
+    <net_terms type="integer">30</net_terms>
+    <net_terms_type type="string">eom</net_terms_type>
+    <collection_method>automatic</collection_method>
+    <line_items type="array">
+      <adjustment href="https://api.recurly.com/v2/adjustments/3d8648fced80685b7f165a43fca65cda" type="charge">
+        <account href="https://api.recurly.com/v2/accounts/6b97ec05-7e9d-4506-a4b6-5459acbd6403"/>
+        <invoice href="https://api.recurly.com/v2/invoices/3704"/>
+        <uuid>3d8648fced80685b7f165a43fca65cda</uuid>
+        <state>invoiced</state>
+        <description nil="nil"></description>
+        <accounting_code nil="nil"></accounting_code>
+        <product_code>4549449c-5870-4845-b672-1d07f15e87dd</product_code>
+        <origin>debit</origin>
+        <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <discount_in_cents type="integer">0</discount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <total_in_cents type="integer">1000</total_in_cents>
+        <currency>USD</currency>
+        <taxable type="boolean">false</taxable>
+        <tax_exempt type="boolean">false</tax_exempt>
+        <tax_code nil="nil"></tax_code>
+        <start_date type="datetime">2017-05-17T17:38:55Z</start_date>
+        <end_date nil="nil"></end_date>
+        <created_at type="datetime">2017-05-17T17:38:55Z</created_at>
+        <updated_at type="datetime">2017-05-17T17:38:55Z</updated_at>
+        <revenue_schedule_type>at_invoice</revenue_schedule_type>
+        <shipping_address>
+          <first_name>Dolores</first_name>
+          <last_name>Du Monde</last_name>
+          <address1>400 Dolores St</address1>
+          <address2 nil="nil"></address2>
+          <city>San Francisco</city>
+          <state>CA</state>
+          <zip>94110</zip>
+          <country>US</country>
+          <nickname>Home</nickname>
+        </shipping_address>
+        <custom_fields type="array">
+          <custom_field>
+            <name>size</name>
+            <value>small</value>
+          </custom_field>
+        </custom_fields>
+      </adjustment>
+    </line_items>
+    <transactions type="array">
+      <transaction href="https://api.recurly.com/v2/transactions/3d8648fd0cc7c6e9196b944878afcd3d" type="credit_card">
+        <account href="https://api.recurly.com/v2/accounts/6b97ec05-7e9d-4506-a4b6-5459acbd6403"/>
+        <invoice href="https://api.recurly.com/v2/invoices/3704"/>
+        <uuid>3d8648fd0cc7c6e9196b944878afcd3d</uuid>
+        <action>purchase</action>
+        <amount_in_cents type="integer">1000</amount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <currency>USD</currency>
+        <status>success</status>
+        <payment_method>credit_card</payment_method>
+        <reference>135998</reference>
+        <source>transaction</source>
+        <recurring type="boolean">false</recurring>
+        <test type="boolean">true</test>
+        <voidable type="boolean">true</voidable>
+        <refundable type="boolean">true</refundable>
+        <ip_address nil="nil"></ip_address>
+        <gateway_type>test</gateway_type>
+        <origin>api</origin>
+        <description nil="nil"></description>
+        <message>Successful test transaction</message>
+        <approval_code nil="nil"></approval_code>
+        <failure_type nil="nil"></failure_type>
+        <gateway_error_codes nil="nil"></gateway_error_codes>
+        <cvv_result code="" nil="nil"></cvv_result>
+        <avs_result code="D">Street address and postal code match.</avs_result>
+        <avs_result_street nil="nil"></avs_result_street>
+        <avs_result_postal nil="nil"></avs_result_postal>
+        <created_at type="datetime">2017-05-17T17:38:55Z</created_at>
+        <collected_at type="datetime">2017-05-17T17:38:55Z</collected_at>
+        <updated_at type="datetime">2017-05-17T17:38:55Z</updated_at>
+        <details>
+          <account>
+            <account_code>6b97ec05-7e9d-4506-a4b6-5459acbd6403</account_code>
+            <first_name nil="nil"></first_name>
+            <last_name nil="nil"></last_name>
+            <company nil="nil"></company>
+            <email nil="nil"></email>
+            <billing_info type="credit_card">
+              <first_name>Benjamin</first_name>
+              <last_name>Du Monde</last_name>
+              <address1>400 Alabama St</address1>
+              <address2 nil="nil"></address2>
+              <city>San Francisco</city>
+              <state>CA</state>
+              <zip>94110</zip>
+              <country>US</country>
+              <phone nil="nil"></phone>
+              <vat_number nil="nil"></vat_number>
+              <card_type>Visa</card_type>
+              <year type="integer">2019</year>
+              <month type="integer">12</month>
+              <first_six>411111</first_six>
+              <last_four>1111</last_four>
+            </billing_info>
+          </account>
+        </details>
+      </transaction>
+    </transactions>
+    <a name="refund" href="https://api.recurly.com/v2/invoices/3704/refund" method="post"/>
+  </charge_invoice>
+</invoice_collection>

--- a/lib/recurly/invoice.php
+++ b/lib/recurly/invoice.php
@@ -36,7 +36,8 @@
  * @property string $tax_type
  * @property string $tax_region
  * @property float $tax_rate
- * @property int $net_terms
+ * @property int $net_terms The net terms of the invoice.
+ * @property string $net_terms_type The net terms type of the invoice. accepted_values: "net", "eom".
  * @property string $collection_method
  * @property Recurly_Stub $redemptions
  * @property Recurly_Adjustment[] $line_items
@@ -246,7 +247,7 @@ class Recurly_Invoice extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'address', 'billing_info', 'billing_info_uuid', 'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
-      'collection_method', 'net_terms', 'po_number', 'currency', 'credit_customer_notes',
+      'collection_method', 'net_terms', 'net_terms_type', 'po_number', 'currency', 'credit_customer_notes',
       'gateway_code'
     );
   }

--- a/lib/recurly/purchase.php
+++ b/lib/recurly/purchase.php
@@ -8,6 +8,7 @@
  * @property string $currency The currency to use in this invoice.
  * @property string $po_number The po number for the invoice.
  * @property integer $net_terms The net terms of the invoice.
+ * @property string $net_terms_type The net terms type of the invoice. accepted_values: "net", "eom".
  * @property string[] $coupon_codes An array of coupon codes to apply to the purchase.
  * @property Recurly_Subscription[] $subscriptions An array of subscriptions to apply to the purchase.
  * @property Recurly_GiftCard $gift_card A gift card to apply to the purchase.
@@ -117,7 +118,7 @@ class Recurly_Purchase extends Recurly_Resource
   protected function getWriteableAttributes() {
     return array(
       'account', 'adjustments', 'billing_info_uuid', 'collection_method', 'currency', 'po_number',
-      'net_terms', 'subscriptions', 'gift_card', 'coupon_codes', 'customer_notes',
+      'net_terms', 'net_terms_type', 'subscriptions', 'gift_card', 'coupon_codes', 'customer_notes',
       'terms_and_conditions', 'vat_reverse_charge_notes', 'shipping_address', 'shipping_address_id',
       'gateway_code', 'shipping_fees', 'transaction_type'
     );

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -22,6 +22,7 @@
  * @property float $tax_rate Tax rate that will be applied to this subscription
  * @property string $collection_method Optional field to set the collection for an invoice as automatic or manual. The default is automatic if it's not set.
  * @property integer $net_terms Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to 0, it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly. Defaults to 0.
+ * @property string $net_terms_type The net terms type of the invoice. accepted_values: "net", "eom".
  * @property string $po_number Optional notes field. Attach a PO number to the invoice.
  * @property boolean $bulk Optional field to be used only when needing to bypass the 60 second limit on creating subscriptions. Should only be used when creating subscriptions in bulk from the API. Set to 'true' or 'false'. Defaults to 'false'.
  * @property string $terms_and_conditions Optional notes field. This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes with this tag to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.
@@ -332,7 +333,7 @@ class Recurly_Subscription extends Recurly_Resource
       'account', 'billing_info', 'plan_code', 'coupon_code', 'coupon_codes',
       'unit_amount_in_cents', 'quantity', 'billing_info_uuid', 'currency', 'starts_at',
       'trial_ends_at', 'total_billing_cycles', 'first_renewal_date',
-      'timeframe', 'subscription_add_ons', 'net_terms', 'po_number',
+      'timeframe', 'subscription_add_ons', 'net_terms', 'net_terms_type', 'po_number',
       'collection_method', 'cost_in_cents', 'remaining_billing_cycles', 'bulk',
       'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
       'bank_account_authorized_at', 'revenue_schedule_type', 'gift_card',


### PR DESCRIPTION
Add net_terms_type for purchases, invoices, and subscriptions to support both net and eom

Playground PR: https://github.com/recurly/v2-playground/pull/199