### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly/resources/address.php
+++ b/lib/recurly/resources/address.php
@@ -73,7 +73,7 @@ class Address extends RecurlyResource
 
     /**
     * Getter method for the geo_code attribute.
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/address_with_name.php
+++ b/lib/recurly/resources/address_with_name.php
@@ -98,7 +98,7 @@ class AddressWithName extends RecurlyResource
 
     /**
     * Getter method for the geo_code attribute.
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/coupon.php
+++ b/lib/recurly/resources/coupon.php
@@ -587,7 +587,7 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
 
     /**
     * Getter method for the temporal_amount attribute.
-    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
     *
     * @return ?int
     */
@@ -610,7 +610,7 @@ property and one of the following properties: `percent`, `fixed`, `trial`.
 
     /**
     * Getter method for the temporal_unit attribute.
-    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/custom_field.php
+++ b/lib/recurly/resources/custom_field.php
@@ -13,6 +13,8 @@ use Recurly\RecurlyResource;
 class CustomField extends RecurlyResource
 {
     private $_name;
+    private $_source_record_id;
+    private $_source_record_type;
     private $_value;
 
     protected static $array_hints = [
@@ -40,6 +42,52 @@ class CustomField extends RecurlyResource
     public function setName(string $name): void
     {
         $this->_name = $name;
+    }
+
+    /**
+    * Getter method for the source_record_id attribute.
+    * The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+    *
+    * @return ?string
+    */
+    public function getSourceRecordId(): ?string
+    {
+        return $this->_source_record_id;
+    }
+
+    /**
+    * Setter method for the source_record_id attribute.
+    *
+    * @param string $source_record_id
+    *
+    * @return void
+    */
+    public function setSourceRecordId(string $source_record_id): void
+    {
+        $this->_source_record_id = $source_record_id;
+    }
+
+    /**
+    * Getter method for the source_record_type attribute.
+    * The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
+    *
+    * @return ?string
+    */
+    public function getSourceRecordType(): ?string
+    {
+        return $this->_source_record_type;
+    }
+
+    /**
+    * Setter method for the source_record_type attribute.
+    *
+    * @param string $source_record_type
+    *
+    * @return void
+    */
+    public function setSourceRecordType(string $source_record_type): void
+    {
+        $this->_source_record_type = $source_record_type;
     }
 
     /**

--- a/lib/recurly/resources/invoice.php
+++ b/lib/recurly/resources/invoice.php
@@ -22,6 +22,7 @@ class Invoice extends RecurlyResource
     private $_created_at;
     private $_credit_payments;
     private $_currency;
+    private $_custom_fields;
     private $_customer_notes;
     private $_discount;
     private $_due_at;
@@ -60,6 +61,7 @@ class Invoice extends RecurlyResource
 
     protected static $array_hints = [
         'setCreditPayments' => '\Recurly\Resources\CreditPayment',
+        'setCustomFields' => '\Recurly\Resources\CustomField',
         'setLineItems' => '\Recurly\Resources\LineItem',
         'setSubscriptionIds' => 'string',
         'setTransactions' => '\Recurly\Resources\Transaction',
@@ -294,6 +296,29 @@ class Invoice extends RecurlyResource
     public function setCurrency(string $currency): void
     {
         $this->_currency = $currency;
+    }
+
+    /**
+    * Getter method for the custom_fields attribute.
+    * A list of custom fields that were on the account at the time of invoice creation and were marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
+    *
+    * @return array
+    */
+    public function getCustomFields(): array
+    {
+        return $this->_custom_fields ?? [] ;
+    }
+
+    /**
+    * Setter method for the custom_fields attribute.
+    *
+    * @param array $custom_fields
+    *
+    * @return void
+    */
+    public function setCustomFields(array $custom_fields): void
+    {
+        $this->_custom_fields = $custom_fields;
     }
 
     /**

--- a/lib/recurly/resources/invoice_address.php
+++ b/lib/recurly/resources/invoice_address.php
@@ -123,7 +123,7 @@ class InvoiceAddress extends RecurlyResource
 
     /**
     * Getter method for the geo_code attribute.
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     *
     * @return ?string
     */

