### PR TITLE
SubscriptionAddon: fix call to undefined method Recurly_SubscriptionAddOn::__valuesString()

### DIFF
--- a/Tests/Recurly/SubscriptionAddOn_Test.php
+++ b/Tests/Recurly/SubscriptionAddOn_Test.php
@@ -1,0 +1,10 @@
+<?php
+
+class Recurly_SubscriptionAddOn_Test extends Recurly_TestCase
+{
+    public function testToString() {
+        $addon = new \Recurly_SubscriptionAddOn();
+
+        $this->assertSame('<Recurly_SubscriptionAddOn >', $addon->__toString());
+    }
+}

--- a/Tests/Recurly/SubscriptionAddOn_Test.php
+++ b/Tests/Recurly/SubscriptionAddOn_Test.php
@@ -5,6 +5,6 @@ class Recurly_SubscriptionAddOn_Test extends Recurly_TestCase
     public function testToString() {
         $addon = new \Recurly_SubscriptionAddOn();
 
-        $this->assertSame('<Recurly_SubscriptionAddOn >', $addon->__toString());
+        $this->assertSame('<Recurly_SubscriptionAddOn[new] >', $addon->__toString());
     }
 }

--- a/lib/recurly/subscription_addon.php
+++ b/lib/recurly/subscription_addon.php
@@ -49,13 +49,4 @@ class Recurly_SubscriptionAddOn extends Recurly_Resource
     );
     return array_diff_key($this->_values, $immutable);
   }
-
-  /**
-   * Pretty string version of the object
-   */
-  public function __toString() {
-    $class = get_class($this);
-    $values = $this->__valuesString();
-    return "<$class $values>";
-  }
 }


### PR DESCRIPTION
Fixes `Uncaught PHP Exception Error: "Call to undefined method Recurly_SubscriptionAddOn::__valuesString()" at subscription_addon.php line 58`