### PR TITLE
fix: do not serialize recurly_stub objects in body payload

### DIFF
--- a/Tests/Recurly/Subscription_Test.php
+++ b/Tests/Recurly/Subscription_Test.php
@@ -283,7 +283,6 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
           <quantity>1</quantity>
         </subscription_add_on>
         <subscription_add_on>
-          <item>&lt;Recurly_Stub[item] href=https://api.recurlyqa.com/v2/items/mockitem&gt;</item>
           <external_sku>tester-sku</external_sku>
           <add_on_code>mockitem</add_on_code>
           <unit_amount_in_cents>199</unit_amount_in_cents>
@@ -465,7 +464,6 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
           <quantity>1</quantity>
         </subscription_add_on>
         <subscription_add_on>
-          <item>&lt;Recurly_Stub[item] href=https://api.recurlyqa.com/v2/items/mockitem&gt;</item>
           <external_sku>tester-sku</external_sku>
           <add_on_code>mockitem</add_on_code>
           <unit_amount_in_cents>199</unit_amount_in_cents>
@@ -518,7 +516,6 @@ class Recurly_SubscriptionTest extends Recurly_TestCase
           <quantity>1</quantity>
         </subscription_add_on>
         <subscription_add_on>
-          <item>&lt;Recurly_Stub[item] href=https://api.recurlyqa.com/v2/items/mockitem&gt;</item>
           <external_sku>tester-sku</external_sku>
           <add_on_code>mockitem</add_on_code>
           <unit_amount_in_cents>199</unit_amount_in_cents>

--- a/lib/recurly/traits/xml_doc.php
+++ b/lib/recurly/traits/xml_doc.php
@@ -178,6 +178,8 @@ trait XmlDoc {
       // doesn't extend Recurly_Resource we should add an interface for this.
       if ($val instanceof Recurly_CurrencyList || $val instanceof Recurly_CustomFieldList) {
         $val->populateXmlDoc($doc, $node);
+      } else if ($val instanceof Recurly_Stub) {
+        continue;
       } else if ($val instanceof Recurly_Resource) {
         $attribute_node = $node->appendChild($doc->createElement($key));
         $this->populateXmlDoc($doc, $attribute_node, $val, true);


### PR DESCRIPTION
Including the string representation of the fetched stub object is not proper to send to the API as it is an improper value for that tag.