--- a/lib/recurly/resources/shipping_address.php
+++ b/lib/recurly/resources/shipping_address.php
@@ -199,7 +199,7 @@ class ShippingAddress extends RecurlyResource
 
     /**
     * Getter method for the geo_code attribute.
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     *
     * @return ?string
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -200,14 +200,12 @@ x-tagGroups:
   - usage
   - automated_exports
   - gift_cards
-- name: App Management
+- name: Invoices and Payments
   tags:
-  - external_subscriptions
-  - external_invoices
-  - external_products
-  - external_accounts
-  - external_product_references
-  - external_payment_phases
+  - invoice
+  - line_item
+  - credit_payment
+  - transaction
 - name: Products and Promotions
   tags:
   - item
@@ -218,12 +216,6 @@ x-tagGroups:
   - coupon_redemption
   - unique_coupon_code
   - price_segment
-- name: Invoices and Payments
-  tags:
-  - invoice
-  - line_item
-  - credit_payment
-  - transaction
 - name: Configuration
   tags:
   - site
@@ -233,6 +225,14 @@ x-tagGroups:
   - business_entities
   - general_ledger_account
   - performance_obligations
+- name: App Management
+  tags:
+  - external_subscriptions
+  - external_invoices
+  - external_products
+  - external_accounts
+  - external_product_references
+  - external_payment_phases
 tags:
 - name: site
   x-displayName: Site
@@ -9245,7 +9245,6 @@ paths:
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
       parameters:
-      - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
       responses:
         '200':
@@ -18621,7 +18620,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     AddressWithName:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19642,12 +19641,14 @@ components:
           title: Temporal amount
           description: If `duration` is "temporal" than `temporal_amount` is an integer
             which is multiplied by `temporal_unit` to define the duration that the
-            coupon will be applied to invoices for.
+            coupon will be applied to invoices for. When `temporal_unit` is "billing_period",
+            this is the number of complete billing cycles.
         temporal_unit:
           title: Temporal unit
           description: If `duration` is "temporal" than `temporal_unit` is multiplied
             by `temporal_amount` to define the duration that the coupon will be applied
-            to invoices for.
+            to invoices for. Use "billing_period" to apply the coupon for a fixed
+            number of billing cycles. Requires `redemption_resource=subscription`.
           "$ref": "#/components/schemas/TemporalUnitEnum"
         free_trial_unit:
           title: Free trial unit
@@ -19833,12 +19834,14 @@ components:
             title: Temporal amount
             description: If `duration` is "temporal" than `temporal_amount` is an
               integer which is multiplied by `temporal_unit` to define the duration
-              that the coupon will be applied to invoices for.
+              that the coupon will be applied to invoices for. When `temporal_unit`
+              is "billing_period", this is the number of complete billing cycles.
           temporal_unit:
             title: Temporal unit
             description: If `duration` is "temporal" than `temporal_unit` is multiplied
               by `temporal_amount` to define the duration that the coupon will be
-              applied to invoices for.
+              applied to invoices for. Use "billing_period" to apply the coupon for
+              a fixed number of billing cycles. Requires `redemption_resource=subscription`.
             "$ref": "#/components/schemas/TemporalUnitEnum"
           coupon_type:
             title: Coupon type
@@ -20195,6 +20198,19 @@ components:
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
           maxLength: 255
+        source_record_type:
+          type: string
+          title: Source record type
+          description: The type of record this custom field was automatically copied
+            from. Only present when the field was copied from another record.
+          readOnly: true
+          "$ref": "#/components/schemas/SourceRecordTypeEnum"
+        source_record_id:
+          type: string
+          title: Source record ID
+          description: The UUID of the record this custom field was automatically
+            copied from. Only present when the field was copied from another record.
+          readOnly: true
       required:
       - name
       - value
@@ -20204,6 +20220,15 @@ components:
       description: The custom fields will only be altered when they are included in
         a request. Sending an empty array will not remove any existing values. To
         remove a field send the name with a null or empty value.
+      items:
+        "$ref": "#/components/schemas/CustomField"
+    InvoiceCustomFields:
+      type: array
+      title: Custom fields
+      description: A list of custom fields that were on the account at the time of
+        invoice creation and were marked to be displayed on invoices. Read-only; cannot
+        be set directly on the invoice.
+      readOnly: true
       items:
         "$ref": "#/components/schemas/CustomField"
     CustomFieldDefinition:
@@ -21084,6 +21109,8 @@ components:
           title: Business Entity ID
           description: Unique ID to identify the business entity assigned to the invoice.
             Available when the `Multiple Business Entities` feature is enabled.
+        custom_fields:
+          "$ref": "#/components/schemas/InvoiceCustomFields"
     InvoiceCreate:
       type: object
       properties:
@@ -22735,7 +22762,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         created_at:
           type: string
           title: Created at
@@ -22823,7 +22850,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         country:
           type: string
           maxLength: 50
@@ -23154,7 +23181,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     Site:
       type: object
       properties:
@@ -27196,11 +27223,16 @@ components:
       - temporal
     TemporalUnitEnum:
       type: string
+      description: The temporal unit for the coupon's duration. Used with temporal_amount
+        to define how long the coupon applies. When temporal_unit is billing_period,
+        the coupon applies for temporal_amount complete billing cycles rather than
+        a fixed calendar duration. billing_period requires redemption_resource=subscription.
       enum:
       - day
       - month
       - week
       - year
+      - billing_period
     FreeTrialUnitEnum:
       type: string
       enum:
@@ -28104,3 +28136,11 @@ components:
       enum:
       - customer
       - merchant
+    SourceRecordTypeEnum:
+      type: string
+      description: The type of record a custom field was automatically copied from.
+      enum:
+      - account
+      - plan
+      - product
+      - subscription


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `CustomField` now exposes `source_record_id` and `source_record_type` (read-only) — populated when a custom field was automatically copied from another record.
- `Invoice` now exposes `custom_fields` (read-only) — the list of custom fields that were on the account at invoice creation time and were marked for display on invoices.

**New enum values**
- `TemporalUnit`: added `billing_period` — use with `temporal_amount` to apply a coupon for a fixed number of billing cycles (requires `redemption_resource=subscription`).
- `SourceRecordType` (new enum): `account`, `plan`, `product`, `subscription`.

**Documentation clarifications**
- `Coupon` / `CouponCreate`: clarified `temporal_amount` and `temporal_unit` descriptions to document `billing_period` behavior.
- `Address`, `AddressWithName`, `InvoiceAddress`, `ShippingAddress`: updated `geo_code` description — now reads "Only returned when Vertex or Avalara for Communications is enabled" (previously referenced Sling Vertex only).