### PR TITLE
PHP8: Avoids a warning about the undefined variable in the case file_get_contents fails

### DIFF
--- a/lib/recurly/http_adapter.php
+++ b/lib/recurly/http_adapter.php
@@ -52,6 +52,6 @@ class HttpAdapter
                 }
             }
         }
-        return [$result, $http_response_header];
+        return [$result, $http_response_header ?? null];
     }
 }


### PR DESCRIPTION
`E_WARNING: Undefined variable $http_response_header` is reported when `file_get_contents` fails to fetch the specified `$url`. This seems to happen because HTTP Wrapper doesn't set `$http_response_header` when it fails. 

Since PHP 8 accesses to undefined variables are reported as E_WARNING, this became more visible and noisier.

This PR avoids the warning by using a coalescing operator.

