### PR TITLE
Correct implicit null parameter types which are deprecated in PHP 8.4

### DIFF
--- a/lib/recurly/base_client.php
+++ b/lib/recurly/base_client.php
@@ -25,13 +25,14 @@ abstract class BaseClient
     /**
      * Constructor
      *
-     * @param string $api_key The API key to use when making requests
-     * @param string $options initialize options
+     * @param string           $api_key The API key to use when making requests
+     * @param ?LoggerInterface $logger Logger
+     * @param string $options  initialize options
      *
      * In addition to the options managed by BaseClient, it accepts the following options:
      *  - "region" to define the Data Center connection - defaults to "us";
      */
-    public function __construct(string $api_key, LoggerInterface $logger = null, array $options = [])
+    public function __construct(string $api_key, ?LoggerInterface $logger = null, array $options = [])
     {
         $this->_api_key = $api_key;
         if (isset($options['region'])) {

--- a/lib/recurly/recurly_error.php
+++ b/lib/recurly/recurly_error.php
@@ -11,11 +11,11 @@ class RecurlyError extends \Error
 
     /**
      * Constructor
-     * 
-     * @param string                                     $message   The error message from the API response
-     * @param \Recurly\Resources\ErrorMayHaveTransaction $api_error The error from the API response
+     *
+     * @param string                                      $message   The error message from the API response
+     * @param ?\Recurly\Resources\ErrorMayHaveTransaction $api_error The error from the API response
      */
-    public function __construct(string $message, \Recurly\Resources\ErrorMayHaveTransaction $api_error = null)
+    public function __construct(string $message, ?\Recurly\Resources\ErrorMayHaveTransaction $api_error = null)
     {
         parent::__construct($message);
         $this->_api_error = $api_error;

--- a/lib/recurly/recurly_resource.php
+++ b/lib/recurly/recurly_resource.php
@@ -72,14 +72,14 @@ abstract class RecurlyResource
 
     /**
      * Converts a Recurly response object into a \Recurly\RecurlyResource.
-     * 
-     * @param \Recurly\Response $response The Recurly HTTP Response
-     * @param object            $json     (optional) JSON payload to use instead of
+     *
+     * @param \Recurly\Response  $response The Recurly HTTP Response
+     * @param ?object            $json     (optional) JSON payload to use instead of
      *                                    the $response's. Primarily used for errors
-     * 
+     *
      * @return \Recurly\RecurlyResource An instance of a Recurly Resource
      */
-    public static function fromResponse(\Recurly\Response $response, object $json = null): \Recurly\RecurlyResource
+    public static function fromResponse(\Recurly\Response $response, ?object $json = null): \Recurly\RecurlyResource
     {
         $json = is_null($json) ? $response->getJsonResponse() : $json;
         $klass_name = static::resourceClass($json->object);


### PR DESCRIPTION
Correct implicit null parameter types which are deprecated in PHP 8.4 and generate E_DEPRECATED errors