### PR TITLE
Generated Latest Changes for v2021-02-25 (add UUID to external subscriptions)

### DIFF
--- a/lib/recurly/client.php
+++ b/lib/recurly/client.php
@@ -1883,7 +1883,7 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
     /**
      * Fetch an external subscription
      *
-     * @param string $external_subscription_id External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+     * @param string $external_subscription_id External subscription ID, external_id or uuid. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
      * @param array  $options                  Associative array of optional parameters
      *
      * @return \Recurly\Resources\ExternalSubscription Settings for an external subscription.

--- a/lib/recurly/resources/external_subscription.php
+++ b/lib/recurly/resources/external_subscription.php
@@ -33,6 +33,7 @@ class ExternalSubscription extends RecurlyResource
     private $_trial_ends_at;
     private $_trial_started_at;
     private $_updated_at;
+    private $_uuid;
 
     protected static $array_hints = [
         'setExternalPaymentPhases' => '\Recurly\Resources\ExternalPaymentPhase',
@@ -520,5 +521,28 @@ class ExternalSubscription extends RecurlyResource
     public function setUpdatedAt(string $updated_at): void
     {
         $this->_updated_at = $updated_at;
+    }
+
+    /**
+    * Getter method for the uuid attribute.
+    * Universally Unique Identifier created automatically.
+    *
+    * @return ?string
+    */
+    public function getUuid(): ?string
+    {
+        return $this->_uuid;
+    }
+
+    /**
+    * Setter method for the uuid attribute.
+    *
+    * @param string $uuid
+    *
+    * @return void
+    */
+    public function setUuid(string $uuid): void
+    {
+        $this->_uuid = $uuid;
     }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16743,8 +16743,9 @@ components:
     external_subscription_id_fetch:
       name: external_subscription_id
       in: path
-      description: External subscription ID or external_id. For ID no prefix is used
-        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      description: External subscription ID, external_id or uuid. For ID no prefix
+        is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g.
+        `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
       required: true
       schema:
         type: string
@@ -25100,6 +25101,10 @@ components:
           title: External Id
           description: The id of the subscription in the external systems., I.e. Apple
             App Store or Google Play Store.
+        uuid:
+          type: string
+          title: Uuid
+          description: Universally Unique Identifier created automatically.
         last_purchased:
           type: string
           format: date-time


### PR DESCRIPTION
We are giving the ability to fetch external subscriptions by uuid v3 v2021-02-25

Get `/external_subscriptions/uuid-<uuid_code>` replace <uuid_code> for specific uuid value