### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -518,6 +518,7 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
+     * - $options['state'] (string): Invoice state.
      * - $options['limit'] (int): Limit number of records 1-200.
      * - $options['order'] (string): Sort order.
      * - $options['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
@@ -1394,6 +1395,7 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
+     * - $options['state'] (string): Invoice state.
      * - $options['limit'] (int): Limit number of records 1-200.
      * - $options['order'] (string): Sort order.
      * - $options['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending
@@ -2352,6 +2354,7 @@ class Client extends BaseClient
      *          results correspond to your request.
      *        * Records are returned in an arbitrary order. Since results are all
      *          returned at once you can sort the records yourself.
+     * - $options['state'] (string): Invoice state.
      * - $options['limit'] (int): Limit number of records 1-200.
      * - $options['order'] (string): Sort order.
      * - $options['sort'] (string): Sort field. You *really* only want to sort by `updated_at` in ascending

--- a/lib/recurly/resources/account.php
+++ b/lib/recurly/resources/account.php
@@ -23,6 +23,7 @@ class Account extends RecurlyResource
     private $_deleted_at;
     private $_dunning_campaign_id;
     private $_email;
+    private $_entity_use_code;
     private $_exemption_certificate;
     private $_first_name;
     private $_has_active_subscription;
@@ -302,6 +303,29 @@ class Account extends RecurlyResource
     public function setEmail(string $email): void
     {
         $this->_email = $email;
+    }
+
+    /**
+    * Getter method for the entity_use_code attribute.
+    * The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
+    *
+    * @return ?string
+    */
+    public function getEntityUseCode(): ?string
+    {
+        return $this->_entity_use_code;
+    }
+
+    /**
+    * Setter method for the entity_use_code attribute.
+    *
+    * @param string $entity_use_code
+    *
+    * @return void
+    */
+    public function setEntityUseCode(string $entity_use_code): void
+    {
+        $this->_entity_use_code = $entity_use_code;
     }
 
     /**

--- a/lib/recurly/resources/address.php
+++ b/lib/recurly/resources/address.php
@@ -15,6 +15,7 @@ class Address extends RecurlyResource
     private $_city;
     private $_country;
     private $_first_name;
+    private $_geo_code;
     private $_last_name;
     private $_phone;
     private $_postal_code;
@@ -93,6 +94,29 @@ class Address extends RecurlyResource
     public function setFirstName(string $first_name): void
     {
         $this->_first_name = $first_name;
+    }
+
+    /**
+    * Getter method for the geo_code attribute.
+    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    *
+    * @return ?string
+    */
+    public function getGeoCode(): ?string
+    {
+        return $this->_geo_code;
+    }
+
+    /**
+    * Setter method for the geo_code attribute.
+    *
+    * @param string $geo_code
+    *
+    * @return void
+    */
+    public function setGeoCode(string $geo_code): void
+    {
+        $this->_geo_code = $geo_code;
     }
 
     /**

--- a/lib/recurly/resources/gateway_attributes.php
+++ b/lib/recurly/resources/gateway_attributes.php
@@ -20,7 +20,7 @@ class GatewayAttributes extends RecurlyResource
     
     /**
     * Getter method for the account_reference attribute.
-    * Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+    * Used by Adyen and Braintree gateways. For Adyen the Shopper Reference value used when the external token was created. For Braintree the PayPal PayerID is populated in the response.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/invoice_address.php
+++ b/lib/recurly/resources/invoice_address.php
@@ -16,6 +16,7 @@ class InvoiceAddress extends RecurlyResource
     private $_company;
     private $_country;
     private $_first_name;
+    private $_geo_code;
     private $_last_name;
     private $_name_on_account;
     private $_phone;
@@ -118,6 +119,29 @@ class InvoiceAddress extends RecurlyResource
     public function setFirstName(string $first_name): void
     {
         $this->_first_name = $first_name;
+    }
+
+    /**
+    * Getter method for the geo_code attribute.
+    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    *
+    * @return ?string
+    */
+    public function getGeoCode(): ?string
+    {
+        return $this->_geo_code;
+    }
+
+    /**
+    * Setter method for the geo_code attribute.
+    *
+    * @param string $geo_code
+    *
+    * @return void
+    */
+    public function setGeoCode(string $geo_code): void
+    {
+        $this->_geo_code = $geo_code;
     }
 
     /**

--- a/lib/recurly/resources/payment_method.php
+++ b/lib/recurly/resources/payment_method.php
@@ -14,6 +14,7 @@ class PaymentMethod extends RecurlyResource
 {
     private $_account_type;
     private $_billing_agreement_id;
+    private $_card_network_preference;
     private $_card_type;
     private $_cc_bin_country;
     private $_exp_month;
@@ -77,6 +78,29 @@ class PaymentMethod extends RecurlyResource
     public function setBillingAgreementId(string $billing_agreement_id): void
     {
         $this->_billing_agreement_id = $billing_agreement_id;
+    }
+
+    /**
+    * Getter method for the card_network_preference attribute.
+    * Represents the card network preference associated with the billing info for dual badged cards. Must be a supported card network.
+    *
+    * @return ?string
+    */
+    public function getCardNetworkPreference(): ?string
+    {
+        return $this->_card_network_preference;
+    }
+
+    /**
+    * Setter method for the card_network_preference attribute.
+    *
+    * @param string $card_network_preference
+    *
+    * @return void
+    */
+    public function setCardNetworkPreference(string $card_network_preference): void
+    {
+        $this->_card_network_preference = $card_network_preference;
     }
 
     /**

--- a/lib/recurly/resources/shipping_address.php
+++ b/lib/recurly/resources/shipping_address.php
@@ -19,6 +19,7 @@ class ShippingAddress extends RecurlyResource
     private $_created_at;
     private $_email;
     private $_first_name;
+    private $_geo_code;
     private $_id;
     private $_last_name;
     private $_nickname;
@@ -194,6 +195,29 @@ class ShippingAddress extends RecurlyResource
     public function setFirstName(string $first_name): void
     {
         $this->_first_name = $first_name;
+    }
+
+    /**
+    * Getter method for the geo_code attribute.
+    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    *
+    * @return ?string
+    */
+    public function getGeoCode(): ?string
+    {
+        return $this->_geo_code;
+    }
+
+    /**
+    * Setter method for the geo_code attribute.
+    *
+    * @param string $geo_code
+    *
+    * @return void
+    */
+    public function setGeoCode(string $geo_code): void
+    {
+        $this->_geo_code = $geo_code;
     }
 
     /**

--- a/lib/recurly/resources/subscription_ramp_interval_response.php
+++ b/lib/recurly/resources/subscription_ramp_interval_response.php
@@ -12,14 +12,39 @@ use Recurly\RecurlyResource;
 // phpcs:disable
 class SubscriptionRampIntervalResponse extends RecurlyResource
 {
+    private $_ending_on;
     private $_remaining_billing_cycles;
     private $_starting_billing_cycle;
+    private $_starting_on;
     private $_unit_amount;
 
     protected static $array_hints = [
     ];
 
     
+    /**
+    * Getter method for the ending_on attribute.
+    * Date the ramp interval ends
+    *
+    * @return ?string
+    */
+    public function getEndingOn(): ?string
+    {
+        return $this->_ending_on;
+    }
+
+    /**
+    * Setter method for the ending_on attribute.
+    *
+    * @param string $ending_on
+    *
+    * @return void
+    */
+    public function setEndingOn(string $ending_on): void
+    {
+        $this->_ending_on = $ending_on;
+    }
+
     /**
     * Getter method for the remaining_billing_cycles attribute.
     * Represents how many billing cycles are left in a ramp interval.
@@ -64,6 +89,29 @@ class SubscriptionRampIntervalResponse extends RecurlyResource
     public function setStartingBillingCycle(int $starting_billing_cycle): void
     {
         $this->_starting_billing_cycle = $starting_billing_cycle;
+    }
+
+    /**
+    * Getter method for the starting_on attribute.
+    * Date the ramp interval starts
+    *
+    * @return ?string
+    */
+    public function getStartingOn(): ?string
+    {
+        return $this->_starting_on;
+    }
+
+    /**
+    * Setter method for the starting_on attribute.
+    *
+    * @param string $starting_on
+    *
+    * @return void
+    */
+    public function setStartingOn(string $starting_on): void
+    {
+        $this->_starting_on = $starting_on;
     }
 
     /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -885,7 +885,7 @@ paths:
           Alabama St.\"),\n\t\t\tCity:       recurly.String(\"San Francisco\"),\n\t\t\tPostalCode:
           recurly.String(\"94110\"),\n\t\t\tCountry:    recurly.String(\"US\"),\n\t\t\tRegion:
           \    recurly.String(\"CA\"),\n\t\t},\n\t\tNumber: recurly.String(\"4111111111111111\"),\n\t\tMonth:
-          \ recurly.String(\"12\"),\n\t\tYear:   recurly.String(\"22\"),\n\t\tCvv:
+          \ recurly.String(\"12\"),\n\t\tYear:   recurly.String(\"30\"),\n\t\tCvv:
           \   recurly.String(\"123\"),\n\t},\n}\n\naccount, err := client.CreateAccount(accountReq)\nif
           e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
@@ -3195,6 +3195,7 @@ paths:
       - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/account_id"
       - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/invoice_state"
       - "$ref": "#/components/parameters/limit"
       - "$ref": "#/components/parameters/order"
       - "$ref": "#/components/parameters/sort_dates"
@@ -7394,6 +7395,7 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/invoice_state"
       - "$ref": "#/components/parameters/limit"
       - "$ref": "#/components/parameters/order"
       - "$ref": "#/components/parameters/sort_dates"
@@ -7888,8 +7890,6 @@ paths:
       summary: Apply available credit to a pending or past due charge invoice
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
-        Credit that was refunded from the invoice cannot be applied back to the invoice
-        as payment.
       parameters:
       - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
@@ -13059,6 +13059,7 @@ paths:
       - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/subscription_id"
       - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/invoice_state"
       - "$ref": "#/components/parameters/limit"
       - "$ref": "#/components/parameters/order"
       - "$ref": "#/components/parameters/sort_dates"
@@ -14724,6 +14725,18 @@ components:
       required: true
       schema:
         type: string
+    invoice_state:
+      name: state
+      in: query
+      description: Invoice state.
+      schema:
+        type: string
+        default: all
+        enum:
+        - pending
+        - past_due
+        - paid
+        - failed
     measured_unit_id:
       name: measured_unit_id
       in: path
@@ -15662,6 +15675,11 @@ components:
           "$ref": "#/components/schemas/BillingInfoCreate"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        entity_use_code:
+          type: string
+          description: The Avalara AvaTax value that can be passed to identify the
+            customer type for tax purposes. The range of values can be A - R (more
+            info at Avalara). Value is case-sensitive.
     AccountResponse:
       type: object
       properties:
@@ -15781,6 +15799,11 @@ components:
           "$ref": "#/components/schemas/BillingInfo"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        entity_use_code:
+          type: string
+          description: The Avalara AvaTax value that can be passed to identify the
+            customer type for tax purposes. The range of values can be A - R (more
+            info at Avalara). Value is case-sensitive.
     AccountNote:
       type: object
       required:
@@ -15932,6 +15955,11 @@ components:
           type: string
           title: Country
           description: Country, 2-letter ISO 3166-1 alpha-2 code.
+        geo_code:
+          type: string
+          maxLength: 20
+          description: Code that represents a geographic entity (location or object).
+            Only returned for Sling Vertex Integration
     AddOnMini:
       type: object
       title: Add-on mini details
@@ -16652,16 +16680,30 @@ components:
           properties:
             account_reference:
               type: string
-              description: Used by Adyen gateways. The Shopper Reference value used
-                when the external token was created. Must be used in conjunction with
-                gateway_token and gateway_code.
+              description: Used by Adyen and Braintree gateways. For Adyen The Shopper
+                Reference value used when the external token was created. Must be
+                used in conjunction with gateway_token and gateway_code. For Braintree
+                the PayPal PayerID is populated in the response.
               maxLength: 264
+        card_network_preference:
+          type: string
+          description: Represents the card network preference associated with the
+            billing info for dual badged cards. Must be a supported card network.
+          enum:
+          - Bancontact
+          - CartesBancaires
+          - Dankort
+          - MasterCard
+          - Visa
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
         paypal_billing_agreement_id:
           type: string
           title: PayPal billing agreement ID
+        roku_billing_agreement_id:
+          type: string
+          title: Roku's CIB if billing through Roku
         fraud_session_id:
           type: string
           title: Fraud Session ID
@@ -19734,6 +19776,11 @@ components:
           type: string
           maxLength: 50
           description: Country, 2-letter ISO 3166-1 alpha-2 code.
+        geo_code:
+          type: string
+          maxLength: 20
+          description: Code that represents a geographic entity (location or object).
+            Only returned for Sling Vertex Integration
         created_at:
           type: string
           title: Created at
@@ -19789,6 +19836,11 @@ components:
           type: string
           maxLength: 50
           description: Country, 2-letter ISO 3166-1 alpha-2 code.
+        geo_code:
+          type: string
+          maxLength: 20
+          description: Code that represents a geographic entity (location or object).
+            Only returned for Sling Vertex Integration
       required:
       - first_name
       - last_name
@@ -20039,6 +20091,11 @@ components:
           type: string
           maxLength: 50
           description: Country, 2-letter ISO 3166-1 alpha-2 code.
+        geo_code:
+          type: string
+          maxLength: 20
+          description: Code that represents a geographic entity (location or object).
+            Only returned for Sling Vertex Integration
     Site:
       type: object
       properties:
@@ -21334,6 +21391,14 @@ components:
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
+        starting_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval starts
+        ending_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval ends
         unit_amount:
           type: integer
           description: Represents the price for the ramp interval.
@@ -22275,9 +22340,20 @@ components:
           properties:
             account_reference:
               type: string
-              description: Used by Adyen gateways. The Shopper Reference value used
-                when the external token was created.
+              description: Used by Adyen and Braintree gateways. For Adyen the Shopper
+                Reference value used when the external token was created. For Braintree
+                the PayPal PayerID is populated in the response.
               maxLength: 264
+        card_network_preference:
+          type: string
+          description: Represents the card network preference associated with the
+            billing info for dual badged cards. Must be a supported card network.
+          enum:
+          - Bancontact
+          - CartesBancaires
+          - Dankort
+          - MasterCard
+          - Visa
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal


### PR DESCRIPTION
- Adds `getGeoCode`, `setGeoCode` to `Address`, `InvoiceAddress`, `ShippingAddress`
- Adds `getCardNetworkPreference`,  `setCardNetworkPreference` to `BillingInfo`
- Adds `getRokuBillingAgreementId`, `setRokuBillingAgreementId` to `BillingInfo`
- Adds `getCardNetworkPreference`, `setCardNetworkPreference` to `PaymentMethod`
- Adds `getStartingOn`, `setStartingOn`  to `SubscriptionRampIntervalResponse`
- Adds `getEndingOn`, `setEndingOn` to `SubscriptionRampIntervalResponse`
- Adds `getEntityUseCode`, `setEntityUseCode` to `Account`, `AccountPurchase`