### PR TITLE
ci: Remediate Node.js 20 deprecation in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on: [push]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on: [push]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,10 +13,10 @@ jobs:
       matrix:
         php: [7.2, 7.3, 7.4, 8.0, 8.1]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
       - name: Setup PHP
-        # Using tag 2.10.0
-        uses: shivammathur/setup-php@e9a7adef28d778846228a0d481e041db73bd6db2
+        # Using tag 2.37.1
+        uses: shivammathur/setup-php@2.37.1
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - name: Setup PHP
         # Using tag 2.37.1
-        uses: shivammathur/setup-php@2.37.1
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,6 @@ on:
     types:
       - released
 name: Documentation
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     name: Publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,15 +3,17 @@ on:
     types:
       - released
 name: Documentation
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.3
 
-      # Using tag 2.10.0
-    - uses: shivammathur/setup-php@e9a7adef28d778846228a0d481e041db73bd6db2
+      # Using tag 2.37.1
+    - uses: shivammathur/setup-php@2.37.1
       with:
         php-version: '8.0'
         coverage: xdebug2
@@ -22,8 +24,8 @@ jobs:
     - name: Deploy
       if: success()
       # use the specific sha of 3rd party libraries for security reasons https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
-      # Using tag v2.3.0
-      uses: crazy-max/ghaction-github-pages@b8f8d291c97fe0edd9fb4ee73018163593418e8f
+      # Using tag v5.0.0
+      uses: crazy-max/ghaction-github-pages@v5.0.0
       with:
         target_branch: gh-pages
         build_dir: ./docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v6.0.3
 
       # Using tag 2.37.1
-    - uses: shivammathur/setup-php@2.37.1
+    - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
       with:
         php-version: '8.0'
         coverage: xdebug2
@@ -25,7 +25,7 @@ jobs:
       if: success()
       # use the specific sha of 3rd party libraries for security reasons https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
       # Using tag v5.0.0
-      uses: crazy-max/ghaction-github-pages@v5.0.0
+      uses: crazy-max/ghaction-github-pages@1d6ee9b181a81033a16bd707a1401afa978daab4
       with:
         target_branch: gh-pages
         build_dir: ./docs


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions running on Node.js 20 will be forced to Node.js 24 starting June 2, 2026, and Node.js 20 will be fully removed from runners on September 16, 2026. Three actions in this repo were running on Node.js 12 or 16 (via outdated version pins), making them non-compliant.

### Fix
Upgraded all affected actions to their latest Node.js 24-compatible versions:
- `actions/checkout`: v2/v3 (node12/node16) → v6.0.3 (node24)
- `shivammathur/setup-php`: pinned SHA `e9a7adef` / tag 2.10.0 (node12) → `2.37.1` (node24)
- `crazy-max/ghaction-github-pages`: pinned SHA `b8f8d291` / tag v2.3.0 (node12) → `v5.0.0` (node24)

Input/output compatibility was verified for all three upgrades before applying changes.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` has been added to both workflow files for CI validation. This flag will be removed before merge.

### Files Changed
- `.github/workflows/ci.yml` — upgraded `actions/checkout` and `shivammathur/setup-php`; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` flag
- `.github/workflows/docs.yml` — upgraded `actions/checkout`, `shivammathur/setup-php`, and `crazy-max/ghaction-github-pages`; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` flag

## Testing
CI will run with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` active to validate that all JavaScript actions execute correctly under Node.js 24.