### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -39,6 +39,7 @@ class Invoice extends RecurlyResource
     private $_paid;
     private $_po_number;
     private $_previous_invoice_id;
+    private $_reference_only_currency_conversion;
     private $_refundable_amount;
     private $_shipping_address;
     private $_state;
@@ -701,6 +702,29 @@ When `eom` an invoice becomes past due the specified number of `Net Terms` days 
     public function setPreviousInvoiceId(string $previous_invoice_id): void
     {
         $this->_previous_invoice_id = $previous_invoice_id;
+    }
+
+    /**
+    * Getter method for the reference_only_currency_conversion attribute.
+    * Reference Only Currency Conversion
+    *
+    * @return ?\Recurly\Resources\ReferenceOnlyCurrencyConversion
+    */
+    public function getReferenceOnlyCurrencyConversion(): ?\Recurly\Resources\ReferenceOnlyCurrencyConversion
+    {
+        return $this->_reference_only_currency_conversion;
+    }
+
+    /**
+    * Setter method for the reference_only_currency_conversion attribute.
+    *
+    * @param \Recurly\Resources\ReferenceOnlyCurrencyConversion $reference_only_currency_conversion
+    *
+    * @return void
+    */
+    public function setReferenceOnlyCurrencyConversion(\Recurly\Resources\ReferenceOnlyCurrencyConversion $reference_only_currency_conversion): void
+    {
+        $this->_reference_only_currency_conversion = $reference_only_currency_conversion;
     }
 
     /**

--- a/lib/recurly/resources/reference_only_currency_conversion.php
+++ b/lib/recurly/resources/reference_only_currency_conversion.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+namespace Recurly\Resources;
+
+use Recurly\RecurlyResource;
+
+// phpcs:disable
+class ReferenceOnlyCurrencyConversion extends RecurlyResource
+{
+    private $_currency;
+    private $_subtotal_in_cents;
+    private $_tax_in_cents;
+
+    protected static $array_hints = [
+    ];
+
+    
+    /**
+    * Getter method for the currency attribute.
+    * 3-letter ISO 4217 currency code.
+    *
+    * @return ?string
+    */
+    public function getCurrency(): ?string
+    {
+        return $this->_currency;
+    }
+
+    /**
+    * Setter method for the currency attribute.
+    *
+    * @param string $currency
+    *
+    * @return void
+    */
+    public function setCurrency(string $currency): void
+    {
+        $this->_currency = $currency;
+    }
+
+    /**
+    * Getter method for the subtotal_in_cents attribute.
+    * The subtotal converted to the currency.
+    *
+    * @return ?float
+    */
+    public function getSubtotalInCents(): ?float
+    {
+        return $this->_subtotal_in_cents;
+    }
+
+    /**
+    * Setter method for the subtotal_in_cents attribute.
+    *
+    * @param float $subtotal_in_cents
+    *
+    * @return void
+    */
+    public function setSubtotalInCents(float $subtotal_in_cents): void
+    {
+        $this->_subtotal_in_cents = $subtotal_in_cents;
+    }
+
+    /**
+    * Getter method for the tax_in_cents attribute.
+    * The tax converted to the currency.
+    *
+    * @return ?float
+    */
+    public function getTaxInCents(): ?float
+    {
+        return $this->_tax_in_cents;
+    }
+
+    /**
+    * Setter method for the tax_in_cents attribute.
+    *
+    * @param float $tax_in_cents
+    *
+    * @return void
+    */
+    public function setTaxInCents(float $tax_in_cents): void
+    {
+        $this->_tax_in_cents = $tax_in_cents;
+    }
+}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -20276,6 +20276,8 @@ components:
           format: float
           title: Tax
           description: The total tax on this invoice.
+        reference_only_currency_conversion:
+          "$ref": "#/components/schemas/ReferenceOnlyCurrencyConversion"
         total:
           type: number
           format: float
@@ -22289,6 +22291,25 @@ components:
           title: Updated at
           format: date-time
           readOnly: true
+    ReferenceOnlyCurrencyConversion:
+      type: object
+      title: Reference Only Currency Conversion
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        subtotal_in_cents:
+          type: number
+          format: float
+          title: Subtotal In Cents
+          description: The subtotal converted to the currency.
+        tax_in_cents:
+          type: number
+          format: float
+          title: Tax In Cents
+          description: The tax converted to the currency.
     ShippingAddressCreate:
       type: object
       properties:


### PR DESCRIPTION
This PR adds `reference_only_currency_conversion` values to Invoice responses.

```json
  "reference_only_currency_conversion": {
    "currency": "str",
    "subtotal_in_cents": 0,
    "tax_in_cents": 0
  },
  ```