### PR TITLE
Added support for `proration_settings` for updating subscriptions

### DIFF
--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -444,6 +444,44 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
     $this->assertEquals('gold', $subscription->plan_code);
   }
 
+  public function testUpdateSubscriptionWithProrationSettings() {
+    $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200.xml');
+    $subscription = Recurly_Subscription::get('012345678901234567890123456789ab', $this->client);
+
+    $subscription->unit_amount_in_cents = 0;
+    $subscription->subscription_add_ons[0]->unit_amount_in_cents = 100;
+
+    $subscription->proration_settings = new Recurly_ProrationSettings();
+    $subscription->proration_settings->charge = 'prorated_amount';
+    $subscription->proration_settings->credit = 'prorated_amount';
+
+    $this->assertXmlStringEqualsXmlString("
+    <subscription>
+      <unit_amount_in_cents>0</unit_amount_in_cents>
+      <subscription_add_ons>
+        <subscription_add_on>
+          <add_on_code>marketing_emails</add_on_code>
+          <unit_amount_in_cents>100</unit_amount_in_cents>
+          <quantity>1</quantity>
+        </subscription_add_on>
+        <subscription_add_on>
+          <item>&lt;Recurly_Stub[item] href=https://api.recurlyqa.com/v2/items/mockitem&gt;</item>
+          <external_sku>tester-sku</external_sku>
+          <add_on_code>mockitem</add_on_code>
+          <unit_amount_in_cents>199</unit_amount_in_cents>
+          <quantity>1</quantity>
+          <revenue_schedule_type>never</revenue_schedule_type>
+          <tier_type>flat</tier_type>
+          <add_on_source>item</add_on_source>
+        </subscription_add_on>
+      </subscription_add_ons>
+      <proration_settings>
+        <charge>prorated_amount</charge>
+        <credit>prorated_amount</credit>
+      </proration_settings>
+    </subscription>", $subscription->xml());
+  }
+
   public function testUpdateNotes() {
     $this->client->addResponse('GET', '/subscriptions/012345678901234567890123456789ab', 'subscriptions/show-200.xml');
     $this->client->addResponse('PUT', 'https://api.recurly.com/v2/subscriptions/012345678901234567890123456789ab/notes', 'subscriptions/show-200-changed-notes.xml');

--- a/lib/recurly.php
+++ b/lib/recurly.php
@@ -83,6 +83,7 @@ require_once(__DIR__ . '/recurly/plan.php');
 require_once(__DIR__ . '/recurly/plan_list.php');
 require_once(__DIR__ . '/recurly/ramp_interval.php');
 require_once(__DIR__ . '/recurly/plan_ramp_interval.php');
+require_once(__DIR__ . '/recurly/proration_settings.php');
 require_once(__DIR__ . '/recurly/purchase.php');
 require_once(__DIR__ . '/recurly/redemption.php');
 require_once(__DIR__ . '/recurly/redemption_list.php');

--- a/lib/recurly/proration_settings.php
+++ b/lib/recurly/proration_settings.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Class Recurly_ProrationSettings
+ * @property string $charge Determines how the amount charged is determined for the subscription change
+ * @property string $credit Determines how the amount credited is determined for the subscription change
+ */
+class Recurly_ProrationSettings extends Recurly_Resource
+{
+  protected function getNodeName() {
+    return 'proration_settings';
+  }
+
+  protected function getWriteableAttributes() {
+    return array(
+      'charge',
+      'credit'
+    );
+  }
+}

--- a/lib/recurly/subscription.php
+++ b/lib/recurly/subscription.php
@@ -48,6 +48,7 @@
  * @property-read DateTime $activated_at Date the subscription was activated
  * @property-read DateTime $updated_at Date the subscription was last updated
  * @property Recurly_CustomFieldList $custom_fields Optional custom fields for the subscription.
+ * @property Recurly_ProrationSettings $proration_settings Optional proration settings for the subscription update. Determines how any resulting charge/credit invoices are applied during an update.
  * @property string $uuid Subscription's unique identifier.
  * @property string $timeframe now for immediate, renewal to perform when the subscription renews. This must be one of 'now', 'bill_date', or 'term_end'. Defaults to 'now'
  * @property string $gateway_code The unique identifier of a payment gateway used to specify which payment gateway you wish to process this subscriptions’ payments
@@ -338,7 +339,7 @@ class Recurly_Subscription extends Recurly_Resource
       'terms_and_conditions', 'customer_notes', 'vat_reverse_charge_notes',
       'bank_account_authorized_at', 'revenue_schedule_type', 'gift_card',
       'shipping_address', 'shipping_address_id', 'imported_trial',
-      'remaining_pause_cycles', 'custom_fields', 'auto_renew',
+      'remaining_pause_cycles', 'custom_fields', 'proration_settings', 'auto_renew',
       'renewal_billing_cycles', 'gateway_code', 'shipping_method_code',
       'shipping_amount_in_cents', 'transaction_type', 'tax_inclusive',
       'ramp_intervals', 'action_result'

--- a/lib/recurly/util/xml_tools.php
+++ b/lib/recurly/util/xml_tools.php
@@ -103,6 +103,7 @@ class XmlTools
     'ramp_intervals' => 'array',
     'pending_subscription' => 'Recurly_Subscription',
     'processing_prepayment_balance_in_cents' => 'Recurly_CurrencyList',
+    'proration_settings' => 'Recurly_ProrationSettings',
     'redemption' => 'Recurly_CouponRedemption',
     'redemptions' => 'Recurly_CouponRedemptionList',
     'setup_fee_in_cents' => 'Recurly_CurrencyList',


### PR DESCRIPTION
This adds support for sending `<proration_settings>` when updating a `Recurly_Subscription`, via the property `Recurly_ProrationSettings`.